### PR TITLE
fix: correctness and performance fixes from code review

### DIFF
--- a/Brewy/Models/BrewService+Actions.swift
+++ b/Brewy/Models/BrewService+Actions.swift
@@ -132,7 +132,10 @@ extension BrewService {
         if let cached = infoCache[package.id] { return cached }
         let command = package.isCask ? ["info", "--cask", package.name] : ["info", package.name]
         let result = await runBrewCommand(command)
-        infoCache[package.id] = result.output
+        // Don't cache failures: a transient error would otherwise stick until the version changes.
+        if result.success {
+            infoCache[package.id] = result.output
+        }
         return result.output
     }
 }

--- a/Brewy/Models/BrewService.swift
+++ b/Brewy/Models/BrewService.swift
@@ -276,12 +276,14 @@ final class BrewService {
         async let outdated = fetchOutdatedPackages()
         async let masApps = fetchInstalledMasApps()
         async let masOutdated = fetchOutdatedMasApps()
+        async let taps = fetchTaps()
 
         let fetchedFormulae = await formulae
         let fetchedCasks = await casks
         let fetchedOutdated = await outdated
         let fetchedMasApps = await masApps
         let fetchedMasOutdated = await masOutdated
+        let fetchedTaps = await taps
         let allOutdated = fetchedOutdated + fetchedMasOutdated
         let outdatedByID = Dictionary(allOutdated.map { ($0.id, $0) }, uniquingKeysWith: { _, last in last })
 
@@ -298,7 +300,7 @@ final class BrewService {
             infoCache.removeValue(forKey: id)
         }
 
-        installedTaps = await fetchTaps()
+        installedTaps = fetchedTaps
         tapsLoaded = true
 
         let masCount = fetchedMasApps.count
@@ -320,12 +322,12 @@ final class BrewService {
         }
 
         isLoading = true
+        defer { isLoading = false }
         lastError = nil
 
         let results = await performSearch(query: query)
         guard !Task.isCancelled else { return }
         searchResults = results
-        isLoading = false
     }
 
     func upgradeSelected(packages: [BrewPackage]) async {

--- a/Brewy/Models/CommandRunner.swift
+++ b/Brewy/Models/CommandRunner.swift
@@ -190,9 +190,11 @@ enum CommandRunner {
         }
 
         let (stdoutData, stderrData) = drainPipesInParallel(stdout: stdoutPipe, stderr: stderrPipe)
-        let timedOut = scheduleTimeout(for: process, after: timeout, commandDescription: commandDescription)
+        let (timedOut, timeoutWork) = scheduleTimeout(for: process, after: timeout, commandDescription: commandDescription)
 
         process.waitUntilExit()
+        // Process finished; cancel the pending timeout so it can't fire later.
+        timeoutWork.cancel()
         let out = stdoutData.wait()
         let err = stderrData.wait()
 
@@ -222,7 +224,7 @@ enum CommandRunner {
         for process: Process,
         after timeout: Duration,
         commandDescription: String
-    ) -> LockedFlag {
+    ) -> (flag: LockedFlag, work: DispatchWorkItem) {
         let timedOut = LockedFlag()
         let timeoutWork = DispatchWorkItem { [weak process] in
             guard let process, process.isRunning else { return }
@@ -241,7 +243,7 @@ enum CommandRunner {
             deadline: .now() + dispatchInterval(from: timeout),
             execute: timeoutWork
         )
-        return timedOut
+        return (timedOut, timeoutWork)
     }
 }
 

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -255,7 +255,7 @@ Common types: `feat`, `fix`, `refactor`, `docs`, `ci`, `chore`
 
 All commits must:
 - Use `git commit -s` for DCO sign-off
-- Include a `Co-Authored-By: Claude Opus 4.7 (1M context) <noreply@anthropic.com>` trailer when authored with Claude (the local pre-commit hook checks for this)
+- Include a `Co-Authored-By: Claude Opus 4.8 (1M context) <noreply@anthropic.com>` trailer when authored with Claude (the local pre-commit hook checks for this)
 
 PRs are squash-merged with the PR number appended, e.g. `feat: add test suite with CI, sanitizers, and code coverage (#38)`.
 


### PR DESCRIPTION
## Summary

Small, independent correctness/performance fixes surfaced while reviewing the codebase:

- **`search()` loading state** — reset `isLoading` via `defer` so a cancelled search can't leave the loading spinner stuck on.
- **`info(for:)` caching** — only cache `brew info` output on success, so a transient failure doesn't persist as the package's info until its version changes.
- **`refresh()` taps** — fetch taps concurrently with the other refresh queries instead of serially after them.
- **`CommandRunner` timeout** — cancel the pending timeout work item once a process exits normally so it doesn't linger until the deadline fires.

Also bumps the documented `Co-Authored-By` trailer to Opus 4.8.