### PR TITLE
fix(dependabot): remove unsupported versioning-strategy for Swift

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -15,7 +15,6 @@ updates:
     directory: "/"
     schedule:
       interval: "daily"
-    versioning-strategy: increase
     cooldown:
       default-days: 7
     groups:


### PR DESCRIPTION
## Summary

- Remove `versioning-strategy: increase` from the Swift ecosystem — Dependabot doesn't support it for Swift