### PR TITLE
test: make app deterministic under tests

### DIFF
--- a/Brewy/Views/ContentView.swift
+++ b/Brewy/Views/ContentView.swift
@@ -78,9 +78,11 @@ struct ContentView: View {
             brewService.loadGroups()
             brewService.loadHistory()
             brewService.loadLastUpdateResult()
-            // Skip non-deterministic startup work under UI tests: real `brew` subprocesses
+            // Skip non-deterministic startup work under tests: real `brew` subprocesses
             // hang the runner, and the WhatsNew sheet's modal AX hierarchy hides the sidebar.
-            guard ProcessInfo.processInfo.environment["BREWY_UI_TESTING"] != "1" else { return }
+            // XCTestBundlePath is set by unit-test hosts; BREWY_UI_TESTING is set by UI-test setUp.
+            let env = ProcessInfo.processInfo.environment
+            guard env["XCTestBundlePath"] == nil, env["BREWY_UI_TESTING"] != "1" else { return }
             let currentVersion = Bundle.main.object(forInfoDictionaryKey: "CFBundleShortVersionString") as? String ?? ""
             if !currentVersion.isEmpty, currentVersion != lastSeenVersion {
                 lastSeenVersion = currentVersion

--- a/Brewy/Views/ContentView.swift
+++ b/Brewy/Views/ContentView.swift
@@ -78,6 +78,9 @@ struct ContentView: View {
             brewService.loadGroups()
             brewService.loadHistory()
             brewService.loadLastUpdateResult()
+            // Skip non-deterministic startup work under UI tests: real `brew` subprocesses
+            // hang the runner, and the WhatsNew sheet's modal AX hierarchy hides the sidebar.
+            guard ProcessInfo.processInfo.environment["BREWY_UI_TESTING"] != "1" else { return }
             let currentVersion = Bundle.main.object(forInfoDictionaryKey: "CFBundleShortVersionString") as? String ?? ""
             if !currentVersion.isEmpty, currentVersion != lastSeenVersion {
                 lastSeenVersion = currentVersion

--- a/BrewyUITests/SidebarNavigationUITests.swift
+++ b/BrewyUITests/SidebarNavigationUITests.swift
@@ -12,6 +12,7 @@ final class SidebarNavigationUITests: XCTestCase {
         continueAfterFailure = false
         app = XCUIApplication()
         app.launchArguments += ["-NSConstraintBasedLayoutVisualizeMutuallyExclusiveConstraints", "YES"]
+        app.launchEnvironment["BREWY_UI_TESTING"] = "1"
         app.launch()
     }
 


### PR DESCRIPTION
## Summary

CI on `main` started failing after GitHub flipped the default Xcode on the `macos-26-arm64` runner image from 26.2 to 26.4.1 (image `20260520.0098.1`, released 2026-05-20). Two failure modes, same root cause:

- **UI tests timeout at ~137s** with `Failed to get matching snapshots: Timed out while evaluating UI query` ([failing main run](https://github.com/starhaven-io/Brewy/actions/runs/26253987896)).
- **Unit-test host hangs** with `The test runner hung before establishing connection` (seen on this PR's first push before the fix-up).

`ContentView.task` runs `brewService.refresh()` and may present the WhatsNew sheet on every launch — including under tests. On the new image:

- `brew info` subprocesses can hang on Actions runners (we already skip `CommandRunner Process Execution` with "Pipe reads hang on Actions runner images"). This hung the unit-test host past xcodebuild's patience.
- The WhatsNew sheet's modal AX hierarchy covers the sidebar that UI tests query.
- Xcode 26.4.1's AX subsystem is also slower at capturing debug snapshots when an element isn't found (~29s per attempt), so each `waitForExistence(timeout: 30)` retries 4 times before failing at 137s.

Gate the startup work behind two env vars in `ContentView.task`: `XCTestBundlePath` (set by unit-test hosts) and `BREWY_UI_TESTING` (set by UI-test `setUp`). The app then renders a quiet, fully-rendered sidebar with no in-flight subprocesses or sheets — AX queries return immediately, and the unit-test runner connects without waiting on a hung subprocess. Independent of which Xcode version the runner picks.