### PR TITLE
chore: add tracked DCO commit-msg hook

### DIFF
--- a/.githooks/commit-msg
+++ b/.githooks/commit-msg
@@ -1,0 +1,14 @@
+#!/bin/sh
+# Enforce DCO sign-off on every local commit.
+# Commit messages must carry a "Signed-off-by:" trailer — add one with `git commit -s`.
+#
+# Enable this hook once per clone with: just install-hooks
+# (sets core.hooksPath to this directory).
+
+msg_file="$1"
+
+if ! grep -qE '^Signed-off-by: .+ <.+@.+>' "$msg_file"; then
+    echo "commit-msg hook: missing DCO sign-off." >&2
+    echo "  Re-run with 'git commit -s' to add a Signed-off-by trailer." >&2
+    exit 1
+fi

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -254,8 +254,8 @@ Conventional Commits format: `type(scope): description`
 Common types: `feat`, `fix`, `refactor`, `docs`, `ci`, `chore`
 
 All commits must:
-- Use `git commit -s` for DCO sign-off
-- Include a `Co-Authored-By: Claude Opus 4.8 (1M context) <noreply@anthropic.com>` trailer when authored with Claude (the local pre-commit hook checks for this)
+- Use `git commit -s` for DCO sign-off (enforced by the `.githooks/commit-msg` hook — run `just install-hooks` once per clone to enable it)
+- Include a `Co-Authored-By: Claude Opus 4.8 (1M context) <noreply@anthropic.com>` trailer when authored with Claude
 
 PRs are squash-merged with the PR number appended, e.g. `feat: add test suite with CI, sanitizers, and code coverage (#38)`.
 

--- a/justfile
+++ b/justfile
@@ -19,6 +19,12 @@ clean:
         -project Brewy.xcodeproj \
         -scheme Brewy
 
+# Setup
+
+# Install git hooks (enables DCO sign-off enforcement via .githooks)
+install-hooks:
+    git config core.hooksPath .githooks
+
 # Test
 
 # Run unit tests (skips UI tests that require code signing locally)


### PR DESCRIPTION
## Summary

Restores DCO sign-off enforcement, which broke when the repo moved and its absolute `core.hooksPath` went stale (the previous hook script lived outside version control and was lost).

- Adds `.githooks/commit-msg` — rejects local commits lacking a `Signed-off-by` trailer.
- Adds a `just install-hooks` recipe that sets `core.hooksPath=.githooks` (relative, so it survives future repo moves).
- Updates CLAUDE.md: the sign-off bullet now points at the hook + install step, and drops the inaccurate claim that the hook checks the `Co-Authored-By` trailer (it checks sign-off; the trailer stays a convention since it can't be enforced for non-Claude commits).