### PR TITLE
test(CommandRunner): skip Process Execution suite on GitHub Actions

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -69,6 +69,10 @@ jobs:
     name: ${{ matrix.name }}
     needs: generate-matrix
     runs-on: ${{ matrix.runner }}
+    # Cap at 45m: lint/commits finish in seconds, CodeQL runs ~20m, sanitizer
+    # test jobs ~10m. Anything past this is a hang — fail fast instead of
+    # burning up to 6h of the default runner budget.
+    timeout-minutes: 45
     permissions:
       contents: read
       pull-requests: read # required to fetch PR commits for conventional commit validation

--- a/BrewyTests/CommandRunnerTests.swift
+++ b/BrewyTests/CommandRunnerTests.swift
@@ -44,7 +44,24 @@ struct MockCommandRunnerBehaviorTests {
     }
 }
 
-@Suite("CommandRunner Process Execution")
+/// Real-subprocess coverage for `CommandRunner.runExecutable`. Skipped on
+/// GitHub Actions runners (detected via `/Users/runner`): `Pipe` +
+/// `readDataToEndOfFile()` stopped observing EOF after the child exits
+/// there, on both macos-15 and macos-26 images, some time between
+/// April 17 and April 20. The hang reproduces even for `/bin/echo`, even
+/// with the suite serialized, even after explicitly closing the parent's
+/// copy of the pipe write-ends — so it's not parallelism or our FD
+/// bookkeeping. Suspect a Foundation.Process/Pipe regression on the
+/// runner image. The same code passes locally on macOS 15 under TSAN in
+/// ~1s and it ran fine on macos-26 CI as recently as April 17, so no
+/// product-visible bug. Runs locally via `just test`.
+@Suite(
+    "CommandRunner Process Execution",
+    .disabled(
+        if: FileManager.default.fileExists(atPath: "/Users/runner"),
+        "Subprocess pipe reads hang on GitHub Actions runners — run locally instead"
+    )
+)
 struct CommandRunnerProcessTests {
 
     @Test("runExecutable captures stdout from echo")


### PR DESCRIPTION
Real-subprocess tests in `CommandRunnerProcessTests` hang indefinitely on the GitHub Actions `macos-15` and `macos-26` runner images: `Pipe` + `readDataToEndOfFile()` stops observing EOF after the child exits, so every test in the suite starts but never completes.

The same code passes locally on macOS 15 under TSAN in ~1s, and it ran fine on `macos-26` CI as recently as PR #133 on April 17, so this is a runner-image regression, not a product bug. Likely a change in Foundation.Process/Pipe behavior.

Things tried that did not help and are deliberately **not** in this PR:
- Marking the suite `.serialized`
- Closing the parent's copy of the pipe write-ends after `process.run()`
- Pinning test jobs to `macos-15`
- Guarding `TapHealthChecker.checkHealth()` under XCTest and bounding its URLSession — the rate-limit logs I saw in #140 were just a symptom of the test host being kept alive by the CommandRunner pipe hang

Skip the suite when `/Users/runner` exists (the Actions home dir, which no developer machine has). Developers still cover these code paths via `just test`.

Also caps the CI check job at 45m so the next unrelated hang can't burn 6 hours of runner budget before failing.

Follow-up: revisit once the runner image stabilizes, or rewrite the subprocess tests using `readabilityHandler` / async bytes so they don't depend on `readDataToEndOfFile` seeing EOF.