### PR TITLE
ci: move DEVELOPMENT_TEAM from secret to variable

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -14,7 +14,7 @@ concurrency:
 permissions: {}
 
 env:
-  DEVELOPMENT_TEAM: ${{ secrets.DEVELOPMENT_TEAM }}
+  DEVELOPMENT_TEAM: ${{ vars.DEVELOPMENT_TEAM }}
 
 jobs:
   build:


### PR DESCRIPTION
The Apple Team ID is embedded in every signed app's codesign output — it's a public identifier, not a credential. Moving it to an environment variable (per GitHub's recommendation for non-sensitive config) keeps it visible in logs and avoids the maintenance overhead of a secret.