### PR TITLE
chore: modernize env key, extract ConsoleOutput, move updater to @Observable

### DIFF
--- a/Brewy/BrewyApp.swift
+++ b/Brewy/BrewyApp.swift
@@ -1,3 +1,4 @@
+import Combine
 import Sparkle
 import SwiftUI
 
@@ -84,27 +85,31 @@ struct BrewyApp: App {
 // MARK: - Sparkle Updates
 
 @MainActor
-private final class CheckForUpdatesViewModel: ObservableObject {
-    @Published var canCheckForUpdates = false
+@Observable
+private final class CheckForUpdatesViewModel {
+    var canCheckForUpdates = false
+    @ObservationIgnored private var cancellable: AnyCancellable?
 
     init(updater: SPUUpdater) {
-        updater.publisher(for: \.canCheckForUpdates)
-            .assign(to: &$canCheckForUpdates)
+        cancellable = updater.publisher(for: \.canCheckForUpdates)
+            .sink { [weak self] value in
+                self?.canCheckForUpdates = value
+            }
     }
 }
 
 private struct CheckForUpdatesView: View {
-    @ObservedObject private var checkForUpdatesViewModel: CheckForUpdatesViewModel
+    @State private var viewModel: CheckForUpdatesViewModel
     private let updater: SPUUpdater
 
     init(updater: SPUUpdater) {
         self.updater = updater
-        self.checkForUpdatesViewModel = CheckForUpdatesViewModel(updater: updater)
+        _viewModel = State(wrappedValue: CheckForUpdatesViewModel(updater: updater))
     }
 
     var body: some View {
         Button("Check for Updates…", action: updater.checkForUpdates)
-            .disabled(!checkForUpdatesViewModel.canCheckForUpdates)
+            .disabled(!viewModel.canCheckForUpdates)
     }
 }
 

--- a/Brewy/Views/ContentView.swift
+++ b/Brewy/Views/ContentView.swift
@@ -6,15 +6,8 @@ extension Notification.Name {
 
 // MARK: - Package Navigation Environment
 
-private struct SelectPackageActionKey: EnvironmentKey {
-    static let defaultValue: @MainActor @Sendable (String) -> Void = { _ in }
-}
-
 extension EnvironmentValues {
-    var selectPackage: @MainActor @Sendable (String) -> Void {
-        get { self[SelectPackageActionKey.self] }
-        set { self[SelectPackageActionKey.self] = newValue }
-    }
+    @Entry var selectPackage: @MainActor @Sendable (String) -> Void = { _ in }
 }
 
 struct ContentView: View {

--- a/Brewy/Views/HistoryView.swift
+++ b/Brewy/Views/HistoryView.swift
@@ -139,13 +139,7 @@ struct HistoryDetailView: View {
                     .font(.callout)
                     .foregroundStyle(.tertiary)
             } else {
-                Text(entry.output)
-                    .font(.system(.caption, design: .monospaced))
-                    .foregroundStyle(.secondary)
-                    .textSelection(.enabled)
-                    .frame(maxWidth: .infinity, alignment: .leading)
-                    .padding(8)
-                    .background(.quaternary.opacity(0.5), in: .rect(cornerRadius: 8))
+                ConsoleOutput(text: entry.output, padding: 8)
             }
         } header: {
             Label("Output", systemImage: "terminal")

--- a/Brewy/Views/MaintenanceView.swift
+++ b/Brewy/Views/MaintenanceView.swift
@@ -80,13 +80,7 @@ struct MaintenanceView: View {
                 }
 
                 if let output = doctorOutput {
-                    Text(output.isEmpty ? "Your system is ready to brew." : output)
-                        .font(.system(.caption, design: .monospaced))
-                        .foregroundStyle(output.isEmpty ? .green : .secondary)
-                        .textSelection(.enabled)
-                        .padding(10)
-                        .frame(maxWidth: .infinity, alignment: .leading)
-                        .background(.quaternary.opacity(0.5), in: .rect(cornerRadius: 8))
+                    ConsoleOutput(text: output.isEmpty ? "Your system is ready to brew." : output, padding: 10)
                 }
             }
         } footer: {

--- a/Brewy/Views/PackageDetailView.swift
+++ b/Brewy/Views/PackageDetailView.swift
@@ -425,13 +425,7 @@ private struct BrewInfoSection: View {
                     .frame(maxWidth: .infinity)
                     .background(.quaternary.opacity(0.5), in: .rect(cornerRadius: 8))
                 } else if !info.isEmpty {
-                    Text(info)
-                        .font(.system(.caption, design: .monospaced))
-                        .foregroundStyle(.secondary)
-                        .textSelection(.enabled)
-                        .padding(12)
-                        .frame(maxWidth: .infinity, alignment: .leading)
-                        .background(.quaternary.opacity(0.5), in: .rect(cornerRadius: 8))
+                    ConsoleOutput(text: info)
                 }
             }
         }

--- a/Brewy/Views/ServicesView.swift
+++ b/Brewy/Views/ServicesView.swift
@@ -261,13 +261,7 @@ struct ServiceDetailView: View {
 
     private func outputSection(_ output: String) -> some View {
         Section {
-            Text(output)
-                .font(.system(.caption, design: .monospaced))
-                .foregroundStyle(.secondary)
-                .textSelection(.enabled)
-                .frame(maxWidth: .infinity, alignment: .leading)
-                .padding(8)
-                .background(.quaternary.opacity(0.5), in: .rect(cornerRadius: 8))
+            ConsoleOutput(text: output, padding: 8)
         } header: {
             Label("Output", systemImage: "terminal")
         }

--- a/Brewy/Views/SharedViews.swift
+++ b/Brewy/Views/SharedViews.swift
@@ -60,6 +60,29 @@ struct FlowLayout: Layout {
     }
 }
 
+// MARK: - Console Output
+
+struct ConsoleOutput: View {
+    let text: String
+    var maxHeight: CGFloat?
+    var padding: CGFloat = 12
+
+    var body: some View {
+        let content = Text(text)
+            .font(.system(.caption, design: .monospaced))
+            .foregroundStyle(.secondary)
+            .textSelection(.enabled)
+            .frame(maxWidth: .infinity, alignment: .leading)
+            .padding(padding)
+            .background(.quaternary.opacity(0.5), in: .rect(cornerRadius: 8))
+        if let maxHeight {
+            ScrollView { content }.frame(maxHeight: maxHeight)
+        } else {
+            content
+        }
+    }
+}
+
 // MARK: - Action Overlay
 
 struct ActionOverlay: View {


### PR DESCRIPTION
- Replace manual `EnvironmentKey` for `selectPackage` with the `@Entry` macro.
- Extract the repeated monospaced-output styling block into a reusable `ConsoleOutput` view (used in PackageDetail, History, Maintenance, Services).
- Move `CheckForUpdatesViewModel` from `ObservableObject` / `@ObservedObject` to `@Observable` + `@State`.