### PR TITLE
ci: integrate Codecov coverage and test analytics

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -165,6 +165,7 @@ jobs:
             -project Brewy.xcodeproj \
             -scheme Brewy \
             -destination 'platform=macOS' \
+            -derivedDataPath ./DerivedData \
             ${XCODEBUILD_FLAGS} \
             -resultBundlePath "${RESULT_BUNDLE}.xcresult" \
             CODE_SIGN_IDENTITY="" \
@@ -175,6 +176,62 @@ jobs:
       - name: Coverage Summary
         if: success() && matrix.check == 'test-tsan'
         run: xcrun xccov view --report --only-targets TestResults-TSAN.xcresult
+
+      - name: Export LCOV for Codecov
+        if: success() && matrix.check == 'test-tsan'
+        run: |
+          PROFDATA=$(find ./DerivedData -name 'Coverage.profdata' -type f | head -1)
+          if [[ -z "${PROFDATA}" ]]; then
+            echo "::error::No Coverage.profdata found under ./DerivedData"
+            exit 1
+          fi
+          BINARY_ARGS=()
+          FIRST=""
+          while IFS= read -r xctest; do
+            name=$(basename "${xctest}" .xctest)
+            bin="${xctest}/Contents/MacOS/${name}"
+            [[ -f "${bin}" ]] || continue
+            if [[ -z "${FIRST}" ]]; then FIRST="${bin}"; else BINARY_ARGS+=(-object "${bin}"); fi
+          done < <(find ./DerivedData/Build/Products -name '*.xctest' -type d)
+          while IFS= read -r app; do
+            name=$(basename "${app}" .app)
+            bin="${app}/Contents/MacOS/${name}"
+            [[ -f "${bin}" ]] || continue
+            if [[ -z "${FIRST}" ]]; then FIRST="${bin}"; else BINARY_ARGS+=(-object "${bin}"); fi
+          done < <(find ./DerivedData/Build/Products -name '*.app' -type d -not -path '*.xctest*')
+          if [[ -z "${FIRST}" ]]; then
+            echo "::error::No instrumented binaries found under ./DerivedData/Build/Products"
+            exit 1
+          fi
+          xcrun llvm-cov export -format=lcov \
+            -ignore-filename-regex='(Tests/|\.build/|DerivedData/|/Checkouts/|/SourcePackages/)' \
+            "${FIRST}" \
+            "${BINARY_ARGS[@]}" \
+            -instr-profile="${PROFDATA}" \
+            > coverage.lcov
+          echo "lcov: $(wc -l < coverage.lcov) lines"
+
+      - name: Upload coverage to Codecov
+        if: success() && matrix.check == 'test-tsan'
+        uses: codecov/codecov-action@75cd11691c0faa626561e295848008c8a7dddffe # v5.5.4
+        with:
+          token: ${{ secrets.CODECOV_TOKEN }}
+          files: coverage.lcov
+          fail_ci_if_error: false
+
+      - name: Convert xcresult to JUnit
+        if: ${{ !cancelled() && matrix.check == 'test-tsan' }}
+        env:
+          RESULT_BUNDLE: ${{ matrix.result_bundle }}
+        run: python3 scripts/xcresult-to-junit.py "${RESULT_BUNDLE}.xcresult" > junit.xml
+
+      - name: Upload test results to Codecov
+        if: ${{ !cancelled() && matrix.check == 'test-tsan' }}
+        uses: codecov/test-results-action@0fa95f0e1eeaafde2c782583b36b28ad0d8c77d3 # v1.2.1
+        with:
+          token: ${{ secrets.CODECOV_TOKEN }}
+          files: junit.xml
+          fail_ci_if_error: false
 
       - name: Upload Test Results
         if: always() && startsWith(matrix.check, 'test-')

--- a/scripts/xcresult-to-junit.py
+++ b/scripts/xcresult-to-junit.py
@@ -1,0 +1,119 @@
+#!/usr/bin/env python3
+"""Convert an Xcode xcresult bundle to JUnit XML for Codecov test analytics.
+
+Usage: xcresult-to-junit.py <path-to-xcresult> > junit.xml
+
+Uses `xcrun xcresulttool get test-results tests` (Xcode 16+).
+"""
+
+from __future__ import annotations
+
+import json
+import re
+import subprocess
+import sys
+from xml.etree.ElementTree import Element, ElementTree, SubElement, indent
+
+DURATION_RE = re.compile(r"([\d.]+)\s*(ms|s|m|h)")
+
+
+def parse_duration(raw: str | None) -> float:
+    if not raw:
+        return 0.0
+    total = 0.0
+    for value, unit in DURATION_RE.findall(raw):
+        value = float(value)
+        if unit == "ms":
+            total += value / 1000
+        elif unit == "s":
+            total += value
+        elif unit == "m":
+            total += value * 60
+        elif unit == "h":
+            total += value * 3600
+    return total
+
+
+def collect_failure_messages(node: dict) -> list[str]:
+    messages: list[str] = []
+    for child in node.get("children", []):
+        if child.get("nodeType") == "Failure Message":
+            text = child.get("name", "")
+            if text:
+                messages.append(text)
+        messages.extend(collect_failure_messages(child))
+    return messages
+
+
+def walk_tests(node: dict, suite: str | None):
+    node_type = node.get("nodeType")
+    name = node.get("name", "")
+    if node_type == "Test Case":
+        yield suite or "Unknown", node
+        return
+    next_suite = suite
+    if node_type in ("Test Suite", "Test Bundle"):
+        next_suite = name if suite is None else f"{suite}.{name}"
+    for child in node.get("children", []):
+        yield from walk_tests(child, next_suite)
+
+
+def main() -> int:
+    if len(sys.argv) != 2:
+        print("usage: xcresult-to-junit.py <xcresult>", file=sys.stderr)
+        return 2
+
+    xcresult = sys.argv[1]
+    proc = subprocess.run(
+        ["xcrun", "xcresulttool", "get", "test-results", "tests", "--path", xcresult],
+        capture_output=True,
+        check=True,
+    )
+    data = json.loads(proc.stdout)
+
+    suites: dict[str, list[dict]] = {}
+    for plan in data.get("testNodes", []):
+        for suite_name, test in walk_tests(plan, None):
+            suites.setdefault(suite_name, []).append(test)
+
+    root = Element("testsuites")
+    for suite_name, tests in suites.items():
+        failed = sum(1 for t in tests if t.get("result") == "Failed")
+        skipped = sum(1 for t in tests if t.get("result") == "Skipped")
+        total_time = sum(parse_duration(t.get("duration")) for t in tests)
+        suite_elem = SubElement(
+            root,
+            "testsuite",
+            {
+                "name": suite_name,
+                "tests": str(len(tests)),
+                "failures": str(failed),
+                "skipped": str(skipped),
+                "time": f"{total_time:.3f}",
+            },
+        )
+        for test in tests:
+            tc = SubElement(
+                suite_elem,
+                "testcase",
+                {
+                    "name": test.get("name", ""),
+                    "classname": suite_name,
+                    "time": f"{parse_duration(test.get('duration')):.3f}",
+                },
+            )
+            result = test.get("result")
+            if result == "Failed":
+                messages = collect_failure_messages(test)
+                failure = SubElement(tc, "failure", {"message": messages[0] if messages else "Test failed"})
+                failure.text = "\n".join(messages) if messages else "Failed"
+            elif result == "Skipped":
+                SubElement(tc, "skipped")
+
+    indent(root, space="  ")
+    ElementTree(root).write(sys.stdout.buffer, xml_declaration=True, encoding="utf-8")
+    return 0
+
+
+if __name__ == "__main__":
+    sys.exit(main())


### PR DESCRIPTION
Uploads coverage (lcov) and test results (JUnit XML) to Codecov from the Thread Sanitizer test job.

- `xcodebuild test` now uses an explicit `-derivedDataPath ./DerivedData` so the `Coverage.profdata` and instrumented binaries can be located deterministically
- New step exports lcov via `xcrun llvm-cov export`, scoped to the app and xctest binaries and ignoring test and dependency sources
- New script `scripts/xcresult-to-junit.py` converts the xcresult bundle to JUnit XML using `xcrun xcresulttool get test-results tests` (Xcode 16+). Verified locally against an existing xcresult — produces well-formed JUnit with 190 test cases
- Uploads use `codecov/codecov-action@v5.5.4` and `codecov/test-results-action@v1.2.1`, both hash-pinned; `CODECOV_TOKEN` comes from the org-level secret
- `fail_ci_if_error: false` on both uploads so a Codecov outage doesn't block CI