### PR TITLE
ci: harden release workflow and tighten lint rules

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -9,7 +9,9 @@ defaults:
     shell: bash -xeuo pipefail {0}
 
 concurrency:
-  group: "ci-${{ github.ref }}"
+  # PR body/title edits fire `edited` events; give them their own per-run group so
+  # they can't cancel in-flight tests from the preceding `opened`/`synchronize` run.
+  group: ${{ github.event.action == 'edited' && format('ci-edit-{0}-{1}', github.ref, github.run_id) || format('ci-{0}', github.ref) }}
   cancel-in-progress: true
 
 permissions: {}

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -167,8 +167,8 @@ jobs:
             EXCLUDED_ARCHS=x86_64
 
       - name: Coverage Summary
-        if: always() && matrix.check == 'test-tsan'
-        run: xcrun xccov view --report --only-targets TestResults-TSAN.xcresult || true
+        if: success() && matrix.check == 'test-tsan'
+        run: xcrun xccov view --report --only-targets TestResults-TSAN.xcresult
 
       - name: Upload Test Results
         if: always() && startsWith(matrix.check, 'test-')

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -42,13 +42,18 @@ jobs:
       - name: Extract version from Xcode project
         id: version
         run: |
-          TAG=$(grep -m1 'MARKETING_VERSION' Brewy.xcodeproj/project.pbxproj | sed 's/.*= *//;s/ *;.*//')
+          SETTINGS=$(xcodebuild -project Brewy.xcodeproj -target Brewy -configuration Release -showBuildSettings 2>/dev/null)
+          TAG=$(echo "${SETTINGS}" | awk -F' = ' '/^[[:space:]]*MARKETING_VERSION[[:space:]]*=/ {print $2; exit}')
+          BUILD_NUMBER=$(echo "${SETTINGS}" | awk -F' = ' '/^[[:space:]]*CURRENT_PROJECT_VERSION[[:space:]]*=/ {print $2; exit}')
           if [[ -z "${TAG}" ]]; then
-            echo "::error::Could not extract MARKETING_VERSION from project.pbxproj"
+            echo "::error::Could not extract MARKETING_VERSION from Brewy target"
+            exit 1
+          fi
+          if [[ -z "${BUILD_NUMBER}" ]]; then
+            echo "::error::Could not extract CURRENT_PROJECT_VERSION from Brewy target"
             exit 1
           fi
           echo "tag=${TAG}" >> "${GITHUB_OUTPUT}"
-          BUILD_NUMBER=$(grep -m1 'CURRENT_PROJECT_VERSION' Brewy.xcodeproj/project.pbxproj | sed 's/.*= *//;s/ *;.*//')
           echo "build_number=${BUILD_NUMBER}" >> "${GITHUB_OUTPUT}"
           echo "TAG=${TAG}" >> "${GITHUB_ENV}"
 
@@ -194,9 +199,9 @@ jobs:
           ARTIFACT_NAME: ${{ needs.build.outputs.artifact_name }}
         run: |
           SPARKLE_KEY_FILE="${RUNNER_TEMP}/sparkle_private_key"
+          trap 'rm -f "${SPARKLE_KEY_FILE}"' EXIT
           echo "${SPARKLE_KEY}" > "${SPARKLE_KEY_FILE}"
           SIG_OUTPUT=$("${RUNNER_TEMP}/sparkle/bin/sign_update" "${ARTIFACT_NAME}" --ed-key-file "${SPARKLE_KEY_FILE}" 2>&1)
-          rm -f "${SPARKLE_KEY_FILE}"
           echo "SPARKLE_SIG=$(echo "${SIG_OUTPUT}" | grep -o 'sparkle:edSignature="[^"]*"' | cut -d'"' -f2)" >> "${GITHUB_ENV}"
           echo "SPARKLE_LENGTH=$(echo "${SIG_OUTPUT}" | grep -o 'length="[^"]*"' | cut -d'"' -f2)" >> "${GITHUB_ENV}"
 
@@ -245,7 +250,8 @@ jobs:
           export PUBDATE="$(date -u '+%a, %d %b %Y %H:%M:%S %z')"
           export DOWNLOAD_URL="https://github.com/${REPOSITORY}/releases/download/${TAG}/${ARTIFACT_NAME}"
           export RELEASE_NOTES_HTML="$(cat "${RUNNER_TEMP}/release_notes.html")"
-          envsubst < .github/appcast-template.xml > appcast.xml
+          envsubst '$TAG $PUBDATE $BUILD_NUMBER $DOWNLOAD_URL $SPARKLE_LENGTH $SPARKLE_SIG $RELEASE_NOTES_HTML' \
+            < .github/appcast-template.xml > appcast.xml
 
       - name: Push appcast
         env:

--- a/.swiftlint.yml
+++ b/.swiftlint.yml
@@ -22,9 +22,11 @@ opt_in_rules:
   # Modern Swift
   - direct_return
   - implicit_return
+  - prefer_key_path
   - prefer_self_in_static_references
   - prefer_self_type_over_type_of_self
   - prefer_zero_over_explicit_init
+  - redundant_self_in_closure
   - self_binding
   - shorthand_optional_binding
   - superfluous_else
@@ -41,6 +43,7 @@ opt_in_rules:
   - private_swiftui_state
   - return_value_from_void_function
   - unavailable_function
+  - unhandled_throwing_task
   - unowned_variable_capture
   - yoda_condition
 
@@ -58,6 +61,7 @@ opt_in_rules:
   - joined_default_parameter
   - legacy_multiple
   - modifier_order
+  - no_extension_access_modifier
   - number_separator
   - operator_usage_whitespace
   - redundant_nil_coalescing


### PR DESCRIPTION
- Extract version via `xcodebuild -showBuildSettings` instead of `grep -m1 MARKETING_VERSION` (brittle against multiple build configs).
- Whitelist `envsubst` vars so release-note `\${…}` strings can't clobber appcast placeholders.
- Clean up the Sparkle private-key file via `trap ... EXIT` so a failed sign still removes it.
- Stop swallowing `xccov` failures; gate the coverage step on test success.
- Opt into `prefer_key_path`, `redundant_self_in_closure`, `no_extension_access_modifier`, `unhandled_throwing_task` (no existing violations).