### PR TITLE
fix(views): correctness and perf across content, detail, and services

### DIFF
--- a/Brewy/Views/ContentView.swift
+++ b/Brewy/Views/ContentView.swift
@@ -32,9 +32,8 @@ struct ContentView: View {
     @State private var selectedServiceItem: BrewServiceItem?
     @State private var selectedGroupItem: PackageGroup?
     @State private var selectedHistoryEntry: ActionHistoryEntry?
-    @State private var servicesRefreshTrigger = false
+    @State private var servicesRefreshTrigger = 0
     @State private var searchText = ""
-    @State private var showError = false
     @State private var showWhatsNew = false
 
     var body: some View {
@@ -76,7 +75,7 @@ struct ContentView: View {
         } detail: {
             detailView
         }
-        .environment(\.selectPackage) { [self] name in navigateToPackage(name) }
+        .environment(\.selectPackage) { name in navigateToPackage(name) }
         .task {
             if showCasksByDefault {
                 selectedCategory = .casks
@@ -85,6 +84,11 @@ struct ContentView: View {
             brewService.loadTapHealthCache()
             brewService.loadGroups()
             brewService.loadHistory()
+            let currentVersion = Bundle.main.object(forInfoDictionaryKey: "CFBundleShortVersionString") as? String ?? ""
+            if !currentVersion.isEmpty, currentVersion != lastSeenVersion {
+                lastSeenVersion = currentVersion
+                showWhatsNew = true
+            }
             await brewService.refresh()
         }
         .task(id: autoRefreshInterval) {
@@ -95,12 +99,18 @@ struct ContentView: View {
                 await brewService.refresh()
             }
         }
-        .onChange(of: brewService.lastError?.errorDescription) {
-            showError = brewService.lastError != nil
+        .onChange(of: selectedCategory) {
+            selectedTap = nil
+            selectedServiceItem = nil
+            selectedGroupItem = nil
+            selectedHistoryEntry = nil
         }
         .alert(
             "Error",
-            isPresented: $showError,
+            isPresented: Binding(
+                get: { brewService.lastError != nil },
+                set: { if !$0 { brewService.lastError = nil } }
+            ),
             presenting: brewService.lastError
         ) { _ in
             Button("OK") { brewService.lastError = nil }
@@ -109,13 +119,6 @@ struct ContentView: View {
         }
         .sheet(isPresented: $showWhatsNew) {
             WhatsNewView()
-        }
-        .onAppear {
-            let currentVersion = Bundle.main.object(forInfoDictionaryKey: "CFBundleShortVersionString") as? String ?? ""
-            if !currentVersion.isEmpty, currentVersion != lastSeenVersion {
-                lastSeenVersion = currentVersion
-                showWhatsNew = true
-            }
         }
         .onReceive(NotificationCenter.default.publisher(for: .showWhatsNew)) { _ in
             showWhatsNew = true
@@ -128,7 +131,7 @@ struct ContentView: View {
                 .navigationSplitViewColumnWidth(0)
         } else if selectedCategory == .services, let service = selectedServiceItem {
             ServiceDetailView(service: service) {
-                servicesRefreshTrigger.toggle()
+                servicesRefreshTrigger &+= 1
             }
             .id(service.id)
             .navigationSplitViewColumnWidth(ideal: 450)

--- a/Brewy/Views/DiscoverView.swift
+++ b/Brewy/Views/DiscoverView.swift
@@ -5,14 +5,16 @@ struct DiscoverView: View {
     private var brewService
     @Binding var selectedPackage: BrewPackage?
     @State private var searchText = ""
+    @State private var results: [BrewPackage] = []
+    @State private var isSearching = false
     @State private var searchTask: Task<Void, Never>?
 
     var body: some View {
         List(selection: $selectedPackage) {
-            if brewService.searchResults.isEmpty {
+            if results.isEmpty {
                 emptyContent
             } else {
-                ForEach(brewService.searchResults) { package in
+                ForEach(results) { package in
                     DiscoverRow(
                         package: package,
                         onInstall: { pkg in await brewService.install(package: pkg) }
@@ -26,17 +28,22 @@ struct DiscoverView: View {
         .onChange(of: searchText) {
             searchTask?.cancel()
             guard !searchText.isEmpty else {
-                brewService.searchResults = []
+                results = []
+                isSearching = false
                 return
             }
             searchTask = Task {
                 try? await Task.sleep(for: .milliseconds(300))
                 guard !Task.isCancelled else { return }
-                await brewService.search(query: searchText)
+                isSearching = true
+                let fetched = await brewService.performSearch(query: searchText)
+                guard !Task.isCancelled else { return }
+                results = fetched
+                isSearching = false
             }
         }
         .overlay {
-            if brewService.isLoading, !searchText.isEmpty, brewService.searchResults.isEmpty {
+            if isSearching, !searchText.isEmpty, results.isEmpty {
                 ProgressView("Searching...")
             }
         }
@@ -44,7 +51,7 @@ struct DiscoverView: View {
         .navigationSubtitle(
             searchText.isEmpty
                 ? "Search to find new packages"
-                : "\(brewService.searchResults.count) results"
+                : "\(results.count) results"
         )
     }
 
@@ -55,7 +62,7 @@ struct DiscoverView: View {
                 systemImage: "magnifyingglass",
                 description: Text("Search all of Homebrew to discover and install formulae and casks.")
             )
-        } else if !brewService.isLoading {
+        } else if !isSearching {
             ContentUnavailableView.search(text: searchText)
         }
     }

--- a/Brewy/Views/DryRunConfirmationSheet.swift
+++ b/Brewy/Views/DryRunConfirmationSheet.swift
@@ -11,7 +11,6 @@ struct DryRunConfirmationSheet: View {
 
     @State private var isLoadingPreview = true
     @State private var previewOutput = ""
-    @State private var hasLoadedPreview = false
 
     var body: some View {
         VStack(spacing: 16) {
@@ -38,8 +37,6 @@ struct DryRunConfirmationSheet: View {
         .padding(20)
         .frame(width: 480)
         .task {
-            guard !hasLoadedPreview else { return }
-            hasLoadedPreview = true
             previewOutput = await dryRunAction()
             isLoadingPreview = false
         }

--- a/Brewy/Views/HistoryView.swift
+++ b/Brewy/Views/HistoryView.swift
@@ -7,18 +7,17 @@ struct HistoryView: View {
 
     var body: some View {
         List(selection: $selectedEntry) {
-            ForEach(brewService.actionHistory) { entry in
-                HistoryRow(entry: entry)
-                    .tag(entry)
-            }
-        }
-        .overlay {
             if brewService.actionHistory.isEmpty {
                 ContentUnavailableView(
                     "No History",
                     systemImage: "clock.arrow.circlepath",
                     description: Text("Actions you perform will appear here.")
                 )
+            } else {
+                ForEach(brewService.actionHistory) { entry in
+                    HistoryRow(entry: entry)
+                        .tag(entry)
+                }
             }
         }
         .navigationTitle("History")

--- a/Brewy/Views/MaintenanceView.swift
+++ b/Brewy/Views/MaintenanceView.swift
@@ -47,13 +47,6 @@ struct MaintenanceView: View {
             async let configTask: () = loadConfig()
             _ = await (cacheTask, configTask)
         }
-        .task {
-            while !Task.isCancelled {
-                try? await Task.sleep(for: .seconds(60))
-                guard !Task.isCancelled else { break }
-                brewConfig = await brewService.config()
-            }
-        }
     }
 
     // MARK: - Health Check
@@ -183,13 +176,23 @@ struct MaintenanceView: View {
 
     private func loadCacheSize() async {
         isCalculatingCache = true
-        cacheSizeBytes = await brewService.cacheSize()
+        let size = await brewService.cacheSize()
+        guard !Task.isCancelled else {
+            isCalculatingCache = false
+            return
+        }
+        cacheSizeBytes = size
         isCalculatingCache = false
     }
 
     private func loadConfig() async {
         isLoadingConfig = true
-        brewConfig = await brewService.config()
+        let config = await brewService.config()
+        guard !Task.isCancelled else {
+            isLoadingConfig = false
+            return
+        }
+        brewConfig = config
         isLoadingConfig = false
     }
 

--- a/Brewy/Views/PackageDetailView.swift
+++ b/Brewy/Views/PackageDetailView.swift
@@ -23,11 +23,9 @@ struct PackageDetailView: View {
                     package: displayPackage,
                     showUninstallConfirm: $showUninstallConfirm
                 )
-                .id(displayPackage.homepage)
                 Divider()
                     .padding(.horizontal)
                 PackageInfoSection(package: displayPackage)
-                .id(displayPackage.description)
                 if !package.isMas {
                     Divider()
                         .padding(.horizontal)
@@ -46,10 +44,15 @@ struct PackageDetailView: View {
             if package.homepage.isEmpty {
                 async let details = brewService.fetchPackageDetail(for: package)
                 async let info = brewService.info(for: package)
-                enrichedPackage = await details
-                detailedInfo = await info
+                let fetchedDetails = await details
+                let fetchedInfo = await info
+                guard !Task.isCancelled else { return }
+                enrichedPackage = fetchedDetails
+                detailedInfo = fetchedInfo
             } else {
-                detailedInfo = await brewService.info(for: package)
+                let fetched = await brewService.info(for: package)
+                guard !Task.isCancelled else { return }
+                detailedInfo = fetched
             }
             isLoadingInfo = false
         }

--- a/Brewy/Views/PackageListView.swift
+++ b/Brewy/Views/PackageListView.swift
@@ -44,7 +44,8 @@ struct PackageListView: View {
     }
 
     var body: some View {
-        packageList
+        let packages = displayedPackages
+        return packageList(packages: packages)
             .listStyle(.inset(alternatesRowBackgrounds: true))
             .searchable(text: $searchText, isPresented: $isSearchPresented, prompt: searchPrompt)
             .searchScopes($searchScope, activation: .onSearchPresentation) {
@@ -77,44 +78,34 @@ struct PackageListView: View {
                 selectedPackage = nil
             }
             .overlay {
-                if brewService.isLoading, displayedPackages.isEmpty {
+                if brewService.isLoading, packages.isEmpty {
                     ProgressView("Loading packages...")
                 }
             }
             .navigationTitle(navigationTitle)
-            .navigationSubtitle("\(displayedPackages.count) packages")
+            .navigationSubtitle("\(packages.count) packages")
             .toolbar {
                 PackageListToolbar(
                     isOutdated: isOutdatedCategory,
                     isSelecting: $isSelectingForUpgrade,
                     selectedForUpgrade: $selectedForUpgrade,
-                    outdatedPackages: isOutdatedCategory ? displayedPackages : []
+                    outdatedPackages: isOutdatedCategory ? packages : []
                 )
             }
     }
 
-    private var packageList: some View {
+    private func packageList(packages: [BrewPackage]) -> some View {
         List(selection: $selectedPackage) {
-            if displayedPackages.isEmpty {
+            if packages.isEmpty {
                 emptyContent
             } else {
-                ForEach(displayedPackages) { package in
+                ForEach(packages) { package in
                     HStack {
                         if isOutdatedCategory, isSelectingForUpgrade {
-                            Toggle(isOn: Binding(
-                                get: { selectedForUpgrade.contains(package.id) },
-                                set: { isSelected in
-                                    if isSelected {
-                                        selectedForUpgrade.insert(package.id)
-                                    } else {
-                                        selectedForUpgrade.remove(package.id)
-                                    }
-                                }
-                            )) {
-                                EmptyView()
-                            }
-                            .toggleStyle(.checkbox)
-                            .labelsHidden()
+                            UpgradeSelectionToggle(
+                                packageID: package.id,
+                                selectedForUpgrade: $selectedForUpgrade
+                            )
                         }
                         PackageRow(
                             package: package,
@@ -207,6 +198,28 @@ private struct PackageListToolbar: ToolbarContent {
                 }
             }
         }
+    }
+}
+
+// MARK: - Upgrade Selection Toggle
+
+private struct UpgradeSelectionToggle: View {
+    let packageID: String
+    @Binding var selectedForUpgrade: Set<String>
+
+    var body: some View {
+        Toggle(isOn: Binding(
+            get: { selectedForUpgrade.contains(packageID) },
+            set: { isSelected in
+                if isSelected {
+                    selectedForUpgrade.insert(packageID)
+                } else {
+                    selectedForUpgrade.remove(packageID)
+                }
+            }
+        )) { EmptyView() }
+        .toggleStyle(.checkbox)
+        .labelsHidden()
     }
 }
 

--- a/Brewy/Views/ServicesView.swift
+++ b/Brewy/Views/ServicesView.swift
@@ -6,9 +6,8 @@ struct ServicesView: View {
     @State private var services: [BrewServiceItem] = []
     @State private var isLoading = true
     @State private var errorMessage: String?
-    @State private var showError = false
     @Binding var selectedService: BrewServiceItem?
-    var refreshTrigger: Bool
+    var refreshTrigger: Int
 
     var body: some View {
         List(selection: $selectedService) {
@@ -28,9 +27,8 @@ struct ServicesView: View {
                 )
             }
         }
-        .task { await loadServices() }
+        .task(id: refreshTrigger) { await loadServices() }
         .refreshable { await loadServices() }
-        .onChange(of: refreshTrigger) { Task { await loadServices() } }
         .navigationTitle("Services")
         .toolbar {
             ToolbarItem(placement: .primaryAction) {
@@ -43,16 +41,27 @@ struct ServicesView: View {
                 .disabled(isLoading)
             }
         }
-        .alert("Error", isPresented: $showError) {
+        .alert(
+            "Error",
+            isPresented: Binding(
+                get: { errorMessage != nil },
+                set: { if !$0 { errorMessage = nil } }
+            ),
+            presenting: errorMessage
+        ) { _ in
             Button("OK") { errorMessage = nil }
-        } message: {
-            Text(errorMessage ?? "An unknown error occurred.")
+        } message: { message in
+            Text(message)
         }
     }
 
     func loadServices() async {
         isLoading = true
         let fetched = await brewService.fetchServices()
+        guard !Task.isCancelled else {
+            isLoading = false
+            return
+        }
         services = fetched
         if let selected = selectedService {
             selectedService = fetched.first { $0.id == selected.id }
@@ -64,7 +73,6 @@ struct ServicesView: View {
         let result = await brewService.cleanupServices()
         if !result.success {
             errorMessage = result.output.isEmpty ? "Cleanup failed" : result.output
-            showError = true
         }
         await loadServices()
     }
@@ -143,7 +151,6 @@ struct ServiceDetailView: View {
     @State private var isPerformingAction = false
     @State private var actionOutput: String?
     @State private var errorMessage: String?
-    @State private var showError = false
     @State private var useSudo = false
 
     var body: some View {
@@ -157,10 +164,17 @@ struct ServiceDetailView: View {
         }
         .formStyle(.grouped)
         .navigationTitle(service.name)
-        .alert("Error", isPresented: $showError) {
+        .alert(
+            "Error",
+            isPresented: Binding(
+                get: { errorMessage != nil },
+                set: { if !$0 { errorMessage = nil } }
+            ),
+            presenting: errorMessage
+        ) { _ in
             Button("OK") { errorMessage = nil }
-        } message: {
-            Text(errorMessage ?? "An unknown error occurred.")
+        } message: { message in
+            Text(message)
         }
     }
 
@@ -319,14 +333,13 @@ struct ServiceDetailView: View {
         return .secondary
     }
 
-    private func performAction(_ action: () async -> CommandResult) async {
+    private func performAction(_ action: @MainActor () async -> CommandResult) async {
         isPerformingAction = true
         actionOutput = nil
         let result = await action()
         actionOutput = result.output
         if !result.success {
             errorMessage = result.output.isEmpty ? "Command failed" : result.output
-            showError = true
         }
         isPerformingAction = false
         await onRefresh()

--- a/Brewy/Views/SidebarView.swift
+++ b/Brewy/Views/SidebarView.swift
@@ -1,27 +1,25 @@
 import SwiftUI
 
 struct SidebarView: View {
-    @Environment(BrewService.self)
-    private var brewService
     @Binding var selectedCategory: SidebarCategory?
 
     var body: some View {
         List(selection: $selectedCategory) {
             Section("Packages") {
                 ForEach(SidebarCategory.packageCategories) { category in
-                    SidebarRow(category: category, count: count(for: category))
+                    SidebarRow(category: category)
                         .tag(category)
                 }
             }
             Section("Management") {
                 ForEach(SidebarCategory.managementCategories) { category in
-                    SidebarRow(category: category, count: count(for: category))
+                    SidebarRow(category: category)
                         .tag(category)
                 }
             }
             Section("Tools") {
                 ForEach(SidebarCategory.toolCategories) { category in
-                    SidebarRow(category: category, count: count(for: category))
+                    SidebarRow(category: category)
                         .tag(category)
                 }
             }
@@ -32,26 +30,14 @@ struct SidebarView: View {
         }
         .navigationTitle("Brewy")
     }
-
-    private func count(for category: SidebarCategory) -> Int? {
-        switch category {
-        case .masApps: brewService.isMasAvailable ? brewService.packages(for: category).count : nil
-        case .taps: brewService.installedTaps.count
-        case .services: nil
-        case .groups: brewService.packageGroups.isEmpty ? nil : brewService.packageGroups.count
-        case .history: brewService.actionHistory.isEmpty ? nil : brewService.actionHistory.count
-        case .discover: nil
-        case .maintenance: nil
-        default: brewService.packages(for: category).count
-        }
-    }
 }
 
 // MARK: - Sidebar Row
 
 private struct SidebarRow: View {
+    @Environment(BrewService.self)
+    private var brewService
     let category: SidebarCategory
-    let count: Int?
 
     var body: some View {
         Label {
@@ -68,6 +54,19 @@ private struct SidebarRow: View {
         } icon: {
             Image(systemName: category.systemImage)
                 .foregroundStyle(iconColor)
+        }
+    }
+
+    private var count: Int? {
+        switch category {
+        case .masApps: brewService.isMasAvailable ? brewService.packages(for: category).count : nil
+        case .taps: brewService.installedTaps.count
+        case .services: nil
+        case .groups: brewService.packageGroups.isEmpty ? nil : brewService.packageGroups.count
+        case .history: brewService.actionHistory.isEmpty ? nil : brewService.actionHistory.count
+        case .discover: nil
+        case .maintenance: nil
+        default: brewService.packages(for: category).count
         }
     }
 

--- a/Brewy/Views/TapListView.swift
+++ b/Brewy/Views/TapListView.swift
@@ -20,7 +20,9 @@ struct TapListView: View {
                         .tag(tap)
                         .contextMenu {
                             Button("Remove Tap", role: .destructive) {
-                                Task { await brewService.removeTap(name: tap.name) }
+                                let name = tap.name
+                                if selectedTap?.name == name { selectedTap = nil }
+                                Task { await brewService.removeTap(name: name) }
                             }
                         }
                 }

--- a/Brewy/Views/WhatsNewView.swift
+++ b/Brewy/Views/WhatsNewView.swift
@@ -4,6 +4,7 @@ struct WhatsNewView: View {
     @Environment(\.dismiss)
     private var dismiss
     @State private var release: AppcastRelease?
+    @State private var parsedNotes: AttributedString?
     @State private var isLoading = true
     @State private var errorMessage: String?
 
@@ -79,8 +80,7 @@ struct WhatsNewView: View {
                         }
                     }
 
-                    if let html = release.descriptionHTML,
-                       let attributed = Self.attributedString(from: html) {
+                    if let attributed = parsedNotes {
                         Text(attributed)
                             .font(.callout)
                             .textSelection(.enabled)
@@ -132,9 +132,14 @@ struct WhatsNewView: View {
             }
 
             let parser = AppcastParser()
-            release = parser.parse(data: data)
+            let loaded = parser.parse(data: data)
+            guard !Task.isCancelled else { return }
+            release = loaded
 
-            if release == nil {
+            if let html = loaded?.descriptionHTML {
+                parsedNotes = Self.attributedString(from: html)
+            }
+            if loaded == nil {
                 errorMessage = "No release notes found."
             }
             isLoading = false


### PR DESCRIPTION
- Clear sibling selections (`selectedTap/Service/Group/History`) on category change so stale selections don't persist.
- Drop `.id()`-driven teardown in `PackageDetailView` that was destroying in-flight confirmation dialogs.
- Keep `DiscoverView` search results in local state instead of mutating shared `brewService.searchResults` (prevents cross-talk with `PackageListView`).
- Memoize `displayedPackages` via a local let (was filtered 4× per body).
- Convert services refresh trigger from `Bool` to `Int` + `.task(id:)` so rapid actions cancel prior loads.
- Push `count` into `SidebarRow` so each row observes a narrow slice of service state.
- Parse release-notes HTML off body, drop the 60s maintenance polling loop, drive alerts off optionals directly, clear `selectedTap` on context-menu remove, and add cancellation checks after awaits.