### PR TITLE
chore: update repo URLs after org transfer to starhaven-io

### DIFF
--- a/.github/workflows/pinprick-audit.yml
+++ b/.github/workflows/pinprick-audit.yml
@@ -27,7 +27,7 @@ jobs:
           persist-credentials: false
 
       - name: Install pinprick
-        run: /home/linuxbrew/.linuxbrew/bin/brew install p-linnane/tap/pinprick
+        run: /home/linuxbrew/.linuxbrew/bin/brew install starhaven-io/tap/pinprick
 
       - name: Run pinprick audit
         env:

--- a/Brewy/Info.plist
+++ b/Brewy/Info.plist
@@ -3,7 +3,7 @@
 <plist version="1.0">
 <dict>
 	<key>SUFeedURL</key>
-	<string>https://raw.githubusercontent.com/p-linnane/Brewy/appcast/appcast.xml</string>
+	<string>https://raw.githubusercontent.com/starhaven-io/Brewy/appcast/appcast.xml</string>
 	<key>SUPublicEDKey</key>
 	<string>bDdj4oLQDw8Ut2IoUsIH2DbaP5eSqtkqXS1fSjd3/6s=</string>
 </dict>

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -1,6 +1,6 @@
 # Brewy — Claude Project Context
 
-Brewy is a native macOS GUI for managing Homebrew packages, written in Swift/SwiftUI. It lets users browse, search, install, upgrade, pin, and uninstall formulae and casks without opening Terminal. The project is open source (AGPL-3.0-only) and lives at https://github.com/p-linnane/brewy.
+Brewy is a native macOS GUI for managing Homebrew packages, written in Swift/SwiftUI. It lets users browse, search, install, upgrade, pin, and uninstall formulae and casks without opening Terminal. The project is open source (AGPL-3.0-only) and lives at https://github.com/starhaven-io/Brewy.
 
 ## Project overview
 

--- a/README.md
+++ b/README.md
@@ -2,7 +2,7 @@
 
 <p align="center"><img src="assets/BrewyIcon.png" alt="Brewy icon" width="128"></p>
 
-[![CI](https://github.com/p-linnane/brewy/actions/workflows/ci.yml/badge.svg)](https://github.com/p-linnane/brewy/actions/workflows/ci.yml)
+[![CI](https://github.com/starhaven-io/Brewy/actions/workflows/ci.yml/badge.svg)](https://github.com/starhaven-io/Brewy/actions/workflows/ci.yml)
 [![License: AGPL-3.0-only](https://img.shields.io/badge/License-AGPL--3.0--only-blue.svg)](LICENSE)
 
 A native macOS app for managing [Homebrew](https://brew.sh) packages. Browse, search, install, and update formulae and casks — all without opening Terminal.
@@ -40,7 +40,7 @@ The best way to install Brewy is naturally with Homebrew:
 brew install brewy
 ```
 
-You can also grab the latest release from the [GitHub releases page](https://github.com/p-linnane/brewy/releases).
+You can also grab the latest release from the [GitHub releases page](https://github.com/starhaven-io/Brewy/releases).
 
 ## Building
 


### PR DESCRIPTION
## Summary

Update in-repo references from \`p-linnane/Brewy\` to \`starhaven-io/Brewy\` following the org transfer. Covers CLAUDE.md description, README CI badge and releases link, Sparkle \`SUFeedURL\` in \`Info.plist\` (now points at \`raw.githubusercontent.com/starhaven-io/Brewy/appcast/appcast.xml\`), and the \`pinprick\`-audit workflow's \`brew install starhaven-io/tap/pinprick\`.

Existing installed Brewy apps continue to receive updates via GitHub's \`raw.githubusercontent.com\` redirect; new builds carry the new URL directly.