### PR TITLE
ci: promote zizmor to auditor persona

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -49,7 +49,7 @@ jobs:
           # Swift changes: lint + sanitizer tests
           if echo "${CHANGED}" | grep -qE '\.swift$|^Brewy\.xcodeproj/|^\.swiftlint\.yml$'; then
             MATRIX+=',{"name":"Lint","check":"lint","runner":"macos-26"}'
-            MATRIX+=',{"name":"Test (Thread Sanitizer)","check":"test-tsan","runner":"macos-26","xcodebuild_flags":"-enableCodeCoverage YES -enableThreadSanitizer YES","result_bundle":"TestResults-TSAN"}'
+            MATRIX+=',{"name":"Test (Thread Sanitizer)","check":"test-tsan","runner":"macos-26","xcodebuild_flags":"-enableCodeCoverage YES -enableThreadSanitizer YES","result_bundle":"TestResults-TSAN","environment":"codecov"}'
             MATRIX+=',{"name":"Test (Address Sanitizer)","check":"test-asan","runner":"macos-26","xcodebuild_flags":"-enableAddressSanitizer YES","result_bundle":"TestResults-ASAN"}'
           fi
 
@@ -69,6 +69,9 @@ jobs:
     name: ${{ matrix.name }}
     needs: generate-matrix
     runs-on: ${{ matrix.runner }}
+    environment:
+      name: ${{ matrix.environment }}
+      deployment: false
     # Cap at 45m: lint/commits finish in seconds, CodeQL runs ~20m, sanitizer
     # test jobs ~10m. Anything past this is a hang — fail fast instead of
     # burning up to 6h of the default runner budget.
@@ -276,7 +279,7 @@ jobs:
         if: matrix.check == 'zizmor'
         uses: zizmorcore/zizmor-action@b1d7e1fb5de872772f31590499237e7cce841e8e # v0.5.3
         with:
-          persona: pedantic
+          persona: auditor
 
   conclusion:
     name: conclusion

--- a/justfile
+++ b/justfile
@@ -38,7 +38,7 @@ test:
 
 # Audit GitHub Actions workflows
 audit:
-    zizmor .github/workflows/
+    zizmor --persona auditor .github/workflows/
 
 # Run SwiftLint
 lint:
@@ -81,7 +81,7 @@ check:
         skip typos typos typos-cli
     fi
     if command -v zizmor &>/dev/null; then
-        run zizmor .github/workflows/
+        run zizmor --persona auditor .github/workflows/
     else
         skip audit zizmor zizmor
     fi


### PR DESCRIPTION
Follow-up to the Codecov integration.

- `justfile` audit recipes updated to `--persona auditor`
- CI workflow `zizmor` step bumped from `pedantic` to `auditor`
- `test-tsan` matrix entry scoped to a new `codecov` GitHub environment (conditional via `matrix.environment`, with `deployment: false`) so the `CODECOV_TOKEN` references satisfy auditor's `secrets-outside-env` check

Requires the `codecov` GitHub environment to exist in the repo (already created via API).