### PR TITLE
workflows/codeql: only run when Swift files change

### DIFF
--- a/.github/workflows/codeql.yml
+++ b/.github/workflows/codeql.yml
@@ -4,6 +4,9 @@ on:
   push:
     branches:
       - main
+    paths:
+      - '**/*.swift'
+      - '*.xcodeproj/**'
 
 defaults:
   run:


### PR DESCRIPTION
No reason to run this if there are no Swift changes.