### PR TITLE
chore: move appcast to dedicated branch

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -245,7 +245,11 @@ jobs:
           git config user.name "github-actions[bot]"
           git config user.email "41898282+github-actions[bot]@users.noreply.github.com"
           git remote set-url origin "https://x-access-token:${GH_TOKEN}@github.com/${REPOSITORY}.git"
+          cp appcast.xml "${RUNNER_TEMP}/appcast.xml"
+          git fetch origin appcast
+          git checkout appcast
+          cp "${RUNNER_TEMP}/appcast.xml" appcast.xml
           git add appcast.xml
           git diff --cached --quiet && exit 0
           git commit -m "Update appcast for ${TAG}"
-          git push origin main
+          git push origin appcast

--- a/.gitignore
+++ b/.gitignore
@@ -1,6 +1,9 @@
 # Claude Code
 .claude/
 
+# Appcast (lives on the appcast branch, not main)
+appcast.xml
+
 # macOS
 .DS_Store
 

--- a/Brewy/Info.plist
+++ b/Brewy/Info.plist
@@ -3,7 +3,7 @@
 <plist version="1.0">
 <dict>
 	<key>SUFeedURL</key>
-	<string>https://raw.githubusercontent.com/p-linnane/Brewy/main/appcast.xml</string>
+	<string>https://raw.githubusercontent.com/p-linnane/Brewy/appcast/appcast.xml</string>
 	<key>SUPublicEDKey</key>
 	<string>bDdj4oLQDw8Ut2IoUsIH2DbaP5eSqtkqXS1fSjd3/6s=</string>
 </dict>

--- a/appcast.xml
+++ b/appcast.xml
@@ -1,8 +1,0 @@
-<?xml version="1.0" standalone="yes"?>
-<rss xmlns:sparkle="http://www.andymatuschak.org/xml-namespaces/sparkle" xmlns:dc="http://purl.org/dc/elements/1.1/" version="2.0">
-    <channel>
-        <title>Brewy Changelog</title>
-        <description>Most recent changes with links to updates.</description>
-        <language>en</language>
-    </channel>
-</rss>


### PR DESCRIPTION
Don't want to have automated pushes to `main`.