### PR TITLE
feat: surface new formulae/casks from brew update

### DIFF
--- a/Brewy/Models/BrewService+Actions.swift
+++ b/Brewy/Models/BrewService+Actions.swift
@@ -30,10 +30,6 @@ extension BrewService {
     func link(package: BrewPackage) async { await performAction("link", package: package) }
     func unlink(package: BrewPackage) async { await performAction("unlink", package: package) }
 
-    func updateHomebrew() async {
-        await performBrewAction(["update"], refreshAfter: true)
-    }
-
     func cleanup() async {
         await performBrewAction(["cleanup", "--prune=all"])
     }

--- a/Brewy/Models/BrewService+Updates.swift
+++ b/Brewy/Models/BrewService+Updates.swift
@@ -1,0 +1,70 @@
+import Foundation
+import OSLog
+
+private let logger = Logger(subsystem: "io.linnane.brewy", category: "BrewService+Updates")
+
+// MARK: - Homebrew Update Tracking
+
+extension BrewService {
+
+    nonisolated static let lastUpdateResultURL: URL? = cacheDirectory?.appendingPathComponent("lastUpdateResult.json")
+
+    // MARK: - Run
+
+    func updateHomebrew() async {
+        guard !isPerformingAction else {
+            logger.info("updateHomebrew skipped, action already in progress")
+            return
+        }
+        isPerformingAction = true
+        actionOutput = ""
+        lastError = nil
+        defer { isPerformingAction = false }
+
+        let arguments = ["update"]
+        let result = await runBrewCommand(arguments)
+        actionOutput = result.output
+
+        if !result.success {
+            lastError = .commandFailed(command: "update", output: result.output)
+        } else {
+            let parsed = BrewUpdateParser.parse(result.output)
+            lastUpdateResult = parsed
+            saveLastUpdateResult()
+            logger.info("Update parsed: \(parsed.newFormulae.count) new formulae, \(parsed.newCasks.count) new casks")
+        }
+
+        recordAction(arguments: arguments, packageName: nil, packageSource: nil, success: result.success, output: result.output)
+        await refresh()
+    }
+
+    // MARK: - Persistence
+
+    func loadLastUpdateResult() {
+        guard let url = Self.lastUpdateResultURL else { return }
+        do {
+            let data = try Data(contentsOf: url)
+            lastUpdateResult = try JSONDecoder().decode(BrewUpdateResult.self, from: data)
+            logger.info("Loaded last update result with \(self.lastUpdateResult?.totalCount ?? 0) new packages")
+        } catch CocoaError.fileReadNoSuchFile {
+            // no prior update saved yet — normal on first launch
+        } catch {
+            logger.warning("Failed to load last update result: \(error.localizedDescription)")
+        }
+    }
+
+    private func saveLastUpdateResult() {
+        guard let url = Self.lastUpdateResultURL,
+              ProcessInfo.processInfo.environment["XCTestBundlePath"] == nil,
+              let result = lastUpdateResult else { return }
+        Task.detached(priority: .utility) {
+            do {
+                let data = try JSONEncoder().encode(result)
+                try data.write(to: url, options: .atomic)
+                logger.debug("Last update result saved")
+            } catch {
+                logger.error("Failed to save last update result: \(error.localizedDescription)")
+            }
+        }
+    }
+}

--- a/Brewy/Models/BrewService.swift
+++ b/Brewy/Models/BrewService.swift
@@ -85,6 +85,7 @@ final class BrewService {
     var tapHealthStatuses: [String: TapHealthStatus] = [:]
     var packageGroups: [PackageGroup] = []
     var actionHistory: [ActionHistoryEntry] = []
+    var lastUpdateResult: BrewUpdateResult?
 
     var tapsLoaded = false
     private var isRefreshing = false

--- a/Brewy/Models/PackageModel.swift
+++ b/Brewy/Models/PackageModel.swift
@@ -389,3 +389,71 @@ struct BrewConfig {
         )
     }
 }
+
+// MARK: - Brew Update Result
+
+struct BrewUpdateItem: Identifiable, Hashable, Codable, Sendable {
+    let name: String
+    let description: String?
+    let source: PackageSource
+
+    var id: String { "\(source.rawValue)-\(name)" }
+}
+
+struct BrewUpdateResult: Codable, Sendable {
+    let newFormulae: [BrewUpdateItem]
+    let newCasks: [BrewUpdateItem]
+    let timestamp: Date
+    let rawOutput: String
+
+    var isEmpty: Bool { newFormulae.isEmpty && newCasks.isEmpty }
+    var totalCount: Int { newFormulae.count + newCasks.count }
+}
+
+enum BrewUpdateParser {
+    private static let formulaeHeader = "new formulae"
+    private static let casksHeader = "new casks"
+
+    static func parse(_ output: String, at timestamp: Date = Date()) -> BrewUpdateResult {
+        var newFormulae: [BrewUpdateItem] = []
+        var newCasks: [BrewUpdateItem] = []
+        var currentSection: PackageSource?
+
+        for rawLine in output.split(separator: "\n", omittingEmptySubsequences: false) {
+            let line = String(rawLine)
+            if line.hasPrefix("==>") {
+                let header = line.dropFirst(3).trimmingCharacters(in: .whitespaces).lowercased()
+                switch header {
+                case Self.formulaeHeader: currentSection = .formula
+                case Self.casksHeader: currentSection = .cask
+                default: currentSection = nil
+                }
+                continue
+            }
+            guard let section = currentSection else { continue }
+            let trimmed = line.trimmingCharacters(in: .whitespaces)
+            guard !trimmed.isEmpty else { continue }
+            let item = parseItem(trimmed, source: section)
+            switch section {
+            case .formula: newFormulae.append(item)
+            case .cask: newCasks.append(item)
+            case .mas: break
+            }
+        }
+        return BrewUpdateResult(
+            newFormulae: newFormulae,
+            newCasks: newCasks,
+            timestamp: timestamp,
+            rawOutput: output
+        )
+    }
+
+    private static func parseItem(_ line: String, source: PackageSource) -> BrewUpdateItem {
+        guard let colonIndex = line.firstIndex(of: ":") else {
+            return BrewUpdateItem(name: line, description: nil, source: source)
+        }
+        let name = line[..<colonIndex].trimmingCharacters(in: .whitespaces)
+        let desc = line[line.index(after: colonIndex)...].trimmingCharacters(in: .whitespaces)
+        return BrewUpdateItem(name: name, description: desc.isEmpty ? nil : desc, source: source)
+    }
+}

--- a/Brewy/Models/PackageModel.swift
+++ b/Brewy/Models/PackageModel.swift
@@ -398,6 +398,25 @@ struct BrewUpdateItem: Identifiable, Hashable, Codable, Sendable {
     let source: PackageSource
 
     var id: String { "\(source.rawValue)-\(name)" }
+
+    /// Builds a minimal BrewPackage suitable for handing to brew install actions.
+    func asPlaceholderPackage() -> BrewPackage {
+        BrewPackage(
+            id: id,
+            name: name,
+            version: "",
+            description: description ?? "",
+            homepage: "",
+            isInstalled: false,
+            isOutdated: false,
+            installedVersion: nil,
+            latestVersion: nil,
+            source: source,
+            pinned: false,
+            installedOnRequest: false,
+            dependencies: []
+        )
+    }
 }
 
 struct BrewUpdateResult: Codable, Sendable {

--- a/Brewy/Views/ContentView.swift
+++ b/Brewy/Views/ContentView.swift
@@ -77,6 +77,7 @@ struct ContentView: View {
             brewService.loadTapHealthCache()
             brewService.loadGroups()
             brewService.loadHistory()
+            brewService.loadLastUpdateResult()
             let currentVersion = Bundle.main.object(forInfoDictionaryKey: "CFBundleShortVersionString") as? String ?? ""
             if !currentVersion.isEmpty, currentVersion != lastSeenVersion {
                 lastSeenVersion = currentVersion

--- a/Brewy/Views/MaintenanceView.swift
+++ b/Brewy/Views/MaintenanceView.swift
@@ -18,6 +18,7 @@ struct MaintenanceView: View {
             orphansSection
             cacheSection
             homebrewUpdateSection
+            whatsNewSection
         }
         .formStyle(.grouped)
         .navigationTitle("Maintenance")
@@ -166,6 +167,44 @@ struct MaintenanceView: View {
         }
     }
 
+    // MARK: - What's New in Homebrew
+
+    @ViewBuilder private var whatsNewSection: some View {
+        if let result = brewService.lastUpdateResult, !result.isEmpty {
+            Section {
+                HStack(spacing: 8) {
+                    Label {
+                        Text("New since \(Self.relativeTime(since: result.timestamp))")
+                    } icon: {
+                        Image(systemName: "sparkles")
+                            .foregroundStyle(.yellow)
+                    }
+                    .font(.headline)
+                    Spacer()
+                    Text("\(result.totalCount)")
+                        .foregroundStyle(.secondary)
+                        .monospacedDigit()
+                }
+
+                if !result.newFormulae.isEmpty {
+                    NewItemsList(title: "New Formulae", items: result.newFormulae)
+                }
+                if !result.newCasks.isEmpty {
+                    NewItemsList(title: "New Casks", items: result.newCasks)
+                }
+            } footer: {
+                Text("Newly available packages from the last brew update.")
+                    .frame(maxWidth: .infinity, alignment: .leading)
+            }
+        }
+    }
+
+    private static func relativeTime(since date: Date) -> String {
+        let formatter = RelativeDateTimeFormatter()
+        formatter.unitsStyle = .full
+        return formatter.localizedString(for: date, relativeTo: Date())
+    }
+
     // MARK: - Helpers
 
     private func loadCacheSize() async {
@@ -211,5 +250,125 @@ struct MaintenanceView: View {
 
     private func formattedSize(_ bytes: Int64) -> String {
         Self.sizeFormatter.string(fromByteCount: bytes)
+    }
+}
+
+// MARK: - New Items List
+
+private struct NewItemsList: View {
+    let title: String
+    let items: [BrewUpdateItem]
+    @State private var isExpanded = false
+
+    private static let collapsedLimit = 8
+
+    private var visibleItems: [BrewUpdateItem] {
+        if isExpanded || items.count <= Self.collapsedLimit { return items }
+        return Array(items.prefix(Self.collapsedLimit))
+    }
+
+    var body: some View {
+        VStack(alignment: .leading, spacing: 6) {
+            HStack {
+                Text(title)
+                    .font(.subheadline)
+                    .foregroundStyle(.secondary)
+                Spacer()
+                Text("\(items.count)")
+                    .font(.caption)
+                    .foregroundStyle(.tertiary)
+                    .monospacedDigit()
+            }
+
+            ForEach(visibleItems) { item in
+                NewItemRow(item: item)
+            }
+
+            if items.count > Self.collapsedLimit {
+                Button {
+                    withAnimation { isExpanded.toggle() }
+                } label: {
+                    Text(isExpanded ? "Show fewer" : "Show all \(items.count)")
+                        .font(.caption)
+                }
+                .buttonStyle(.borderless)
+            }
+        }
+    }
+}
+
+// MARK: - New Item Row
+
+private struct NewItemRow: View {
+    @Environment(BrewService.self)
+    private var brewService
+    let item: BrewUpdateItem
+
+    private var isInstalled: Bool {
+        brewService.installedNames.contains(item.name)
+    }
+
+    var body: some View {
+        HStack(spacing: 8) {
+            VStack(alignment: .leading, spacing: 2) {
+                HStack(spacing: 6) {
+                    Text(item.name)
+                        .font(.body)
+                    sourceBadge
+                }
+                if let desc = item.description {
+                    Text(desc)
+                        .font(.caption)
+                        .foregroundStyle(.secondary)
+                        .lineLimit(2)
+                }
+            }
+            Spacer()
+            if isInstalled {
+                Text("Installed")
+                    .font(.caption)
+                    .foregroundStyle(.secondary)
+            } else {
+                Button {
+                    Task { await install() }
+                } label: {
+                    Label("Install", systemImage: "arrow.down.circle.fill")
+                        .font(.caption)
+                }
+                .buttonStyle(.bordered)
+                .controlSize(.small)
+                .disabled(brewService.isPerformingAction)
+            }
+        }
+        .padding(.vertical, 2)
+    }
+
+    @ViewBuilder private var sourceBadge: some View {
+        let isCask = item.source == .cask
+        Text(isCask ? "cask" : "formula")
+            .font(.system(size: 9, weight: .medium))
+            .foregroundStyle(isCask ? .purple : .green)
+            .padding(.horizontal, 5)
+            .padding(.vertical, 1)
+            .background((isCask ? Color.purple : Color.green).opacity(0.12), in: .capsule)
+    }
+
+    private func install() async {
+        let placeholder = BrewPackage(
+            id: item.id,
+            name: item.name,
+            version: "",
+            description: item.description ?? "",
+            homepage: "",
+            isInstalled: false,
+            isOutdated: false,
+            installedVersion: nil,
+            latestVersion: nil,
+            source: item.source,
+            pinned: false,
+            installedOnRequest: false,
+            dependencies: []
+        )
+        await brewService.install(package: placeholder)
     }
 }

--- a/Brewy/Views/MaintenanceView.swift
+++ b/Brewy/Views/MaintenanceView.swift
@@ -173,19 +173,13 @@ struct MaintenanceView: View {
         if let result = brewService.lastUpdateResult, !result.isEmpty {
             Section {
                 HStack(spacing: 8) {
-                    Label {
-                        Text("New since \(Self.relativeTime(since: result.timestamp))")
-                    } icon: {
-                        Image(systemName: "sparkles")
-                            .foregroundStyle(.yellow)
-                    }
-                    .font(.headline)
+                    Label("New since \(result.timestamp.formatted(.relative(presentation: .named)))", systemImage: "sparkles")
+                        .font(.headline)
                     Spacer()
                     Text("\(result.totalCount)")
                         .foregroundStyle(.secondary)
                         .monospacedDigit()
                 }
-
                 if !result.newFormulae.isEmpty {
                     NewItemsList(title: "New Formulae", items: result.newFormulae)
                 }
@@ -197,12 +191,6 @@ struct MaintenanceView: View {
                     .frame(maxWidth: .infinity, alignment: .leading)
             }
         }
-    }
-
-    private static func relativeTime(since date: Date) -> String {
-        let formatter = RelativeDateTimeFormatter()
-        formatter.unitsStyle = .full
-        return formatter.localizedString(for: date, relativeTo: Date())
     }
 
     // MARK: - Helpers
@@ -258,14 +246,6 @@ struct MaintenanceView: View {
 private struct NewItemsList: View {
     let title: String
     let items: [BrewUpdateItem]
-    @State private var isExpanded = false
-
-    private static let collapsedLimit = 8
-
-    private var visibleItems: [BrewUpdateItem] {
-        if isExpanded || items.count <= Self.collapsedLimit { return items }
-        return Array(items.prefix(Self.collapsedLimit))
-    }
 
     var body: some View {
         VStack(alignment: .leading, spacing: 6) {
@@ -279,19 +259,8 @@ private struct NewItemsList: View {
                     .foregroundStyle(.tertiary)
                     .monospacedDigit()
             }
-
-            ForEach(visibleItems) { item in
+            ForEach(items) { item in
                 NewItemRow(item: item)
-            }
-
-            if items.count > Self.collapsedLimit {
-                Button {
-                    withAnimation { isExpanded.toggle() }
-                } label: {
-                    Text(isExpanded ? "Show fewer" : "Show all \(items.count)")
-                        .font(.caption)
-                }
-                .buttonStyle(.borderless)
             }
         }
     }
@@ -304,16 +273,11 @@ private struct NewItemRow: View {
     private var brewService
     let item: BrewUpdateItem
 
-    private var isInstalled: Bool {
-        brewService.installedNames.contains(item.name)
-    }
-
     var body: some View {
         HStack(spacing: 8) {
             VStack(alignment: .leading, spacing: 2) {
                 HStack(spacing: 6) {
-                    Text(item.name)
-                        .font(.body)
+                    Text(item.name).font(.body)
                     sourceBadge
                 }
                 if let desc = item.description {
@@ -324,13 +288,13 @@ private struct NewItemRow: View {
                 }
             }
             Spacer()
-            if isInstalled {
+            if brewService.installedNames.contains(item.name) {
                 Text("Installed")
                     .font(.caption)
                     .foregroundStyle(.secondary)
             } else {
                 Button {
-                    Task { await install() }
+                    Task { await brewService.install(package: item.asPlaceholderPackage()) }
                 } label: {
                     Label("Install", systemImage: "arrow.down.circle.fill")
                         .font(.caption)
@@ -351,24 +315,5 @@ private struct NewItemRow: View {
             .padding(.horizontal, 5)
             .padding(.vertical, 1)
             .background((isCask ? Color.purple : Color.green).opacity(0.12), in: .capsule)
-    }
-
-    private func install() async {
-        let placeholder = BrewPackage(
-            id: item.id,
-            name: item.name,
-            version: "",
-            description: item.description ?? "",
-            homepage: "",
-            isInstalled: false,
-            isOutdated: false,
-            installedVersion: nil,
-            latestVersion: nil,
-            source: item.source,
-            pinned: false,
-            installedOnRequest: false,
-            dependencies: []
-        )
-        await brewService.install(package: placeholder)
     }
 }

--- a/BrewyTests/BrewServiceDetailTests.swift
+++ b/BrewyTests/BrewServiceDetailTests.swift
@@ -65,6 +65,72 @@ struct MaintenanceTests {
         #expect(mock.executedCommands.contains(["update"]))
     }
 
+    @Test("updateHomebrew parses new formulae and casks into lastUpdateResult")
+    func updateHomebrewParsesNewPackages() async {
+        let mock = MockCommandRunner()
+        let (service, _) = makeService(mock: mock)
+        setupRefreshMock(mock)
+        let updateOutput = """
+        Updated Homebrew from abc123 to def456.
+        ==> New Formulae
+        new-tool: A new formula
+        another-tool: Another formula
+        ==> New Casks
+        new-app: A new cask
+        """
+        mock.setResult(for: ["update"], output: updateOutput)
+
+        await service.updateHomebrew()
+
+        let result = service.lastUpdateResult
+        #expect(result != nil)
+        #expect(result?.newFormulae.count == 2)
+        #expect(result?.newFormulae.first?.name == "new-tool")
+        #expect(result?.newCasks.count == 1)
+        #expect(result?.newCasks.first?.name == "new-app")
+        #expect(result?.totalCount == 3)
+        #expect(service.lastError == nil)
+    }
+
+    @Test("updateHomebrew records action history on success")
+    func updateHomebrewRecordsHistory() async {
+        let mock = MockCommandRunner()
+        let (service, _) = makeService(mock: mock)
+        setupRefreshMock(mock)
+        mock.setResult(for: ["update"], output: "Already up-to-date.")
+
+        await service.updateHomebrew()
+
+        #expect(service.actionHistory.contains { $0.arguments == ["update"] })
+        #expect(service.actionHistory.first?.status == .success)
+    }
+
+    @Test("updateHomebrew does not store result on failure")
+    func updateHomebrewFailure() async {
+        let mock = MockCommandRunner()
+        let (service, _) = makeService(mock: mock)
+        setupRefreshMock(mock)
+        mock.setResult(for: ["update"], output: "fatal: network error", success: false)
+
+        await service.updateHomebrew()
+
+        #expect(service.lastUpdateResult == nil)
+        #expect(service.actionHistory.first?.status == .failure)
+    }
+
+    @Test("updateHomebrew is reentrancy-guarded by isPerformingAction")
+    func updateHomebrewReentrancyGuard() async {
+        let mock = MockCommandRunner()
+        let (service, _) = makeService(mock: mock)
+        setupRefreshMock(mock)
+        mock.setResult(for: ["update"], output: "Already up-to-date.")
+        service.isPerformingAction = true
+
+        await service.updateHomebrew()
+
+        #expect(!mock.executedCommands.contains(["update"]))
+    }
+
     @Test("config parses brew config output")
     func configParsesOutput() async {
         let mock = MockCommandRunner()

--- a/BrewyTests/BrewUpdateParserTests.swift
+++ b/BrewyTests/BrewUpdateParserTests.swift
@@ -155,6 +155,23 @@ struct BrewUpdateParserTests {
         #expect(!result.isEmpty)
     }
 
+    @Test("asPlaceholderPackage produces a BrewPackage matching the item")
+    func asPlaceholderPackageMatchesItem() {
+        let formulaItem = BrewUpdateItem(name: "wget", description: "File retriever", source: .formula)
+        let pkg = formulaItem.asPlaceholderPackage()
+        #expect(pkg.name == "wget")
+        #expect(pkg.source == .formula)
+        #expect(pkg.description == "File retriever")
+        #expect(!pkg.isInstalled)
+        #expect(!pkg.isOutdated)
+        #expect(pkg.id == formulaItem.id)
+
+        let caskWithoutDesc = BrewUpdateItem(name: "font-foo", description: nil, source: .cask)
+        let caskPkg = caskWithoutDesc.asPlaceholderPackage()
+        #expect(caskPkg.source == .cask)
+        #expect(caskPkg.description.isEmpty)
+    }
+
     @Test("Codable round-trip preserves all fields")
     func codableRoundTrip() throws {
         let original = BrewUpdateResult(

--- a/BrewyTests/BrewUpdateParserTests.swift
+++ b/BrewyTests/BrewUpdateParserTests.swift
@@ -1,0 +1,174 @@
+@testable import Brewy
+import Foundation
+import Testing
+
+// MARK: - BrewUpdateParser Tests
+
+@Suite("BrewUpdateParser")
+struct BrewUpdateParserTests {
+
+    @Test("Parses a typical brew update output with new formulae and casks")
+    func parsesTypicalOutput() {
+        let output = """
+        Updated Homebrew from abc123 to def456.
+        Updated 2 taps (homebrew/core, homebrew/cask).
+        ==> New Formulae
+        copilot-language-server: Language Server Protocol server for GitHub Copilot
+        graalvm: JDK distribution with Graal compiler and Native Image
+        ==> New Casks
+        claude-code@latest: Terminal-based AI coding assistant
+        font-ioskeley-mono
+        wallspace: Live wallpaper app
+        """
+        let result = BrewUpdateParser.parse(output)
+
+        #expect(result.newFormulae.count == 2)
+        #expect(result.newFormulae[0].name == "copilot-language-server")
+        #expect(result.newFormulae[0].description == "Language Server Protocol server for GitHub Copilot")
+        #expect(result.newFormulae[0].source == .formula)
+        #expect(result.newFormulae[1].name == "graalvm")
+
+        #expect(result.newCasks.count == 3)
+        #expect(result.newCasks[0].name == "claude-code@latest")
+        #expect(result.newCasks[0].description == "Terminal-based AI coding assistant")
+        #expect(result.newCasks[0].source == .cask)
+    }
+
+    @Test("Handles items without a description")
+    func itemWithoutDescription() {
+        let output = """
+        ==> New Casks
+        font-ioskeley-mono
+        """
+        let result = BrewUpdateParser.parse(output)
+
+        #expect(result.newCasks.count == 1)
+        #expect(result.newCasks[0].name == "font-ioskeley-mono")
+        #expect(result.newCasks[0].description == nil)
+    }
+
+    @Test("Preserves colons inside descriptions")
+    func descriptionWithColon() {
+        let output = """
+        ==> New Formulae
+        rvvm: RISC-V Virtual Machine: x86 host edition
+        """
+        let result = BrewUpdateParser.parse(output)
+
+        #expect(result.newFormulae.count == 1)
+        #expect(result.newFormulae[0].name == "rvvm")
+        #expect(result.newFormulae[0].description == "RISC-V Virtual Machine: x86 host edition")
+    }
+
+    @Test("Empty output yields empty result")
+    func emptyOutput() {
+        let result = BrewUpdateParser.parse("")
+        #expect(result.newFormulae.isEmpty)
+        #expect(result.newCasks.isEmpty)
+        #expect(result.isEmpty)
+        #expect(result.totalCount == 0)
+    }
+
+    @Test("Already up-to-date output yields empty result")
+    func alreadyUpToDate() {
+        let output = """
+        Already up-to-date.
+        """
+        let result = BrewUpdateParser.parse(output)
+        #expect(result.isEmpty)
+    }
+
+    @Test("Ignores sections that are not New Formulae or New Casks")
+    func skipsNonTargetSections() {
+        let output = """
+        ==> Outdated Formulae
+        wget
+        curl
+        ==> New Formulae
+        a-new-thing: A new thing
+        ==> Updated Casks
+        firefox
+        ==> New Casks
+        another-thing: Another thing
+        """
+        let result = BrewUpdateParser.parse(output)
+
+        #expect(result.newFormulae.count == 1)
+        #expect(result.newFormulae[0].name == "a-new-thing")
+        #expect(result.newCasks.count == 1)
+        #expect(result.newCasks[0].name == "another-thing")
+    }
+
+    @Test("Skips blank lines inside sections")
+    func skipsBlankLines() {
+        let output = """
+        ==> New Formulae
+
+        foo: foo desc
+
+        bar: bar desc
+        """
+        let result = BrewUpdateParser.parse(output)
+
+        #expect(result.newFormulae.count == 2)
+        #expect(result.newFormulae[0].name == "foo")
+        #expect(result.newFormulae[1].name == "bar")
+    }
+
+    @Test("Ignores lines before the first section header")
+    func ignoresPreHeaderLines() {
+        let output = """
+        Updating Homebrew...
+        Updated 1 tap.
+        ==> New Formulae
+        thing: Cool thing
+        """
+        let result = BrewUpdateParser.parse(output)
+        #expect(result.newFormulae.count == 1)
+    }
+
+    @Test("Header is case-insensitive")
+    func headerCaseInsensitive() {
+        let output = """
+        ==> NEW FORMULAE
+        foo: Foo
+        ==> new casks
+        bar: Bar
+        """
+        let result = BrewUpdateParser.parse(output)
+        #expect(result.newFormulae.count == 1)
+        #expect(result.newCasks.count == 1)
+    }
+
+    @Test("totalCount reflects the sum of new formulae and casks")
+    func totalCount() {
+        let output = """
+        ==> New Formulae
+        a: A
+        b: B
+        c: C
+        ==> New Casks
+        d: D
+        """
+        let result = BrewUpdateParser.parse(output)
+        #expect(result.totalCount == 4)
+        #expect(!result.isEmpty)
+    }
+
+    @Test("Codable round-trip preserves all fields")
+    func codableRoundTrip() throws {
+        let original = BrewUpdateResult(
+            newFormulae: [BrewUpdateItem(name: "foo", description: "Foo lib", source: .formula)],
+            newCasks: [BrewUpdateItem(name: "bar", description: nil, source: .cask)],
+            timestamp: Date(timeIntervalSince1970: 1_700_000_000),
+            rawOutput: "==> New Formulae\nfoo: Foo lib\n==> New Casks\nbar"
+        )
+        let data = try JSONEncoder().encode(original)
+        let decoded = try JSONDecoder().decode(BrewUpdateResult.self, from: data)
+        #expect(decoded.newFormulae.count == 1)
+        #expect(decoded.newFormulae[0].name == "foo")
+        #expect(decoded.newCasks.count == 1)
+        #expect(decoded.newCasks[0].description == nil)
+        #expect(decoded.timestamp == original.timestamp)
+    }
+}

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -27,8 +27,9 @@ Brewy/
 │   │   ├── BrewService+History.swift       # Action history recording, persistence, retry, outdated merge helper
 │   │   ├── BrewService+Groups.swift        # User-created package group CRUD and persistence
 │   │   ├── BrewService+DryRun.swift        # Dry-run previews for autoremove and cleanup
+│   │   ├── BrewService+Updates.swift       # `brew update` orchestration, parses + persists new formulae/casks
 │   │   ├── BrewJSONTypes.swift             # Brew JSON v2 Codable response types (extracted from PackageModel)
-│   │   ├── PackageModel.swift              # Data models: BrewPackage, BrewTap, SidebarCategory, PackageGroup, ActionHistoryEntry, BrewServiceItem, BrewConfig, appcast parser
+│   │   ├── PackageModel.swift              # Data models: BrewPackage, BrewTap, SidebarCategory, PackageGroup, ActionHistoryEntry, BrewServiceItem, BrewConfig, BrewUpdateResult/Parser, appcast parser
 │   │   ├── CommandRunner.swift             # Process execution with timeout, cancellation, thread-safe pipe reading, CommandRunning protocol
 │   │   ├── MasService.swift                # Mac App Store integration via mas CLI (list, outdated, install)
 │   │   ├── ServicesService.swift           # Homebrew services management (fetch, start, stop, restart, cleanup)
@@ -60,7 +61,8 @@ Brewy/
 │   ├── GroupsAndMasTests.swift             # Package groups, Mac App Store parsing
 │   ├── HistoryTests.swift                  # Action history recording and retry
 │   ├── ServicesTests.swift                 # Services parsing and integration
-│   └── JSONAndServicesTests.swift          # JSON parsing edge cases and services
+│   ├── JSONAndServicesTests.swift          # JSON parsing edge cases and services
+│   └── BrewUpdateParserTests.swift         # `brew update` output parsing
 ├── BrewyUITests/
 │   └── SidebarNavigationUITests.swift      # UI tests for sidebar navigation
 ├── Brewy.xcodeproj/
@@ -107,12 +109,15 @@ The central service object that holds all app state and orchestrates brew CLI ca
 - `fetchPackageDetail(for:)` — cached single-package detail fetch
 - `config()` — parses `brew config` output
 - `info(for:)` — cached `brew info` output
+- `updateHomebrew()` — runs `brew update`, parses new formulae/casks into `lastUpdateResult`, persists, then refreshes
+- `loadLastUpdateResult()` — restores last `brew update` snapshot from disk on app launch
 
 **Caching:** JSON serialization to `~/Library/Application Support/Brewy/`:
 - `packageCache.json` — packages (formulae, casks, mas apps, outdated, taps). Tagged with `cacheSchemaVersion`; a version mismatch or decode failure deletes the file so the app doesn't silently launch into empty state after a schema change.
 - `tapHealthCache.json` — tap health statuses with 24-hour TTL
 - `packageGroups.json` — user-created package groups
 - `actionHistory.json` — action history (max 100 entries)
+- `lastUpdateResult.json` — last `brew update` parse result with new formulae/casks and timestamp
 
 ### CommandRunner
 
@@ -214,14 +219,15 @@ mas install ID                               # Install Mac App Store app
 - Tap health monitoring: detects archived, moved, and missing tap repositories via GitHub API
 - Tap migration: one-click migrate to a tap's new URL when it has moved
 - "What's New" view parsing Sparkle appcast XML
+- "New in Homebrew" section in Maintenance: parses `brew update` output, lists newly available formulae and casks since the last run with click-to-install actions
 - Sparkle auto-updates with EdDSA signing
 
 ## Testing
 
 - Framework: Swift Testing (`@Suite`, `@Test` macros)
-- ~200 test cases across 11 test files (10 unit test files + 1 test helpers)
+- ~210 test cases across 12 test files (11 unit test files + 1 test helpers)
 - `MockCommandRunner` and shared test helpers in `TestHelpers.swift`
-- Tests cover: derived state, reverse deps, leaves, pinned filtering, category routing, outdated merge logic, all JSON parsing, model equality/hashing, config parsing, appcast XML parsing, tap health status, package groups, Mac App Store parsing, action history, services, dry-run, retry, error handling, async refresh/search/upgrade flows, real-subprocess CommandRunner behavior (stdout/stderr drain, timeout, missing executable)
+- Tests cover: derived state, reverse deps, leaves, pinned filtering, category routing, outdated merge logic, all JSON parsing, model equality/hashing, config parsing, appcast XML parsing, tap health status, package groups, Mac App Store parsing, action history, services, dry-run, retry, error handling, `brew update` output parsing, async refresh/search/upgrade flows, real-subprocess CommandRunner behavior (stdout/stderr drain, timeout, missing executable)
 - UI tests: sidebar navigation
 - CI runs both Thread Sanitizer and Address Sanitizer
 - Code coverage reported via `xccov`


### PR DESCRIPTION
## Summary

Implements [#113](https://github.com/starhaven-io/Brewy/issues/113): capture and surface the "New Formulae" / "New Casks" sections from `brew update` so users can see what newly became available since their last update.

- New `BrewUpdateParser` + `BrewUpdateResult` types in `PackageModel.swift`. Tolerates colons in descriptions, items without descriptions (font casks), and ignores unrelated `==> Outdated/Updated` sections.
- New `BrewService+Updates.swift` reworks `updateHomebrew()` to capture stdout, parse it into `lastUpdateResult`, persist to `lastUpdateResult.json`, then refresh. Restored from disk on launch via `ContentView.task`.
- `MaintenanceView` adds a "New since…" section under Update Homebrew listing each new package with description and a per-row Install button.
- 12 parser tests cover typical output, missing descriptions, colon-in-description, empty output, non-target sections, blank lines, case-insensitive headers, the `BrewUpdateItem.asPlaceholderPackage()` helper, and Codable round-trip. 4 additional service tests cover `updateHomebrew` parsing, history recording, failure handling, and reentrancy.