### PR TITLE
fix: lifecycle and parsing polish from review

### DIFF
--- a/Brewy/BrewyApp.swift
+++ b/Brewy/BrewyApp.swift
@@ -92,6 +92,7 @@ private final class CheckForUpdatesViewModel {
 
     init(updater: SPUUpdater) {
         cancellable = updater.publisher(for: \.canCheckForUpdates)
+            .receive(on: DispatchQueue.main)
             .sink { [weak self] value in
                 self?.canCheckForUpdates = value
             }

--- a/Brewy/Models/BrewService+Taps.swift
+++ b/Brewy/Models/BrewService+Taps.swift
@@ -28,9 +28,12 @@ extension BrewService {
         await performTapAction {
             logger.info("Migrating tap \(oldName) → \(newName)")
             guard await runTapCommand(["untap", oldName]) else { return false }
-            tapHealthStatuses.removeValue(forKey: oldName)
             let tapped = await runTapCommand(["tap", newName])
-            if !tapped {
+            if tapped {
+                // Drop the old tap's cached health only once the new tap is in place; on rollback
+                // it stays installed and keeps its status.
+                tapHealthStatuses.removeValue(forKey: oldName)
+            } else {
                 logger.warning("Rollback: re-adding \(oldName) after failure to add \(newName)")
                 _ = await runTapCommand(["tap", oldName])
             }

--- a/Brewy/Models/BrewService.swift
+++ b/Brewy/Models/BrewService.swift
@@ -68,7 +68,8 @@ final class BrewService {
     var outdatedPackages: [BrewPackage] = []
     var installedTaps: [BrewTap] = []
     var searchResults: [BrewPackage] = []
-    var isLoading = false
+    private var loadingCount = 0
+    var isLoading: Bool { loadingCount > 0 }
     var isPerformingAction = false
     var actionOutput: String = ""
     var lastError: BrewError?
@@ -236,10 +237,9 @@ final class BrewService {
     }
 
     func checkTapHealth() async {
-        tapHealthStatuses = await TapHealthChecker.checkHealth(
-            taps: installedTaps,
-            existing: tapHealthStatuses
-        )
+        let updated = await TapHealthChecker.checkHealth(taps: installedTaps, existing: tapHealthStatuses)
+        guard !Task.isCancelled else { return }
+        tapHealthStatuses = updated
     }
 
     // MARK: - Homebrew CLI Interactions
@@ -254,12 +254,13 @@ final class BrewService {
         logger.info("Starting full refresh")
         let previousVersions = Dictionary(allInstalled.map { ($0.id, $0.version) }, uniquingKeysWith: { _, last in last })
         let hadCachedData = !installedFormulae.isEmpty || !installedCasks.isEmpty
-        if !hadCachedData {
-            isLoading = true
-        }
+        // Only show the spinner when there's no cached data yet; the counter keeps a concurrent
+        // search() from clearing it early (and vice versa).
+        let showsSpinner = !hadCachedData
+        if showsSpinner { loadingCount += 1 }
         lastError = nil
         defer {
-            isLoading = false
+            if showsSpinner { loadingCount -= 1 }
         }
 
         async let formulae = fetchInstalledFormulae()
@@ -300,8 +301,10 @@ final class BrewService {
         let outdatedCount = allOutdated.count
         logger.info("Refresh complete: \(fetchedFormulae.count) formulae, \(fetchedCasks.count) casks, \(masCount) mas, \(outdatedCount) outdated")
         saveToCache()
+        // Cancel any in-flight check unconditionally so a prior refresh's task can't overwrite
+        // tapHealthStatuses after the tap list has changed.
+        tapHealthTask?.cancel()
         if installedTaps.contains(where: { tapHealthStatuses[$0.name]?.isStale ?? true }) {
-            tapHealthTask?.cancel()
             tapHealthTask = Task { [weak self] in
                 await self?.checkTapHealth()
             }
@@ -314,8 +317,8 @@ final class BrewService {
             return
         }
 
-        isLoading = true
-        defer { isLoading = false }
+        loadingCount += 1
+        defer { loadingCount -= 1 }
         lastError = nil
 
         let results = await performSearch(query: query)

--- a/Brewy/Models/PackageModel.swift
+++ b/Brewy/Models/PackageModel.swift
@@ -294,12 +294,15 @@ final class AppcastParser: NSObject, XMLParserDelegate {
     func parser(_ parser: XMLParser, didEndElement elementName: String,
                 namespaceURI: String?, qualifiedName: String?) {
         if elementName == "item" {
-            release = AppcastRelease(
-                title: currentTitle.trimmingCharacters(in: .whitespacesAndNewlines),
-                pubDate: currentPubDate.trimmingCharacters(in: .whitespacesAndNewlines),
-                version: currentVersion.trimmingCharacters(in: .whitespacesAndNewlines),
-                descriptionHTML: currentDescription.isEmpty ? nil : currentDescription
-            )
+            // Keep the first item; Sparkle feeds list newest first, so ignore older entries.
+            if release == nil {
+                release = AppcastRelease(
+                    title: currentTitle.trimmingCharacters(in: .whitespacesAndNewlines),
+                    pubDate: currentPubDate.trimmingCharacters(in: .whitespacesAndNewlines),
+                    version: currentVersion.trimmingCharacters(in: .whitespacesAndNewlines),
+                    descriptionHTML: currentDescription.isEmpty ? nil : currentDescription
+                )
+            }
             insideItem = false
         }
         currentElement = ""

--- a/BrewyTests/TapAndConfigTests.swift
+++ b/BrewyTests/TapAndConfigTests.swift
@@ -289,7 +289,8 @@ struct AppcastParserTests {
         let data = try #require(xml.data(using: .utf8))
         let parser = AppcastParser()
         let release = try #require(parser.parse(data: data))
-        #expect(release.version == "0.1.0")
+        // Sparkle feeds list newest first, so the first item (0.2.0) is the one we want.
+        #expect(release.version == "0.2.0")
     }
 }
 


### PR DESCRIPTION
## Summary

The low-priority polish items from the review pass. **Stacked on #163** (based on `review-first-pass`) — once #163 merges I can retarget this to `main`.

- **Loading-spinner race:** `isLoading` is now derived from a counter, so a concurrent `search()` and `refresh()` can't clear the spinner out from under each other. `refresh()` still only shows the spinner when there's no cached data to display.
- **Tap-health task lifecycle:** the in-flight health-check task is cancelled on every refresh (not only when stale taps are found), and `checkTapHealth()` checks `Task.isCancelled` before assigning — so a stale check can't overwrite `tapHealthStatuses` after the tap list has changed.
- **Tap migration:** the old tap's cached health is dropped only after the new tap succeeds; on rollback it stays installed and keeps its status.
- **Sparkle:** `canCheckForUpdates` KVO updates are delivered on the main queue (`.receive(on:)`) instead of relying on undocumented main-thread delivery into a `@MainActor` property.
- **Appcast:** the parser returns the first (newest) `<item>` from a multi-item feed instead of the last (oldest); the existing multi-item test — named "first" but asserting the last — is corrected.

Deliberately out of scope: per-file SPDX license headers (a project-wide policy choice across ~50 files) and the WhatsNewView main-thread HTML parse (inherent to the HTML importer).
