### PR TITLE
chore: remove CodeQL concurrency cancellation

### DIFF
--- a/.github/workflows/codeql.yml
+++ b/.github/workflows/codeql.yml
@@ -8,13 +8,13 @@ on:
       - '**/*.swift'
       - '*.xcodeproj/**'
 
+concurrency:
+  group: "codeql-${{ github.ref }}"
+  cancel-in-progress: false
+
 defaults:
   run:
     shell: bash -xeuo pipefail {0}
-
-concurrency:
-  group: "codeql-${{ github.ref }}"
-  cancel-in-progress: true
 
 permissions: {}
 


### PR DESCRIPTION
No harm in letting these pile up on free runners.