### PR TITLE
chore: add periphery config, delete unused didTimeOut field

### DIFF
--- a/.periphery.yml
+++ b/.periphery.yml
@@ -1,0 +1,3 @@
+project: Brewy.xcodeproj
+schemes:
+- Brewy

--- a/Brewy/Models/CommandRunner.swift
+++ b/Brewy/Models/CommandRunner.swift
@@ -9,13 +9,6 @@ private let logger = Logger(subsystem: "io.linnane.brewy", category: "CommandRun
 struct CommandResult: Sendable {
     let output: String
     let success: Bool
-    let didTimeOut: Bool
-
-    init(output: String, success: Bool, didTimeOut: Bool = false) {
-        self.output = output
-        self.success = success
-        self.didTimeOut = didTimeOut
-    }
 }
 
 // MARK: - Thread-safe Value Containers
@@ -206,8 +199,7 @@ enum CommandRunner {
         if timedOut.isSet {
             return CommandResult(
                 output: "Command timed out after \(timeout).",
-                success: false,
-                didTimeOut: true
+                success: false
             )
         }
         let stdout = String(data: out, encoding: .utf8) ?? ""

--- a/justfile
+++ b/justfile
@@ -48,6 +48,10 @@ lint:
 typos:
     typos
 
+# Scan for unused code (uses .periphery.yml)
+periphery:
+    periphery scan
+
 # Check
 
 # Run all checks
@@ -80,6 +84,11 @@ check:
         run zizmor .github/workflows/
     else
         skip audit zizmor zizmor
+    fi
+    if command -v periphery &>/dev/null; then
+        run periphery scan --strict --disable-update-check
+    else
+        skip periphery periphery periphery
     fi
     run xcodebuild test \
         -project Brewy.xcodeproj \


### PR DESCRIPTION
## Summary
- Add `.periphery.yml` (generated via `periphery scan --setup`) so `periphery scan` runs with no args.
- Add `just periphery` recipe and `periphery scan --strict --disable-update-check` to `just check`.
- Fix the single finding from the first scan: `CommandResult.didTimeOut` was set to `true` on timeout but never read anywhere. Removed the field, the init parameter, and the `didTimeOut: true` construction. The timeout path is already distinguishable via the `output` string ("Command timed out after …") plus `success == false`.

`periphery scan --strict` now exits 0 with "No unused code detected."