### PR TITLE
chore: remove swift dependabot ecosystem and bump Sparkle to 2.9.0

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -6,10 +6,3 @@ updates:
       interval: daily
     cooldown:
       default-days: 7
-
-  - package-ecosystem: swift
-    directory: /
-    schedule:
-      interval: weekly
-    cooldown:
-      default-days: 7

--- a/Brewy.xcodeproj/project.xcworkspace/xcshareddata/swiftpm/Package.resolved
+++ b/Brewy.xcodeproj/project.xcworkspace/xcshareddata/swiftpm/Package.resolved
@@ -6,8 +6,8 @@
       "kind" : "remoteSourceControl",
       "location" : "https://github.com/sparkle-project/Sparkle",
       "state" : {
-        "revision" : "5581748cef2bae787496fe6d61139aebe0a451f6",
-        "version" : "2.8.1"
+        "revision" : "21d8df80440b1ca3b65fa82e40782f1e5a9e6ba2",
+        "version" : "2.9.0"
       }
     }
   ],

--- a/Brewy/BrewyApp.swift
+++ b/Brewy/BrewyApp.swift
@@ -82,6 +82,7 @@ struct BrewyApp: App {
 
 // MARK: - Sparkle Updates
 
+@MainActor
 private final class CheckForUpdatesViewModel: ObservableObject {
     @Published var canCheckForUpdates = false
 


### PR DESCRIPTION
Turns out Dependabot doesn't support Xcode projects 🤷🏻‍♂️