### PR TITLE
Optimize data lookups and fix cask/formula upgrade separation

### DIFF
--- a/Brewy/Views/ContentView.swift
+++ b/Brewy/Views/ContentView.swift
@@ -55,8 +55,11 @@ struct ContentView: View {
                     title: "Select a Tap",
                     subtitle: "Choose a tap from the list to view its details."
                 )
-            } else if let package = selectedPackage {
+            } else if let selectedPackage {
+                let package = brewService.allInstalled.first(where: { $0.id == selectedPackage.id }) ?? selectedPackage
+                let isOutdated = brewService.outdatedPackages.contains { $0.id == selectedPackage.id }
                 PackageDetailView(package: package)
+                    .id(isOutdated)
             } else {
                 EmptyStateView()
             }

--- a/Brewy/Views/MaintenanceView.swift
+++ b/Brewy/Views/MaintenanceView.swift
@@ -151,9 +151,13 @@ struct MaintenanceView: View {
         isCalculatingCache = false
     }
 
-    private func formattedSize(_ bytes: Int64) -> String {
+    private static let sizeFormatter: ByteCountFormatter = {
         let formatter = ByteCountFormatter()
         formatter.countStyle = .file
-        return formatter.string(fromByteCount: bytes)
+        return formatter
+    }()
+
+    private func formattedSize(_ bytes: Int64) -> String {
+        Self.sizeFormatter.string(fromByteCount: bytes)
     }
 }


### PR DESCRIPTION
Cache derived state to avoid repeated O(n) scans across search, detail, and dependency views. Cache FlowLayout measurements, filter taps with a Set, validate tap names, and use a static ByteCountFormatter. Fix upgradeSelected to run separate brew commands for formulae and casks.