### PR TITLE
fix(models): harden CommandRunner and service state handling

### DIFF
--- a/Brewy/Models/BrewJSONTypes.swift
+++ b/Brewy/Models/BrewJSONTypes.swift
@@ -54,21 +54,23 @@ struct FormulaJSON: Decodable {
 struct CaskJSON: Decodable {
     let token: String
     let version: String?
+    let installed: String?
     let desc: String?
     let homepage: String?
 
     func toPackage() -> BrewPackage {
-        let resolvedVersion = version ?? "unknown"
+        let latest = version ?? "unknown"
+        let installedVersion = installed ?? latest
         return BrewPackage(
             id: "cask-\(token)",
             name: token,
-            version: resolvedVersion,
+            version: installedVersion,
             description: desc ?? "",
             homepage: homepage ?? "",
             isInstalled: true,
             isOutdated: false,
-            installedVersion: resolvedVersion,
-            latestVersion: nil,
+            installedVersion: installedVersion,
+            latestVersion: latest,
             source: .cask,
             pinned: false,
             installedOnRequest: true,

--- a/Brewy/Models/BrewService+Actions.swift
+++ b/Brewy/Models/BrewService+Actions.swift
@@ -41,6 +41,10 @@ extension BrewService {
     // MARK: - Action Helpers
 
     func performBrewAction(_ arguments: [String], refreshAfter: Bool = false) async {
+        guard !isPerformingAction else {
+            logger.info("\(arguments.first ?? "action") skipped, action already in progress")
+            return
+        }
         isPerformingAction = true
         actionOutput = ""
         lastError = nil
@@ -60,6 +64,10 @@ extension BrewService {
     func performAction(_ action: String, package: BrewPackage) async {
         guard !package.isMas else {
             logger.warning("Cannot perform brew action \(action) on mas package \(package.name)")
+            return
+        }
+        guard !isPerformingAction else {
+            logger.info("\(action) on \(package.name) skipped, action already in progress")
             return
         }
         logger.info("Performing \(action) on \(package.name)")
@@ -105,28 +113,13 @@ extension BrewService {
         let cachePath = pathResult.output.trimmingCharacters(in: .whitespacesAndNewlines)
         guard !cachePath.isEmpty else { return 0 }
 
-        return await Task.detached(priority: .userInitiated) {
-            let process = Process()
-            let pipe = Pipe()
-            process.executableURL = URL(fileURLWithPath: "/usr/bin/du")
-            process.arguments = ["-sk", cachePath]
-            process.standardOutput = pipe
-            process.standardError = FileHandle.nullDevice
-
-            do {
-                try process.run()
-                let data = pipe.fileHandleForReading.readDataToEndOfFile()
-                process.waitUntilExit()
-                let output = String(data: data, encoding: .utf8) ?? ""
-                if let sizeStr = output.split(separator: "\t").first,
-                   let sizeKB = Int64(sizeStr) {
-                    return sizeKB * 1_024
-                }
-            } catch {
-                logger.warning("Failed to calculate cache size: \(error.localizedDescription)")
-            }
-            return Int64(0)
-        }.value
+        let result = await commandRunner.runExecutable("/usr/bin/du", arguments: ["-sk", cachePath])
+        guard result.success,
+              let sizeStr = result.output.split(separator: "\t").first,
+              let sizeKB = Int64(sizeStr) else {
+            return 0
+        }
+        return sizeKB * 1_024
     }
 
     func purgeCache() async {

--- a/Brewy/Models/BrewService+History.swift
+++ b/Brewy/Models/BrewService+History.swift
@@ -69,6 +69,10 @@ extension BrewService {
 
     func retryAction(_ entry: ActionHistoryEntry) async {
         guard entry.isRetryable else { return }
+        guard !isPerformingAction else {
+            logger.info("Retry skipped, action already in progress")
+            return
+        }
         isPerformingAction = true
         actionOutput = ""
         lastError = nil
@@ -117,7 +121,8 @@ extension BrewService {
             isInstalled: pkg.isInstalled, isOutdated: true,
             installedVersion: pkg.installedVersion,
             latestVersion: outdatedPkg.latestVersion,
-            source: pkg.source, pinned: pkg.pinned,
+            source: pkg.source,
+            pinned: pkg.pinned || outdatedPkg.pinned,
             installedOnRequest: pkg.installedOnRequest,
             dependencies: pkg.dependencies
         )

--- a/Brewy/Models/BrewService+Taps.swift
+++ b/Brewy/Models/BrewService+Taps.swift
@@ -29,11 +29,20 @@ extension BrewService {
             logger.info("Migrating tap \(oldName) → \(newName)")
             guard await runTapCommand(["untap", oldName]) else { return false }
             tapHealthStatuses.removeValue(forKey: oldName)
-            return await runTapCommand(["tap", newName])
+            let tapped = await runTapCommand(["tap", newName])
+            if !tapped {
+                logger.warning("Rollback: re-adding \(oldName) after failure to add \(newName)")
+                _ = await runTapCommand(["tap", oldName])
+            }
+            return tapped
         }
     }
 
     private func performTapAction(_ action: () async -> Bool) async {
+        guard !isPerformingAction else {
+            logger.info("Tap action skipped, action already in progress")
+            return
+        }
         isPerformingAction = true
         actionOutput = ""
         lastError = nil

--- a/Brewy/Models/BrewService.swift
+++ b/Brewy/Models/BrewService.swift
@@ -18,13 +18,28 @@ enum BrewError: LocalizedError {
         switch self {
         case .brewNotFound(let path):
             return "Homebrew not found at \(path)"
-        case .commandFailed(_, let output):
-            return output
+        case .commandFailed(let command, let output):
+            return Self.summarize(command: command, output: output)
         case .parseFailed(let command):
             return "Failed to parse output from: brew \(command)"
         case .commandTimedOut(let command):
             return "Command timed out: brew \(command)"
         }
+    }
+
+    private static let maxOutputChars = 800
+
+    private static func summarize(command: String, output: String) -> String {
+        let trimmed = output.trimmingCharacters(in: .whitespacesAndNewlines)
+        guard !trimmed.isEmpty else { return "brew \(command) failed." }
+
+        let lines = trimmed.split(separator: "\n", omittingEmptySubsequences: false)
+        if let errorLine = lines.first(where: { $0.lowercased().hasPrefix("error:") }) {
+            return String(errorLine)
+        }
+        let tail = lines.suffix(6).joined(separator: "\n")
+        if tail.count <= maxOutputChars { return tail }
+        return "…" + String(tail.suffix(maxOutputChars))
     }
 }
 
@@ -75,6 +90,7 @@ final class BrewService {
     private var isRefreshing = false
     @ObservationIgnored private var isBatchingUpdates = false
     @ObservationIgnored var infoCache: [String: String] = [:]
+    @ObservationIgnored private var tapHealthTask: Task<Void, Never>?
 
     // MARK: - Cached Derived State
 
@@ -89,6 +105,21 @@ final class BrewService {
         installedFormulae = formulae
         installedCasks = casks
         installedMasApps = masApps
+        isBatchingUpdates = false
+        invalidateDerivedState()
+    }
+
+    private func applyRefreshResults(
+        formulae: [BrewPackage],
+        casks: [BrewPackage],
+        masApps: [BrewPackage],
+        outdated: [BrewPackage]
+    ) {
+        isBatchingUpdates = true
+        installedFormulae = formulae
+        installedCasks = casks
+        installedMasApps = masApps
+        outdatedPackages = outdated
         isBatchingUpdates = false
         invalidateDerivedState()
     }
@@ -145,7 +176,12 @@ final class BrewService {
 
     nonisolated private static let cacheURL: URL? = cacheDirectory?.appendingPathComponent("packageCache.json")
 
+    /// Current schema version for the package cache. Bump when `CachedData` gains a non-optional
+    /// field or changes semantics so old caches are deleted rather than silently discarded each launch.
+    static let cacheSchemaVersion = 1
+
     private struct CachedData: Codable {
+        let schemaVersion: Int
         let formulae: [BrewPackage]
         let casks: [BrewPackage]
         let masApps: [BrewPackage]?
@@ -159,6 +195,11 @@ final class BrewService {
         do {
             let data = try Data(contentsOf: cacheURL)
             let cached = try JSONDecoder().decode(CachedData.self, from: data)
+            guard cached.schemaVersion == Self.cacheSchemaVersion else {
+                logger.warning("Cache schema version \(cached.schemaVersion) != \(Self.cacheSchemaVersion), discarding")
+                try? FileManager.default.removeItem(at: cacheURL)
+                return
+            }
             let masApps = cached.masApps ?? []
             updateInstalledPackages(formulae: cached.formulae, casks: cached.casks, masApps: masApps)
             outdatedPackages = cached.outdated
@@ -169,6 +210,7 @@ final class BrewService {
             logger.info("Loaded \(cached.formulae.count) formulae and \(cached.casks.count) casks from cache")
         } catch {
             logger.warning("Failed to load cache: \(error.localizedDescription)")
+            try? FileManager.default.removeItem(at: cacheURL)
         }
     }
 
@@ -176,6 +218,7 @@ final class BrewService {
         guard let cacheURL = Self.cacheURL,
               ProcessInfo.processInfo.environment["XCTestBundlePath"] == nil else { return }
         let cached = CachedData(
+            schemaVersion: Self.cacheSchemaVersion,
             formulae: installedFormulae,
             casks: installedCasks,
             masApps: installedMasApps,
@@ -241,12 +284,12 @@ final class BrewService {
         let allOutdated = fetchedOutdated + fetchedMasOutdated
         let outdatedByID = Dictionary(allOutdated.map { ($0.id, $0) }, uniquingKeysWith: { _, last in last })
 
-        updateInstalledPackages(
+        applyRefreshResults(
             formulae: fetchedFormulae.map { Self.mergeOutdatedStatus($0, outdatedByID: outdatedByID) },
             casks: fetchedCasks.map { Self.mergeOutdatedStatus($0, outdatedByID: outdatedByID) },
-            masApps: fetchedMasApps.map { Self.mergeOutdatedStatus($0, outdatedByID: outdatedByID) }
+            masApps: fetchedMasApps.map { Self.mergeOutdatedStatus($0, outdatedByID: outdatedByID) },
+            outdated: allOutdated
         )
-        outdatedPackages = allOutdated
         lastUpdated = Date()
 
         let currentVersions = Dictionary(allInstalled.map { ($0.id, $0.version) }, uniquingKeysWith: { _, last in last })
@@ -262,7 +305,10 @@ final class BrewService {
         logger.info("Refresh complete: \(fetchedFormulae.count) formulae, \(fetchedCasks.count) casks, \(masCount) mas, \(outdatedCount) outdated")
         saveToCache()
         if installedTaps.contains(where: { tapHealthStatuses[$0.name]?.isStale ?? true }) {
-            Task { await checkTapHealth() }
+            tapHealthTask?.cancel()
+            tapHealthTask = Task { [weak self] in
+                await self?.checkTapHealth()
+            }
         }
     }
 
@@ -282,6 +328,10 @@ final class BrewService {
     }
 
     func upgradeSelected(packages: [BrewPackage]) async {
+        guard !isPerformingAction else {
+            logger.info("upgradeSelected skipped, action already in progress")
+            return
+        }
         isPerformingAction = true
         actionOutput = ""
         lastError = nil

--- a/Brewy/Models/CommandRunner.swift
+++ b/Brewy/Models/CommandRunner.swift
@@ -1,3 +1,4 @@
+import Darwin
 import Foundation
 import OSLog
 
@@ -8,9 +9,16 @@ private let logger = Logger(subsystem: "io.linnane.brewy", category: "CommandRun
 struct CommandResult: Sendable {
     let output: String
     let success: Bool
+    let didTimeOut: Bool
+
+    init(output: String, success: Bool, didTimeOut: Bool = false) {
+        self.output = output
+        self.success = success
+        self.didTimeOut = didTimeOut
+    }
 }
 
-// MARK: - Locked Data Accumulator
+// MARK: - Thread-safe Value Containers
 
 /// Thread-safe accumulator for data chunks.
 private final class LockedData: Sendable {
@@ -30,6 +38,18 @@ private final class LockedData: Sendable {
         for chunk in chunks { result.append(chunk) }
         lock.unlock()
         return result
+    }
+}
+
+private final class LockedFlag: Sendable {
+    private let lock = NSLock()
+    nonisolated(unsafe) private var value = false
+
+    func set() { lock.lock(); value = true; lock.unlock() }
+
+    var isSet: Bool {
+        lock.lock(); defer { lock.unlock() }
+        return value
     }
 }
 
@@ -67,6 +87,9 @@ struct DefaultCommandRunner: CommandRunning {
 enum CommandRunner {
 
     static let defaultTimeout: Duration = .seconds(300)
+
+    /// Grace period between SIGTERM and SIGKILL when a process exceeds its timeout.
+    private static let killGracePeriod: Duration = .seconds(3)
 
     static func resolvedBrewPath(preferred: String) -> String {
         let fallback = "/usr/local/bin/brew"
@@ -131,13 +154,20 @@ enum CommandRunner {
         let currentPath = env["PATH"] ?? "/usr/bin:/bin:/usr/sbin:/sbin"
         var pathComponents = currentPath.components(separatedBy: ":")
 
-        // Ensure brew's bin and sbin directories are in PATH
         for dir in [brewSbin, brewBin] where !pathComponents.contains(dir) {
             pathComponents.insert(dir, at: 0)
         }
 
         env["PATH"] = pathComponents.joined(separator: ":")
         return env
+    }
+
+    /// Convert a `Duration` into a `DispatchTimeInterval` that preserves sub-second precision.
+    private static func dispatchInterval(from duration: Duration) -> DispatchTimeInterval {
+        let components = duration.components
+        let totalNanos = components.seconds * 1_000_000_000 + components.attoseconds / 1_000_000_000
+        if totalNanos > Int64(Int.max) { return .seconds(Int.max) }
+        return .nanoseconds(Int(totalNanos))
     }
 
     private static func executeProcess(
@@ -158,55 +188,92 @@ enum CommandRunner {
 
         do {
             try process.run()
-
-            let timeoutWork = DispatchWorkItem {
-                if process.isRunning {
-                    logger.warning("Terminating timed-out process: \(commandDescription)")
-                    process.terminate()
-                }
-            }
-            DispatchQueue.global(qos: .utility).asyncAfter(
-                deadline: .now() + .seconds(Int(timeout.components.seconds)),
-                execute: timeoutWork
-            )
-
-            // Read stderr asynchronously to avoid pipe deadlock.
-            let stderrAccumulator = LockedData()
-            let stderrSemaphore = DispatchSemaphore(value: 0)
-            stderrPipe.fileHandleForReading.readabilityHandler = { handle in
-                let chunk = handle.availableData
-                if chunk.isEmpty {
-                    stderrSemaphore.signal()
-                } else {
-                    stderrAccumulator.append(chunk)
-                }
-            }
-
-            let stdoutData = stdoutPipe.fileHandleForReading.readDataToEndOfFile()
-            stderrSemaphore.wait()
-            stderrPipe.fileHandleForReading.readabilityHandler = nil
-
-            process.waitUntilExit()
-            timeoutWork.cancel()
-
-            let stderrData = stderrAccumulator.combined()
-
-            let output = String(data: stdoutData, encoding: .utf8) ?? ""
-            let errorOutput = String(data: stderrData, encoding: .utf8) ?? ""
-            let combinedOutput = output.isEmpty ? errorOutput : output
-
-            // Detect if the process was killed by the timeout (SIGTERM = 15)
-            if process.terminationReason == .uncaughtSignal {
-                return CommandResult(output: "Command timed out after \(timeout)", success: false)
-            }
-
-            return CommandResult(output: combinedOutput, success: process.terminationStatus == 0)
         } catch {
             logger.error("Failed to launch process: \(error.localizedDescription)")
             return CommandResult(
-                output: "Failed to run brew: \(error.localizedDescription)",
+                output: "Failed to run \(commandDescription): \(error.localizedDescription)",
                 success: false
             )
         }
+
+        let (stdoutData, stderrData) = drainPipesInParallel(stdout: stdoutPipe, stderr: stderrPipe)
+        let timedOut = scheduleTimeout(for: process, after: timeout, commandDescription: commandDescription)
+
+        process.waitUntilExit()
+        let out = stdoutData.wait()
+        let err = stderrData.wait()
+
+        if timedOut.isSet {
+            return CommandResult(
+                output: "Command timed out after \(timeout).",
+                success: false,
+                didTimeOut: true
+            )
+        }
+        let stdout = String(data: out, encoding: .utf8) ?? ""
+        let stderr = String(data: err, encoding: .utf8) ?? ""
+        return CommandResult(
+            output: stdout.isEmpty ? stderr : stdout,
+            success: process.terminationStatus == 0
+        )
+    }
+
+    private static func drainPipesInParallel(stdout: Pipe, stderr: Pipe) -> (stdout: PipeReader, stderr: PipeReader) {
+        let stdoutReader = PipeReader(pipe: stdout)
+        let stderrReader = PipeReader(pipe: stderr)
+        stdoutReader.start()
+        stderrReader.start()
+        return (stdoutReader, stderrReader)
+    }
+
+    private static func scheduleTimeout(
+        for process: Process,
+        after timeout: Duration,
+        commandDescription: String
+    ) -> LockedFlag {
+        let timedOut = LockedFlag()
+        let timeoutWork = DispatchWorkItem { [weak process] in
+            guard let process, process.isRunning else { return }
+            logger.warning("Timeout exceeded, sending SIGTERM: \(commandDescription)")
+            timedOut.set()
+            process.terminate()
+            let pid = process.processIdentifier
+            let graceDispatch = dispatchInterval(from: killGracePeriod)
+            DispatchQueue.global(qos: .utility).asyncAfter(deadline: .now() + graceDispatch) { [weak process] in
+                guard let process, process.isRunning else { return }
+                logger.warning("SIGTERM ignored, sending SIGKILL: \(commandDescription)")
+                kill(pid, SIGKILL)
+            }
+        }
+        DispatchQueue.global(qos: .utility).asyncAfter(
+            deadline: .now() + dispatchInterval(from: timeout),
+            execute: timeoutWork
+        )
+        return timedOut
+    }
+}
+
+// MARK: - Pipe Reader
+
+/// Drains a `Pipe` to EOF on a background queue so the subprocess cannot deadlock on a full buffer.
+private final class PipeReader: @unchecked Sendable {
+    private let pipe: Pipe
+    private let accumulator = LockedData()
+    private let semaphore = DispatchSemaphore(value: 0)
+
+    init(pipe: Pipe) { self.pipe = pipe }
+
+    func start() {
+        DispatchQueue.global(qos: .utility).async { [weak self] in
+            guard let self else { return }
+            let data = pipe.fileHandleForReading.readDataToEndOfFile()
+            accumulator.append(data)
+            semaphore.signal()
+        }
+    }
+
+    func wait() -> Data {
+        semaphore.wait()
+        return accumulator.combined()
     }
 }

--- a/Brewy/Models/MasService.swift
+++ b/Brewy/Models/MasService.swift
@@ -134,6 +134,10 @@ extension BrewService {
     }
 
     func installMas() async {
+        guard !isPerformingAction else {
+            logger.info("installMas skipped, action already in progress")
+            return
+        }
         logger.info("Installing mas via Homebrew")
         isPerformingAction = true
         actionOutput = ""

--- a/Brewy/Models/PackageModel.swift
+++ b/Brewy/Models/PackageModel.swift
@@ -230,6 +230,14 @@ final class AppcastParser: NSObject, XMLParserDelegate {
     private var insideItem = false
 
     func parse(data: Data) -> AppcastRelease? {
+        currentElement = ""
+        currentTitle = ""
+        currentPubDate = ""
+        currentVersion = ""
+        currentDescription = ""
+        release = nil
+        insideItem = false
+
         let parser = XMLParser(data: data)
         parser.delegate = self
         parser.parse()

--- a/Brewy/Models/TapHealthChecker.swift
+++ b/Brewy/Models/TapHealthChecker.swift
@@ -61,6 +61,9 @@ enum TapHealthChecker {
         }
     }
 
+    /// Max number of concurrent GitHub requests to avoid triggering rate limits.
+    private static let maxConcurrentChecks = 5
+
     static func checkHealth(
         taps: [BrewTap],
         existing: [String: TapHealthStatus]
@@ -72,15 +75,34 @@ enum TapHealthChecker {
         let session = URLSession(configuration: .ephemeral, delegate: delegate, delegateQueue: nil)
         defer { session.invalidateAndCancel() }
 
-        for tap in taps {
-            if let cached = statuses[tap.name], !cached.isStale {
-                continue
+        struct Pending: Sendable { let name: String; let owner: String; let repo: String }
+        let pending: [Pending] = taps.compactMap { tap in
+            if let cached = statuses[tap.name], !cached.isStale { return nil }
+            guard let (owner, repo) = TapHealthStatus.parseGitHubRepo(from: tap.remote) else { return nil }
+            return Pending(name: tap.name, owner: owner, repo: repo)
+        }
+
+        await withTaskGroup(of: (String, TapHealthStatus).self) { group in
+            var inFlight = 0
+            var iterator = pending.makeIterator()
+            while let next = iterator.next() {
+                group.addTask {
+                    let status = await fetchRepoHealth(owner: next.owner, repo: next.repo, session: session)
+                    return (next.name, status)
+                }
+                inFlight += 1
+                if inFlight >= maxConcurrentChecks {
+                    if let (name, status) = await group.next() {
+                        statuses[name] = status
+                        updated = true
+                    }
+                    inFlight -= 1
+                }
             }
-            guard let (owner, repo) = TapHealthStatus.parseGitHubRepo(from: tap.remote) else {
-                continue
+            for await (name, status) in group {
+                statuses[name] = status
+                updated = true
             }
-            statuses[tap.name] = await fetchRepoHealth(owner: owner, repo: repo, session: session)
-            updated = true
         }
 
         let tapNames = Set(taps.map(\.name))


### PR DESCRIPTION
- CommandRunner: parallel stdout/stderr drain, SIGTERM→SIGKILL escalation, sub-second timeout precision, distinct timeout reporting.
- BrewService: re-entrancy guard on all action entry points, batched outdated update, cache schema versioning with delete-on-mismatch, truncated error summaries, tracked tap-health task.
- JSON: decode `installed` on casks so installed vs latest no longer collapse; merge `pinned` from outdated reports.
- Taps: rollback on failed `migrateTap`, parallel GitHub health checks via capped TaskGroup.
- Misc: route `cacheSize` through CommandRunner, reset AppcastParser state on re-parse.