### PR TITLE
ci: run the standalone zizmor scan with the auditor persona

### DIFF
--- a/.github/workflows/zizmor.yml
+++ b/.github/workflows/zizmor.yml
@@ -26,4 +26,4 @@ jobs:
           persist-credentials: false
       - uses: zizmorcore/zizmor-action@5f14fd08f7cf1cb1609c1e344975f152c7ee938d # v0.5.6
         with:
-          persona: pedantic
+          persona: auditor


### PR DESCRIPTION
Brewy's scheduled zizmor.yml ran with `persona: pedantic`, while every other repo's standalone zizmor workflow — and Brewy's own ci.yml matrix job — uses `persona: auditor` (the more thorough audit). This aligns the push-time scan with the fleet canonical and with Brewy's own PR-time scan, making the workflow byte-identical to the other four repos. Verified clean locally: `zizmor --persona auditor .github/workflows/` reports no findings.