### PR TITLE
feat: add dependency tree and first-pass review fixes

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -29,8 +29,6 @@ jobs:
       artifact_name: "Brewy-${{ steps.version.outputs.tag }}.zip"
     permissions:
       contents: write # required to create tag
-      attestations: write # required to generate build provenance attestations
-      id-token: write # required to generate build provenance attestations
     env:
       TEMPORARY_CERTIFICATE_FILE: "brewy_developer_id_certificate.p12"
       TEMPORARY_KEYCHAIN_FILE: "brewy_signing.keychain-db"
@@ -69,7 +67,11 @@ jobs:
 
       - name: Create and unlock temporary macOS keychain
         run: |
+          # Disable xtrace for this step: the default `bash -xeuo` would otherwise trace the
+          # runtime-generated keychain password (not a registered secret, so unmasked) into the log.
+          set +x
           TEMPORARY_KEYCHAIN_PASSWORD="$(openssl rand -base64 20)"
+          echo "::add-mask::${TEMPORARY_KEYCHAIN_PASSWORD}"
           TEMPORARY_KEYCHAIN_PATH="${RUNNER_TEMP}/${TEMPORARY_KEYCHAIN_FILE}"
           security create-keychain -p "${TEMPORARY_KEYCHAIN_PASSWORD}" "${TEMPORARY_KEYCHAIN_PATH}"
           security set-keychain-settings -lut 21600 "${TEMPORARY_KEYCHAIN_PATH}"
@@ -141,11 +143,6 @@ jobs:
             "${RUNNER_TEMP}/export/Brewy.app" \
             "${RUNNER_TEMP}/Brewy-${TAG}.zip"
 
-      - name: Generate build provenance
-        uses: actions/attest@59d89421af93a897026c735860bf21b6eb4f7b26 # v4.1.0
-        with:
-          subject-path: "${{ runner.temp }}/Brewy-${{ steps.version.outputs.tag }}.zip"
-
       - name: Upload artifact
         uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7.0.1
         with:
@@ -161,6 +158,8 @@ jobs:
       deployment: false
     permissions:
       contents: write # required to create GitHub releases
+      attestations: write # required to attest the published (notarized + stapled) asset
+      id-token: write # required to generate build provenance attestations
     env:
       TAG: ${{ needs.build.outputs.tag }}
     steps:
@@ -186,10 +185,23 @@ jobs:
             "${RUNNER_TEMP}/staple/Brewy.app" \
             "${ARTIFACT_NAME}"
 
+      - name: Generate build provenance for the published asset
+        uses: actions/attest@59d89421af93a897026c735860bf21b6eb4f7b26 # v4.1.0
+        with:
+          # Attest the final notarized + stapled zip that is actually uploaded to the release, so
+          # `gh attestation verify` against the published download matches the attested digest.
+          subject-path: ${{ needs.build.outputs.artifact_name }}
+
       - name: Download Sparkle
+        env:
+          # Keep in lockstep with the Sparkle version pinned in Package.resolved; verify the
+          # download against a known SHA-256 before running sign_update against the private key.
+          SPARKLE_VERSION: "2.9.2"
+          SPARKLE_SHA256: "1cb340cbbef04c6c0d162078610c25e2221031d794a3449d89f2f56f4df77c95"
         run: |
-          curl -L -o "${RUNNER_TEMP}/sparkle.tar.xz" \
-            "https://github.com/sparkle-project/Sparkle/releases/download/2.8.1/Sparkle-2.8.1.tar.xz"
+          curl -fsSL -o "${RUNNER_TEMP}/sparkle.tar.xz" \
+            "https://github.com/sparkle-project/Sparkle/releases/download/${SPARKLE_VERSION}/Sparkle-${SPARKLE_VERSION}.tar.xz"
+          echo "${SPARKLE_SHA256}  ${RUNNER_TEMP}/sparkle.tar.xz" | shasum -a 256 -c -
           mkdir -p "${RUNNER_TEMP}/sparkle"
           tar xf "${RUNNER_TEMP}/sparkle.tar.xz" -C "${RUNNER_TEMP}/sparkle"
 

--- a/Brewy/Models/BrewJSONTypes.swift
+++ b/Brewy/Models/BrewJSONTypes.swift
@@ -57,6 +57,30 @@ struct CaskJSON: Decodable {
     let installed: String?
     let desc: String?
     let homepage: String?
+    let dependencies: [String]
+
+    enum CodingKeys: String, CodingKey {
+        case token, version, installed, desc, homepage
+        case dependsOn = "depends_on"
+    }
+
+    private struct DependsOn: Decodable {
+        let formula: [String]?
+        let cask: [String]?
+    }
+
+    init(from decoder: Decoder) throws {
+        let container = try decoder.container(keyedBy: CodingKeys.self)
+        token = try container.decode(String.self, forKey: .token)
+        version = try container.decodeIfPresent(String.self, forKey: .version)
+        installed = try container.decodeIfPresent(String.self, forKey: .installed)
+        desc = try container.decodeIfPresent(String.self, forKey: .desc)
+        homepage = try container.decodeIfPresent(String.self, forKey: .homepage)
+        // `depends_on` is usually an object but brew sometimes emits an empty array; tolerate
+        // either shape so a cask never fails to decode over its dependency field.
+        let deps = try? container.decodeIfPresent(DependsOn.self, forKey: .dependsOn)
+        dependencies = (deps?.formula ?? []) + (deps?.cask ?? [])
+    }
 
     func toPackage() -> BrewPackage {
         let latest = version ?? "unknown"
@@ -74,7 +98,7 @@ struct CaskJSON: Decodable {
             source: .cask,
             pinned: false,
             installedOnRequest: true,
-            dependencies: []
+            dependencies: dependencies
         )
     }
 }

--- a/Brewy/Models/BrewService+DependencyTree.swift
+++ b/Brewy/Models/BrewService+DependencyTree.swift
@@ -1,0 +1,92 @@
+import Foundation
+
+/// Mutable state threaded through a dependency-tree walk: the ancestor chain (for cycle detection)
+/// and the remaining node budget (to bound total tree size).
+private struct DependencyWalk {
+    var ancestors: Set<String>
+    var budget: Int
+}
+
+extension BrewService {
+    /// Recursive reverse-dependency tree: walks upward through installed packages that depend on `name`.
+    /// Use this to answer "where does this package come from?" — the leaves are the user-requested
+    /// installs that ultimately pulled this in.
+    /// `maxNodes` bounds the total node count so a widely-shared package (e.g. a hub like
+    /// `ca-certificates`) can't generate an unbounded tree that stalls rendering.
+    func reverseDependencyTree(for name: String, maxDepth: Int = 8, maxNodes: Int = 300) -> [DependencyTreeNode] {
+        var walk = DependencyWalk(ancestors: [name], budget: maxNodes)
+        return buildReverseTree(name: name, prefix: name, walk: &walk, remaining: maxDepth)
+    }
+
+    /// Recursive forward-dependency tree: walks downward through what `name` depends on.
+    /// Children of a not-installed dep are omitted since we only know dependencies for installed packages.
+    func forwardDependencyTree(for name: String, maxDepth: Int = 8, maxNodes: Int = 300) -> [DependencyTreeNode] {
+        guard let pkg = allInstalled.first(where: { $0.name == name }) else { return [] }
+        var walk = DependencyWalk(ancestors: [name], budget: maxNodes)
+        // `allInstalled` can hold two entries with the same name (e.g. a `docker` formula and the
+        // `docker` cask), which would trap `Dictionary(uniqueKeysWithValues:)`. Keep the first —
+        // formulae precede casks, and brew dependencies resolve to formulae.
+        let lookup = Dictionary(allInstalled.map { ($0.name, $0) }, uniquingKeysWith: { first, _ in first })
+        return buildForwardTree(deps: pkg.dependencies, prefix: name, lookup: lookup, walk: &walk, remaining: maxDepth)
+    }
+
+    private func buildReverseTree(
+        name: String, prefix: String, walk: inout DependencyWalk, remaining: Int
+    ) -> [DependencyTreeNode] {
+        guard remaining > 0 else { return [] }
+        var nodes: [DependencyTreeNode] = []
+        for parent in dependents(of: name) {
+            guard walk.budget > 0 else { break }
+            walk.budget -= 1
+            let path = "\(prefix)>\(parent.name)"
+            let isCycle = walk.ancestors.contains(parent.name)
+            let children: [DependencyTreeNode]?
+            if isCycle {
+                children = nil
+            } else {
+                walk.ancestors.insert(parent.name)
+                let kids = buildReverseTree(name: parent.name, prefix: path, walk: &walk, remaining: remaining - 1)
+                walk.ancestors.remove(parent.name)
+                children = kids.isEmpty ? nil : kids
+            }
+            nodes.append(DependencyTreeNode(
+                id: path, name: parent.name,
+                isInstalled: true, installedOnRequest: parent.installedOnRequest,
+                isCycle: isCycle, children: children
+            ))
+        }
+        return nodes
+    }
+
+    private func buildForwardTree(
+        deps: [String], prefix: String, lookup: [String: BrewPackage], walk: inout DependencyWalk, remaining: Int
+    ) -> [DependencyTreeNode] {
+        guard remaining > 0 else { return [] }
+        var nodes: [DependencyTreeNode] = []
+        for depName in deps {
+            guard walk.budget > 0 else { break }
+            walk.budget -= 1
+            let path = "\(prefix)>\(depName)"
+            let isCycle = walk.ancestors.contains(depName)
+            let installedPkg = lookup[depName]
+            let children: [DependencyTreeNode]?
+            if !isCycle, let installedPkg {
+                walk.ancestors.insert(depName)
+                let kids = buildForwardTree(
+                    deps: installedPkg.dependencies, prefix: path, lookup: lookup, walk: &walk, remaining: remaining - 1
+                )
+                walk.ancestors.remove(depName)
+                children = kids.isEmpty ? nil : kids
+            } else {
+                children = nil
+            }
+            nodes.append(DependencyTreeNode(
+                id: path, name: depName,
+                isInstalled: installedPkg != nil,
+                installedOnRequest: installedPkg?.installedOnRequest ?? false,
+                isCycle: isCycle, children: children
+            ))
+        }
+        return nodes
+    }
+}

--- a/Brewy/Models/BrewService+Fetching.swift
+++ b/Brewy/Models/BrewService+Fetching.swift
@@ -7,13 +7,15 @@ extension BrewService {
 
     // MARK: - Fetch Installed Packages
 
-    func fetchInstalledFormulae() async -> [BrewPackage] {
+    /// Returns `nil` when the brew command fails so the caller can keep the previously loaded list
+    /// instead of clobbering it to empty; a successful-but-empty response still returns `[]`.
+    func fetchInstalledFormulae() async -> [BrewPackage]? {
         let result = await runBrewCommand(["info", "--installed", "--json=v2"])
         guard result.success, let data = result.output.data(using: .utf8) else {
             if !result.success {
                 lastError = .commandFailed(command: "info --installed", output: result.output)
             }
-            return []
+            return result.success ? [] : nil
         }
 
         return await Task.detached(priority: .userInitiated) {
@@ -27,13 +29,13 @@ extension BrewService {
         }.value
     }
 
-    func fetchInstalledCasks() async -> [BrewPackage] {
+    func fetchInstalledCasks() async -> [BrewPackage]? {
         let result = await runBrewCommand(["info", "--installed", "--cask", "--json=v2"])
         guard result.success, let data = result.output.data(using: .utf8) else {
             if !result.success {
                 lastError = .commandFailed(command: "info --installed --cask", output: result.output)
             }
-            return []
+            return result.success ? [] : nil
         }
 
         return await Task.detached(priority: .userInitiated) {
@@ -47,13 +49,13 @@ extension BrewService {
         }.value
     }
 
-    func fetchOutdatedPackages() async -> [BrewPackage] {
+    func fetchOutdatedPackages() async -> [BrewPackage]? {
         let result = await runBrewCommand(["outdated", "--json=v2"])
         guard result.success, let data = result.output.data(using: .utf8) else {
             if !result.success {
                 lastError = .commandFailed(command: "outdated", output: result.output)
             }
-            return []
+            return result.success ? [] : nil
         }
 
         return await Task.detached(priority: .userInitiated) {
@@ -107,7 +109,10 @@ extension BrewService {
 
             let prefix = source == .cask ? "cask" : "formula"
             for line in result.output.split(separator: "\n") {
-                for token in line.split(whereSeparator: \.isWhitespace) where !token.hasPrefix("==>") {
+                // Skip section headers like "==> Formulae" / "==> Casks" wholesale; otherwise the
+                // header word ("Formulae"/"Casks") survives tokenization as a phantom package.
+                if line.hasPrefix("==>") { continue }
+                for token in line.split(whereSeparator: \.isWhitespace) {
                     let name = String(token)
                     packages.append(BrewPackage(
                         id: "\(prefix)-search-\(name)",

--- a/Brewy/Models/BrewService.swift
+++ b/Brewy/Models/BrewService.swift
@@ -9,21 +9,12 @@ private let logger = Logger(subsystem: "io.linnane.brewy", category: "BrewServic
 // MARK: - Error Types
 
 enum BrewError: LocalizedError {
-    case brewNotFound(path: String)
     case commandFailed(command: String, output: String)
-    case parseFailed(command: String)
-    case commandTimedOut(command: String)
 
     var errorDescription: String? {
         switch self {
-        case .brewNotFound(let path):
-            return "Homebrew not found at \(path)"
         case .commandFailed(let command, let output):
             return Self.summarize(command: command, output: output)
-        case .parseFailed(let command):
-            return "Failed to parse output from: brew \(command)"
-        case .commandTimedOut(let command):
-            return "Command timed out: brew \(command)"
         }
     }
 
@@ -278,9 +269,11 @@ final class BrewService {
         async let masOutdated = fetchOutdatedMasApps()
         async let taps = fetchTaps()
 
-        let fetchedFormulae = await formulae
-        let fetchedCasks = await casks
-        let fetchedOutdated = await outdated
+        // Preserve the previously loaded list when a fetch fails (nil) rather than clobbering it
+        // to empty — a transient `brew` failure shouldn't blank out (and then cache) good data.
+        let fetchedFormulae = await formulae ?? installedFormulae
+        let fetchedCasks = await casks ?? installedCasks
+        let fetchedOutdated = await outdated ?? outdatedPackages
         let fetchedMasApps = await masApps
         let fetchedMasOutdated = await masOutdated
         let fetchedTaps = await taps

--- a/Brewy/Models/PackageModel.swift
+++ b/Brewy/Models/PackageModel.swift
@@ -43,6 +43,22 @@ struct BrewPackage: Identifiable, Hashable, Codable {
     }
 }
 
+// MARK: - Dependency Tree
+
+/// A node in a recursive dependency tree.
+/// `id` is a path-based string so the same package can appear in multiple branches
+/// (diamond dependencies) without collisions.
+struct DependencyTreeNode: Identifiable, Hashable {
+    let id: String
+    let name: String
+    let isInstalled: Bool
+    let installedOnRequest: Bool
+    /// True if walking further would re-enter an ancestor in the same chain.
+    let isCycle: Bool
+    /// `nil` marks a leaf with no further children to disclose.
+    let children: [Self]?
+}
+
 struct BrewTap: Identifiable, Hashable, Codable {
     let name: String
     let remote: String

--- a/Brewy/Models/ServicesService.swift
+++ b/Brewy/Models/ServicesService.swift
@@ -63,9 +63,20 @@ extension BrewService {
     private func runServiceCommand(_ arguments: [String], asSudo: Bool) async -> CommandResult {
         let brewPath = CommandRunner.resolvedBrewPath(preferred: customBrewPath)
         if asSudo {
+            // Run brew as root via the native admin auth dialog. Args pass through osascript's argv
+            // and are shell-quoted with `quoted form of`, so nothing is interpolated into the script.
+            let script = """
+            on run argv
+                set cmd to ""
+                repeat with arg in argv
+                    set cmd to cmd & quoted form of (arg as text) & " "
+                end repeat
+                do shell script cmd with administrator privileges
+            end run
+            """
             return await commandRunner.runExecutable(
-                "/usr/bin/sudo",
-                arguments: [brewPath] + arguments
+                "/usr/bin/osascript",
+                arguments: ["-e", script, brewPath] + arguments
             )
         }
         return await commandRunner.run(arguments, brewPath: brewPath)

--- a/Brewy/Views/ContentView.swift
+++ b/Brewy/Views/ContentView.swift
@@ -99,6 +99,9 @@ struct ContentView: View {
             }
         }
         .onChange(of: selectedCategory) {
+            // Cleared here (not in PackageListView, which is torn down when switching to a
+            // non-package category like Discover and would leave a stale detail showing).
+            selectedPackage = nil
             selectedTap = nil
             selectedServiceItem = nil
             selectedGroupItem = nil

--- a/Brewy/Views/DependencyTreeView.swift
+++ b/Brewy/Views/DependencyTreeView.swift
@@ -1,0 +1,128 @@
+import SwiftUI
+
+struct DependencyTreeSection: View {
+    @Environment(BrewService.self)
+    private var brewService
+    let package: BrewPackage
+
+    @State private var pulledInExpanded = false
+    @State private var pullsInExpanded = false
+    @State private var reverse: [DependencyTreeNode] = []
+    @State private var forward: [DependencyTreeNode] = []
+
+    var body: some View {
+        Group {
+            if !reverse.isEmpty || !forward.isEmpty {
+                VStack(alignment: .leading, spacing: 12) {
+                    Text("Dependency Tree")
+                        .font(.headline)
+
+                    if !reverse.isEmpty {
+                        DependencyTreeDisclosure(
+                            title: "Pulled in by",
+                            help: "Installed packages that depend on \(package.name), recursively up to the user-requested install.",
+                            nodes: reverse,
+                            isExpanded: $pulledInExpanded
+                        )
+                    }
+
+                    if !forward.isEmpty {
+                        DependencyTreeDisclosure(
+                            title: "Pulls in",
+                            help: "What \(package.name) depends on, recursively.",
+                            nodes: forward,
+                            isExpanded: $pullsInExpanded
+                        )
+                    }
+                }
+                .padding(.horizontal)
+                .padding(.vertical, 12)
+            }
+        }
+        .task(id: package.id) {
+            reverse = brewService.reverseDependencyTree(for: package.name)
+            forward = brewService.forwardDependencyTree(for: package.name)
+        }
+    }
+}
+
+private struct DependencyTreeDisclosure: View {
+    let title: String
+    let help: String
+    let nodes: [DependencyTreeNode]
+    @Binding var isExpanded: Bool
+
+    var body: some View {
+        DisclosureGroup(isExpanded: $isExpanded) {
+            VStack(alignment: .leading, spacing: 2) {
+                DependencyTreeRows(nodes: nodes, depth: 0)
+            }
+            .padding(.top, 6)
+        } label: {
+            HStack(spacing: 6) {
+                Text(title)
+                    .font(.subheadline)
+                    .fontWeight(.medium)
+                Text("\(nodes.count)")
+                    .font(.caption)
+                    .foregroundStyle(.secondary)
+                    .padding(.horizontal, 6)
+                    .padding(.vertical, 1)
+                    .background(.secondary.opacity(0.15), in: .capsule)
+            }
+            .help(help)
+        }
+    }
+}
+
+private struct DependencyTreeRows: View {
+    let nodes: [DependencyTreeNode]
+    let depth: Int
+
+    var body: some View {
+        ForEach(nodes) { node in
+            DependencyTreeRow(node: node)
+                .padding(.leading, CGFloat(depth) * 14)
+            if let children = node.children, !children.isEmpty {
+                Self(nodes: children, depth: depth + 1)
+            }
+        }
+    }
+}
+
+private struct DependencyTreeRow: View {
+    @Environment(\.selectPackage)
+    private var selectPackage
+    let node: DependencyTreeNode
+
+    var body: some View {
+        HStack(spacing: 6) {
+            Button {
+                if node.isInstalled { selectPackage(node.name) }
+            } label: {
+                Text(node.name)
+                    .font(.system(.callout, design: .monospaced))
+                    .foregroundStyle(node.isInstalled ? Color.blue : Color.secondary)
+            }
+            .buttonStyle(.plain)
+            .disabled(!node.isInstalled)
+            .help(node.isInstalled ? "Go to \(node.name)" : "\(node.name) (not installed)")
+
+            if node.installedOnRequest {
+                Text("requested")
+                    .font(.caption2)
+                    .foregroundStyle(.orange)
+                    .padding(.horizontal, 5)
+                    .padding(.vertical, 1)
+                    .background(.orange.opacity(0.12), in: .capsule)
+                    .help("Installed on request by the user")
+            }
+            if node.isCycle {
+                Image(systemName: "arrow.triangle.2.circlepath")
+                    .font(.caption2)
+                    .foregroundStyle(.secondary)
+                    .help("Already shown above in this chain")
+            }
+        }
+    }
+}

--- a/Brewy/Views/PackageDetailView.swift
+++ b/Brewy/Views/PackageDetailView.swift
@@ -29,6 +29,9 @@ struct PackageDetailView: View {
                 if !package.isMas {
                     Divider()
                         .padding(.horizontal)
+                    DependencyTreeSection(package: displayPackage)
+                    Divider()
+                        .padding(.horizontal)
                     BrewInfoSection(info: detailedInfo, isLoading: isLoadingInfo)
                 }
             }
@@ -36,7 +39,8 @@ struct PackageDetailView: View {
         }
         .frame(maxWidth: .infinity, maxHeight: .infinity, alignment: .topLeading)
         .background(.background)
-        .task(id: package.id) {
+        // Keyed on version too, so the info reloads after an in-place upgrade (id alone is stable).
+        .task(id: [package.id, package.installedVersion ?? ""]) {
             guard !package.isMas else { return }
             enrichedPackage = nil
             detailedInfo = ""
@@ -284,8 +288,6 @@ private struct ActionBar: View {
 // MARK: - Package Info
 
 private struct PackageInfoSection: View {
-    @Environment(BrewService.self)
-    private var brewService
     let package: BrewPackage
 
     private var packageTypeName: String {
@@ -317,13 +319,6 @@ private struct PackageInfoSection: View {
 
             if !package.dependencies.isEmpty {
                 DependencyTags(label: "Dependencies", packages: package.dependencies)
-            }
-
-            if !package.installedOnRequest {
-                let dependents = brewService.dependents(of: package.name)
-                if !dependents.isEmpty {
-                    DependencyTags(label: "Required by", packages: dependents.map(\.name))
-                }
             }
         }
         .padding(.horizontal)

--- a/Brewy/Views/PackageListView.swift
+++ b/Brewy/Views/PackageListView.swift
@@ -75,7 +75,7 @@ struct PackageListView: View {
                 searchScope = .installed
                 searchText = ""
                 searchTask?.cancel()
-                selectedPackage = nil
+                // selectedPackage is cleared centrally in ContentView.onChange(of: selectedCategory).
             }
             .overlay {
                 if brewService.isLoading, packages.isEmpty {

--- a/BrewyTests/BrewServiceAsyncTests.swift
+++ b/BrewyTests/BrewServiceAsyncTests.swift
@@ -82,6 +82,22 @@ struct RefreshTests {
         #expect(service.lastError != nil)
     }
 
+    @Test("refresh preserves the previously loaded list when a fetch transiently fails")
+    func refreshPreservesPreviousOnFailure() async {
+        let mock = MockCommandRunner()
+        let (service, _) = makeService(mock: mock)
+        setupRefreshMock(mock)
+        await service.refresh()
+        #expect(service.installedFormulae.count == 1)
+
+        // A transient formula-fetch failure must not blank out the good list already on screen.
+        mock.setResult(for: ["info", "--installed", "--json=v2"], output: "Error", success: false)
+        await service.refresh()
+
+        #expect(service.installedFormulae.count == 1)
+        #expect(service.lastError != nil)
+    }
+
     @Test("refresh invalidates info cache when versions change")
     func refreshInvalidatesInfoCache() async {
         let mock = MockCommandRunner()
@@ -224,6 +240,9 @@ struct SearchTests {
 
         let names = service.searchResults.map(\.name)
         #expect(!names.contains("==>"))
+        // The header word itself must not survive tokenization as a phantom package.
+        #expect(!names.contains("Formulae"))
+        #expect(!names.contains("Casks"))
         #expect(names.contains("test-formula"))
         #expect(names.contains("test-cask"))
     }

--- a/BrewyTests/BrewServiceTests.swift
+++ b/BrewyTests/BrewServiceTests.swift
@@ -276,28 +276,10 @@ struct SidebarCategoryTests {
 @Suite("BrewError")
 struct BrewErrorTests {
 
-    @Test("brewNotFound includes path in description")
-    func brewNotFoundDescription() {
-        let error = BrewError.brewNotFound(path: "/opt/homebrew/bin/brew")
-        #expect(error.errorDescription?.contains("/opt/homebrew/bin/brew") == true)
-    }
-
     @Test("commandFailed uses output as description")
     func commandFailedDescription() {
         let error = BrewError.commandFailed(command: "install wget", output: "Error: wget already installed")
         #expect(error.errorDescription == "Error: wget already installed")
-    }
-
-    @Test("parseFailed includes command in description")
-    func parseFailedDescription() {
-        let error = BrewError.parseFailed(command: "info --json=v2")
-        #expect(error.errorDescription?.contains("info --json=v2") == true)
-    }
-
-    @Test("commandTimedOut includes command in description")
-    func commandTimedOutDescription() {
-        let error = BrewError.commandTimedOut(command: "install gcc")
-        #expect(error.errorDescription?.contains("install gcc") == true)
     }
 }
 

--- a/BrewyTests/DependencyTreeTests.swift
+++ b/BrewyTests/DependencyTreeTests.swift
@@ -1,0 +1,190 @@
+@testable import Brewy
+import Foundation
+import Testing
+
+private func makePackage(
+    name: String,
+    installedOnRequest: Bool = true,
+    dependencies: [String] = []
+) -> BrewPackage {
+    BrewPackage(
+        id: "formula-\(name)", name: name, version: "1.0",
+        description: "", homepage: "",
+        isInstalled: true, isOutdated: false,
+        installedVersion: "1.0", latestVersion: nil,
+        source: .formula, pinned: false,
+        installedOnRequest: installedOnRequest,
+        dependencies: dependencies
+    )
+}
+
+private func countNodes(_ nodes: [DependencyTreeNode]) -> Int {
+    nodes.reduce(0) { $0 + 1 + countNodes($1.children ?? []) }
+}
+
+@Suite("BrewService Dependency Tree")
+@MainActor
+struct BrewServiceDependencyTreeTests {
+
+    @Test("Reverse tree walks up to the user-requested install")
+    func reverseTreeChain() {
+        let service = BrewService()
+        service.installedFormulae = [
+            makePackage(name: "openssl", installedOnRequest: false),
+            makePackage(name: "curl", installedOnRequest: false, dependencies: ["openssl"]),
+            makePackage(name: "wget", installedOnRequest: true, dependencies: ["curl"])
+        ]
+
+        let tree = service.reverseDependencyTree(for: "openssl")
+        #expect(tree.count == 1)
+        #expect(tree[0].name == "curl")
+        let curlChildren = tree[0].children ?? []
+        #expect(curlChildren.count == 1)
+        #expect(curlChildren[0].name == "wget")
+        #expect(curlChildren[0].installedOnRequest == true)
+        #expect(curlChildren[0].children == nil)
+    }
+
+    @Test("Reverse tree is empty for top-level packages")
+    func reverseTreeEmpty() {
+        let service = BrewService()
+        service.installedFormulae = [makePackage(name: "wget")]
+        #expect(service.reverseDependencyTree(for: "wget").isEmpty)
+    }
+
+    @Test("Reverse tree handles diamond dependencies via path-based IDs")
+    func reverseTreeDiamond() {
+        let service = BrewService()
+        service.installedFormulae = [
+            makePackage(name: "z", installedOnRequest: false),
+            makePackage(name: "a", installedOnRequest: false, dependencies: ["z"]),
+            makePackage(name: "b", installedOnRequest: false, dependencies: ["z"]),
+            makePackage(name: "top", installedOnRequest: true, dependencies: ["a", "b"])
+        ]
+
+        let tree = service.reverseDependencyTree(for: "z")
+        #expect(tree.count == 2)
+        let ids = Set(tree.flatMap { node -> [String] in
+            [node.id] + (node.children?.map(\.id) ?? [])
+        })
+        #expect(ids.contains("z>a"))
+        #expect(ids.contains("z>b"))
+        #expect(ids.contains("z>a>top"))
+        #expect(ids.contains("z>b>top"))
+    }
+
+    @Test("Reverse tree guards against cycles in the ancestor chain")
+    func reverseTreeCycleGuard() {
+        let service = BrewService()
+        // Fabricated cycle: A→B→A. Brew shouldn't produce this, but the guard protects us.
+        service.installedFormulae = [
+            makePackage(name: "a", dependencies: ["b"]),
+            makePackage(name: "b", dependencies: ["a"])
+        ]
+
+        let tree = service.reverseDependencyTree(for: "a")
+        #expect(tree.count == 1)
+        #expect(tree[0].name == "b")
+        let bChildren = tree[0].children ?? []
+        #expect(bChildren.count == 1)
+        #expect(bChildren[0].name == "a")
+        #expect(bChildren[0].isCycle == true)
+        #expect(bChildren[0].children == nil)
+    }
+
+    @Test("Forward tree walks down the dependencies of the package")
+    func forwardTreeChain() {
+        let service = BrewService()
+        service.installedFormulae = [
+            makePackage(name: "openssl"),
+            makePackage(name: "curl", dependencies: ["openssl"]),
+            makePackage(name: "wget", dependencies: ["curl"])
+        ]
+
+        let tree = service.forwardDependencyTree(for: "wget")
+        #expect(tree.count == 1)
+        #expect(tree[0].name == "curl")
+        #expect(tree[0].isInstalled == true)
+        let curlDeps = tree[0].children ?? []
+        #expect(curlDeps.count == 1)
+        #expect(curlDeps[0].name == "openssl")
+        #expect(curlDeps[0].children == nil)
+    }
+
+    @Test("Forward tree marks uninstalled deps as not installed and stops recursing")
+    func forwardTreeUninstalledDep() {
+        let service = BrewService()
+        service.installedFormulae = [
+            makePackage(name: "wget", dependencies: ["missing-dep"])
+        ]
+
+        let tree = service.forwardDependencyTree(for: "wget")
+        #expect(tree.count == 1)
+        #expect(tree[0].name == "missing-dep")
+        #expect(tree[0].isInstalled == false)
+        #expect(tree[0].children == nil)
+    }
+
+    @Test("Forward tree returns empty for non-installed root")
+    func forwardTreeUnknownRoot() {
+        let service = BrewService()
+        service.installedFormulae = [makePackage(name: "wget")]
+        #expect(service.forwardDependencyTree(for: "nonexistent").isEmpty)
+    }
+
+    @Test("maxDepth cuts off deep recursion")
+    func maxDepthCutoff() {
+        let service = BrewService()
+        service.installedFormulae = [
+            makePackage(name: "l0", dependencies: ["l1"]),
+            makePackage(name: "l1", dependencies: ["l2"]),
+            makePackage(name: "l2", dependencies: ["l3"]),
+            makePackage(name: "l3")
+        ]
+
+        let depth1 = service.forwardDependencyTree(for: "l0", maxDepth: 1)
+        #expect(depth1.count == 1)
+        #expect(depth1[0].name == "l1")
+        #expect(depth1[0].children == nil)
+    }
+
+    @Test("Forward tree does not trap when a formula and cask share a name")
+    func forwardTreeDuplicateNameDoesNotTrap() {
+        let service = BrewService()
+        service.installedFormulae = [
+            makePackage(name: "docker", dependencies: ["openssl"]),
+            makePackage(name: "openssl")
+        ]
+        // A same-named cask is a real configuration (docker CLI formula + Docker Desktop cask).
+        service.installedCasks = [
+            BrewPackage(
+                id: "cask-docker", name: "docker", version: "1.0",
+                description: "", homepage: "",
+                isInstalled: true, isOutdated: false,
+                installedVersion: "1.0", latestVersion: nil,
+                source: .cask, pinned: false,
+                installedOnRequest: true, dependencies: []
+            )
+        ]
+
+        // Building the name-keyed lookup must not trap on the duplicate "docker"; the formula
+        // (which carries the dependency) wins, so the tree resolves down to openssl.
+        let tree = service.forwardDependencyTree(for: "docker")
+        #expect(tree.count == 1)
+        #expect(tree[0].name == "openssl")
+    }
+
+    @Test("maxNodes bounds the total node count for hub packages")
+    func maxNodesCap() {
+        let service = BrewService()
+        var packages = [makePackage(name: "root", dependencies: (0..<50).map { "dep\($0)" })]
+        for index in 0..<50 {
+            packages.append(makePackage(name: "dep\(index)"))
+        }
+        service.installedFormulae = packages
+
+        let tree = service.forwardDependencyTree(for: "root", maxNodes: 10)
+        #expect(!tree.isEmpty)
+        #expect(countNodes(tree) <= 10)
+    }
+}

--- a/BrewyTests/PackageModelTests.swift
+++ b/BrewyTests/PackageModelTests.swift
@@ -161,6 +161,44 @@ struct BrewJSONParsingTests {
         #expect(pkg.id == "cask-firefox")
     }
 
+    @Test("CaskJSON decodes depends_on formula and cask into dependencies")
+    func caskDependsOnDecoded() throws {
+        let json = """
+        {
+            "formulae": [],
+            "casks": [
+                {
+                    "token": "some-app",
+                    "version": "1.0",
+                    "depends_on": { "formula": ["openssl@3"], "cask": ["other-app"], "macos": { ">=": ["12"] } }
+                }
+            ]
+        }
+        """
+        let data = try #require(json.data(using: .utf8))
+        let response = try JSONDecoder().decode(BrewInfoResponse.self, from: data)
+        let cask = try #require(response.casks?.first)
+        #expect(cask.toPackage().dependencies == ["openssl@3", "other-app"])
+    }
+
+    @Test("CaskJSON tolerates an empty-array depends_on without failing to decode")
+    func caskDependsOnEmptyArrayShape() throws {
+        // Brew sometimes emits `"depends_on": []` instead of an object; the cask must still decode.
+        let json = """
+        {
+            "formulae": [],
+            "casks": [
+                { "token": "no-deps", "version": "1.0", "depends_on": [] }
+            ]
+        }
+        """
+        let data = try #require(json.data(using: .utf8))
+        let response = try JSONDecoder().decode(BrewInfoResponse.self, from: data)
+        let cask = try #require(response.casks?.first)
+        #expect(cask.toPackage().dependencies.isEmpty)
+        #expect(cask.toPackage().name == "no-deps")
+    }
+
     @Test("OutdatedFormulaJSON parses correctly")
     func outdatedFormulaJSON() throws {
         let json = """

--- a/BrewyTests/ServicesTests.swift
+++ b/BrewyTests/ServicesTests.swift
@@ -196,16 +196,19 @@ struct BrewServiceServicesControlTests {
         #expect(mock.executedExecutables.last?.arguments == ["services", "restart", "redis"])
     }
 
-    @Test("asSudo routes through /usr/bin/sudo with the brew path prefixed")
+    @Test("asSudo runs brew via osascript with administrator privileges")
     func startServiceAsSudo() async {
         let mock = MockCommandRunner()
         let (service, _) = makeService(mock: mock)
 
         _ = await service.startService("redis", asSudo: true)
 
-        let last = mock.executedExecutables.last
-        #expect(last?.path == "/usr/bin/sudo")
-        #expect(last?.arguments.first?.hasSuffix("brew") == true)
-        #expect(Array(last?.arguments.dropFirst() ?? []) == ["services", "start", "redis"])
+        // osascript -e <privileged script> <brewPath> services start redis
+        let args = mock.executedExecutables.last?.arguments ?? []
+        #expect(mock.executedExecutables.last?.path == "/usr/bin/osascript")
+        #expect(args.first == "-e")
+        #expect(args.dropFirst().first?.contains("administrator privileges") == true)
+        #expect(args.dropFirst(2).first?.hasSuffix("brew") == true)
+        #expect(Array(args.suffix(3)) == ["services", "start", "redis"])
     }
 }

--- a/BrewyTests/ServicesTests.swift
+++ b/BrewyTests/ServicesTests.swift
@@ -165,3 +165,47 @@ struct ServicesParsingTests {
         #expect(loadedNotRunning.isHealthy == false)
     }
 }
+
+// MARK: - Services Control
+
+@Suite("BrewService Services Control")
+@MainActor
+struct BrewServiceServicesControlTests {
+
+    @Test("startService issues `services start <name>` via brew")
+    func startServiceCommand() async {
+        let mock = MockCommandRunner()
+        let (service, _) = makeService(mock: mock)
+
+        _ = await service.startService("redis")
+
+        let last = mock.executedExecutables.last
+        #expect(last?.arguments == ["services", "start", "redis"])
+        #expect(last?.path.hasSuffix("brew") == true)
+    }
+
+    @Test("stopService and restartService issue the matching verbs")
+    func stopAndRestartCommands() async {
+        let mock = MockCommandRunner()
+        let (service, _) = makeService(mock: mock)
+
+        _ = await service.stopService("redis")
+        #expect(mock.executedExecutables.last?.arguments == ["services", "stop", "redis"])
+
+        _ = await service.restartService("redis")
+        #expect(mock.executedExecutables.last?.arguments == ["services", "restart", "redis"])
+    }
+
+    @Test("asSudo routes through /usr/bin/sudo with the brew path prefixed")
+    func startServiceAsSudo() async {
+        let mock = MockCommandRunner()
+        let (service, _) = makeService(mock: mock)
+
+        _ = await service.startService("redis", asSudo: true)
+
+        let last = mock.executedExecutables.last
+        #expect(last?.path == "/usr/bin/sudo")
+        #expect(last?.arguments.first?.hasSuffix("brew") == true)
+        #expect(Array(last?.arguments.dropFirst() ?? []) == ["services", "start", "redis"])
+    }
+}

--- a/BrewyTests/TestHelpers.swift
+++ b/BrewyTests/TestHelpers.swift
@@ -8,9 +8,16 @@ final class MockCommandRunner: CommandRunning, @unchecked Sendable {
     private let lock = NSLock()
     private var _results: [[String]: CommandResult] = [:]
     private var _executedCommands: [[String]] = []
+    private var _executedExecutables: [(path: String, arguments: [String])] = []
 
     var executedCommands: [[String]] {
         lock.withLock { _executedCommands }
+    }
+
+    /// Records the executable/brew path alongside arguments so tests can assert *which* binary ran
+    /// (brew vs mas vs sudo) — `executedCommands` keys on arguments alone.
+    var executedExecutables: [(path: String, arguments: [String])] {
+        lock.withLock { _executedExecutables }
     }
 
     func setResult(for arguments: [String], output: String, success: Bool = true) {
@@ -22,6 +29,7 @@ final class MockCommandRunner: CommandRunning, @unchecked Sendable {
     func run(_ arguments: [String], brewPath: String, timeout: Duration) async -> CommandResult {
         lock.withLock {
             _executedCommands.append(arguments)
+            _executedExecutables.append((path: brewPath, arguments: arguments))
             return _results[arguments] ?? CommandResult(output: "", success: false)
         }
     }
@@ -29,6 +37,7 @@ final class MockCommandRunner: CommandRunning, @unchecked Sendable {
     func runExecutable(_ executablePath: String, arguments: [String], timeout: Duration) async -> CommandResult {
         lock.withLock {
             _executedCommands.append(arguments)
+            _executedExecutables.append((path: executablePath, arguments: arguments))
             return _results[arguments] ?? CommandResult(output: "", success: false)
         }
     }

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -26,8 +26,10 @@ Brewy/
 │   │   ├── BrewService+PackageDetail.swift # Single-package detail fetching
 │   │   ├── BrewService+History.swift       # Action history recording, persistence, retry, outdated merge helper
 │   │   ├── BrewService+Groups.swift        # User-created package group CRUD and persistence
+│   │   ├── BrewService+Taps.swift          # Tap add/remove/migrate orchestration and lazy tap loading
 │   │   ├── BrewService+DryRun.swift        # Dry-run previews for autoremove and cleanup
 │   │   ├── BrewService+Updates.swift       # `brew update` orchestration, parses + persists new formulae/casks
+│   │   ├── BrewService+DependencyTree.swift # Recursive forward/reverse dependency-tree walks (depth + node-budget bounded)
 │   │   ├── BrewJSONTypes.swift             # Brew JSON v2 Codable response types (extracted from PackageModel)
 │   │   ├── PackageModel.swift              # Data models: BrewPackage, BrewTap, SidebarCategory, PackageGroup, ActionHistoryEntry, BrewServiceItem, BrewConfig, BrewUpdateResult/Parser, appcast parser
 │   │   ├── CommandRunner.swift             # Process execution with timeout, cancellation, thread-safe pipe reading, CommandRunning protocol
@@ -38,7 +40,8 @@ Brewy/
 │       ├── ContentView.swift               # NavigationSplitView (3-column), toolbar, state management
 │       ├── SidebarView.swift               # Category list (13 categories, see SidebarCategory enum)
 │       ├── PackageListView.swift           # Package list with search, selection toggles for bulk upgrade
-│       ├── PackageDetailView.swift         # Detail pane: info, dependencies, reverse deps, actions
+│       ├── PackageDetailView.swift         # Detail pane: info, dependencies, dependency tree, actions
+│       ├── DependencyTreeView.swift        # Collapsible "Pulled in by" / "Pulls in" dependency trees
 │       ├── DiscoverView.swift              # Search all of Homebrew (formulae + casks)
 │       ├── GroupsView.swift                # Custom package groups with CRUD UI
 │       ├── HistoryView.swift               # Action history with review and retry
@@ -62,7 +65,8 @@ Brewy/
 │   ├── HistoryTests.swift                  # Action history recording and retry
 │   ├── ServicesTests.swift                 # Services parsing and integration
 │   ├── JSONAndServicesTests.swift          # JSON parsing edge cases and services
-│   └── BrewUpdateParserTests.swift         # `brew update` output parsing
+│   ├── BrewUpdateParserTests.swift         # `brew update` output parsing
+│   └── DependencyTreeTests.swift           # Dependency-tree walks: chains, diamonds, cycles, depth/node bounds
 ├── BrewyUITests/
 │   └── SidebarNavigationUITests.swift      # UI tests for sidebar navigation
 ├── Brewy.xcodeproj/
@@ -125,7 +129,7 @@ Static enum that executes `Process` (brew CLI and other executables) with:
 - `CommandRunning` protocol for dependency injection and testability
 - Configurable timeout (default 5 minutes) with sub-second precision preserved
 - Parallel stdout/stderr drain via dedicated `PipeReader` instances so large output on either stream can't deadlock the subprocess
-- Two-stage timeout termination: SIGTERM first, then SIGKILL after a 3s grace period; `CommandResult.didTimeOut` distinguishes timeouts from other failures
+- Two-stage timeout termination: SIGTERM first, then SIGKILL after a 3s grace period. A timeout surfaces as a failed `CommandResult` whose `output` notes the timeout — there is no separate timeout flag or `BrewError` case
 - `LockedData` (NSLock-backed) and `LockedFlag` accumulators for thread-safe output collection
 - Brew path resolution: preferred path → `/usr/local/bin/brew` fallback
 - `runExecutable(_:arguments:)` — generic executable runner for external tools (mas, sudo, du)
@@ -210,6 +214,7 @@ mas install ID                               # Install Mac App Store app
 - Bulk upgrade: select specific outdated packages to upgrade
 - Reverse dependency computation for installed packages
 - Leaves detection (formulae with no reverse dependencies)
+- Dependency tree in package detail: recursive "Pulled in by" (reverse) and "Pulls in" (forward) trees with cycle detection, bounded by a depth limit and node budget
 - Mac App Store integration via `mas` CLI (browse installed apps, check for updates)
 - Homebrew services management (start, stop, restart, cleanup)
 - Custom package groups: create, edit, delete groups and organize packages into them
@@ -225,9 +230,9 @@ mas install ID                               # Install Mac App Store app
 ## Testing
 
 - Framework: Swift Testing (`@Suite`, `@Test` macros)
-- ~210 test cases across 12 test files (11 unit test files + 1 test helpers)
+- ~230 test cases across 13 test files (12 unit test files + 1 test helpers)
 - `MockCommandRunner` and shared test helpers in `TestHelpers.swift`
-- Tests cover: derived state, reverse deps, leaves, pinned filtering, category routing, outdated merge logic, all JSON parsing, model equality/hashing, config parsing, appcast XML parsing, tap health status, package groups, Mac App Store parsing, action history, services, dry-run, retry, error handling, `brew update` output parsing, async refresh/search/upgrade flows, real-subprocess CommandRunner behavior (stdout/stderr drain, timeout, missing executable)
+- Tests cover: derived state, reverse deps, leaves, pinned filtering, category routing, outdated merge logic, all JSON parsing, model equality/hashing, config parsing, appcast XML parsing, tap health status, package groups, Mac App Store parsing, action history, services, dry-run, retry, error handling, `brew update` output parsing, async refresh/search/upgrade flows, dependency-tree walks (chains, diamonds, cycles, depth/node bounds), services start/stop/restart dispatch (including sudo), real-subprocess CommandRunner behavior (stdout/stderr drain, timeout, missing executable)
 - UI tests: sidebar navigation
 - CI runs both Thread Sanitizer and Address Sanitizer
 - Code coverage reported via `xccov`
@@ -288,8 +293,15 @@ PRs are squash-merged with the PR number appended, e.g. `feat: add test suite wi
 - BrewService acts as both service layer and state container, split into focused extensions for maintainability
 - All brew interactions go through CommandRunner via the `CommandRunning` protocol (single execution path, testable)
 - JSON v2 API used for structured data; text output parsed for search results and config
+- Cask `depends_on` (formula + cask) is decoded into `BrewPackage.dependencies` so casks participate in reverse-dependency/leaves/dependency-tree computation; the decoder tolerates brew emitting `depends_on` as either an object or an empty array
 - Cache enables instant app launch with stale data, then background refresh
 - Derived state (reverse deps, leaves, pinned) computed eagerly via `invalidateDerivedState()`, with batch updates to avoid redundant recomputation
 - Search results tagged with `isInstalled` by cross-referencing `installedNames` set
 - Mac App Store packages use `mas-` prefixed IDs to avoid collisions with brew package IDs
 - Action history capped at 100 entries with automatic pruning
+
+## Gotchas / do-not-touch zones
+
+- The app is intentionally **not sandboxed** (`com.apple.security.app-sandbox = false`): it must exec arbitrary brew-installed binaries. Hardened Runtime is enabled with library validation on (all `RUNTIME_EXCEPTION_*` = NO), and the app ships via Developer ID + notarization, not the App Store. Do not add the sandbox entitlement — it breaks `brew` execution.
+- All CLI execution must keep going through `CommandRunner` with an **argument array** (`process.arguments`), never a shell string — this is what keeps package names injection-safe.
+- Release signing/notarization and the `appcast` branch are produced by `release.yml` (Sparkle EdDSA signing + build-provenance attestation on the notarized asset). Don't hand-edit `appcast.xml` or reorder the signing/attestation steps without understanding that flow.

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -1,0 +1,56 @@
+# Contributing to Brewy
+
+Thanks for your interest in improving Brewy! This document captures the workflow and conventions the project follows.
+
+## Requirements
+
+- macOS 15.0 or later (Apple Silicon)
+- Xcode 16 or later
+- [Homebrew](https://brew.sh) — the app shells out to `brew`
+- [`just`](https://github.com/casey/just) for the local task runner (`brew install just`)
+
+Optional tooling used by the checks below: `swiftlint`, `typos-cli`, `zizmor`, `periphery`.
+
+## Getting started
+
+```sh
+git clone https://github.com/starhaven-io/Brewy.git
+cd Brewy
+just install-hooks   # enable the DCO sign-off commit hook (once per clone)
+open Brewy.xcodeproj
+```
+
+## Local checks
+
+The `justfile` wraps the common tasks — run them before opening a PR:
+
+```sh
+just lint        # SwiftLint (--strict)
+just typos       # spell-check
+just test        # unit tests (BrewyTests; UI tests need code signing)
+just periphery   # unused-code scan
+just audit       # GitHub Actions audit (zizmor)
+just check       # everything above
+```
+
+CI builds with `SWIFT_TREAT_WARNINGS_AS_ERRORS=YES` and `SWIFT_STRICT_CONCURRENCY=complete`, runs SwiftLint in `--strict` mode, and exercises the test suite under both Thread and Address sanitizers. Warnings and lint violations fail the build, so a clean `just check` locally is the best way to avoid CI surprises.
+
+## Commits
+
+- **Conventional Commits**: every commit message and PR title must be `type(scope): description`, where `type` is one of `feat`, `fix`, `docs`, `style`, `refactor`, `perf`, `test`, `build`, `ci`, `chore`. CI enforces this on both the PR title and each commit.
+- **DCO sign-off**: every commit needs a `Signed-off-by:` trailer — use `git commit -s`. The `commit-msg` hook installed by `just install-hooks` rejects commits without it.
+- If you used an AI assistant, include a `Co-Authored-By:` trailer.
+
+## Pull requests
+
+- Never push to `main`. Create a feature branch and open a PR.
+- PRs are squash-merged with the PR number appended (e.g. `feat: add dependency tree (#123)`).
+- Keep PR descriptions to a short summary of the change — no test-plan sections or tool-attribution footers.
+
+## Architecture
+
+See [CLAUDE.md](CLAUDE.md) for a map of the codebase, the `BrewService` architecture, the brew CLI commands used, and the gotchas / do-not-touch zones (notably: the app is intentionally unsandboxed, and all CLI calls must go through `CommandRunner` with an argument array).
+
+## License
+
+By contributing, you agree that your contributions are licensed under the project's [AGPL-3.0-only](LICENSE) license.

--- a/README.md
+++ b/README.md
@@ -11,7 +11,7 @@ A native macOS app for managing [Homebrew](https://brew.sh) packages. Browse, se
 
 - Browse installed formulae and casks, including pinned packages and leaves
 - Discover and search all Homebrew/core and Homebrew/cask packages
-- View package details, dependencies, and reverse dependencies
+- View package details, dependencies, and a recursive dependency tree (what pulled a package in, and what it pulls in)
 - Install, uninstall, upgrade, reinstall, pin, and unpin packages
 - Upgrade all outdated packages at once, or select specific packages to upgrade
 - Mac App Store integration via [`mas`](https://github.com/mas-cli/mas) (browse installed apps, check for updates)
@@ -50,7 +50,7 @@ You can also grab the latest release from the [GitHub releases page](https://git
 
 ## Contributing
 
-Contributions are welcome. Feel free to open a pull request.
+Contributions are welcome. See [CONTRIBUTING.md](CONTRIBUTING.md) for the development setup, local checks, and commit conventions.
 
 ## Acknowledgements
 


### PR DESCRIPTION
## Summary

Completes the package **dependency tree** feature and applies the first pass of fixes from a full-repo review.

**Dependency tree**
- Recursive "Pulled in by" (reverse) and "Pulls in" (forward) trees in the package detail pane, with cycle detection and depth/node-budget bounds.
- Fixes a crash: the forward-tree lookup keyed installed packages by name and trapped when a formula and cask shared one (e.g. the `docker` CLI formula + Docker Desktop cask). It now de-duplicates, preferring the formula.
- Decodes cask `depends_on` so casks participate in reverse-dependency / leaves / tree computation (tolerant of brew emitting an object or an empty array).

**Correctness fixes**
- `refresh()` no longer blanks out (and caches) a good package list when a single `brew` fetch transiently fails.
- The detail pane no longer shows a stale package after switching to a non-package category such as Discover; the selection is now cleared centrally.
- Search no longer surfaces phantom "Formulae"/"Casks" rows from `brew search` section headers.
- The "Brew Info" block reloads after an in-place upgrade.
- The Services "Run as root (sudo)" toggle now works via the native admin prompt (`osascript … with administrator privileges`) instead of a TTY-less `sudo` that only worked with passwordless sudo.
- Removes three never-constructed `BrewError` cases.

**Tests**
- `MockCommandRunner` now records which executable ran; adds coverage for Homebrew services start/stop/restart and the sudo dispatch path.
- Regression tests for the dependency-tree name collision, refresh preservation, cask `depends_on`, and search-header filtering.

**Release pipeline**
- Masks the temporary keychain password (no longer traced into logs).
- Pins the Sparkle signing tool to 2.9.2 (matching the SPM pin) and verifies its SHA-256 before use.
- Moves the build-provenance attestation onto the final notarized + stapled asset so it matches the published download.

**Docs**
- Corrects CLAUDE.md drift (removes the non-existent `CommandResult.didTimeOut` claim, updates counts and the file list, documents the unsandboxed / do-not-touch zones).
- Adds CONTRIBUTING.md and links it from the README.
