### PR TITLE
chore(deps): bump Sparkle from 2.9.1 to 2.9.2

### DIFF
--- a/Brewy.xcodeproj/project.xcworkspace/xcshareddata/swiftpm/Package.resolved
+++ b/Brewy.xcodeproj/project.xcworkspace/xcshareddata/swiftpm/Package.resolved
@@ -6,8 +6,8 @@
       "kind" : "remoteSourceControl",
       "location" : "https://github.com/sparkle-project/Sparkle",
       "state" : {
-        "revision" : "066e75a8b3e99962685d6a90cdd5293ebffd9261",
-        "version" : "2.9.1"
+        "revision" : "6276ba2b404829d139c45ff98427cf90e2efc59b",
+        "version" : "2.9.2"
       }
     }
   ],


### PR DESCRIPTION
## Summary
- Bump Sparkle from 2.9.1 to 2.9.2 in `Package.resolved`.
- Release notes: https://github.com/sparkle-project/Sparkle/releases/tag/2.9.2