### PR TITLE
chore: tidy static-analysis configuration

### DIFF
--- a/.swiftlint.yml
+++ b/.swiftlint.yml
@@ -26,7 +26,7 @@ opt_in_rules:
   - prefer_self_in_static_references
   - prefer_self_type_over_type_of_self
   - prefer_zero_over_explicit_init
-  - redundant_self_in_closure
+  - redundant_self
   - self_binding
   - shorthand_optional_binding
   - superfluous_else

--- a/Brewy/Views/ContentView.swift
+++ b/Brewy/Views/ContentView.swift
@@ -26,6 +26,7 @@ struct ContentView: View {
     @State private var selectedGroupItem: PackageGroup?
     @State private var selectedHistoryEntry: ActionHistoryEntry?
     @State private var servicesRefreshTrigger = 0
+    // periphery:ignore - Mutated through PackageListView's searchable binding.
     @State private var searchText = ""
     @State private var showWhatsNew = false
 

--- a/Brewy/Views/DependencyTreeView.swift
+++ b/Brewy/Views/DependencyTreeView.swift
@@ -5,7 +5,9 @@ struct DependencyTreeSection: View {
     private var brewService
     let package: BrewPackage
 
+    // periphery:ignore - Read and written through DisclosureGroup's projected binding.
     @State private var pulledInExpanded = false
+    // periphery:ignore - Read and written through DisclosureGroup's projected binding.
     @State private var pullsInExpanded = false
     @State private var reverse: [DependencyTreeNode] = []
     @State private var forward: [DependencyTreeNode] = []

--- a/Brewy/Views/PackageDetailView.swift
+++ b/Brewy/Views/PackageDetailView.swift
@@ -6,6 +6,7 @@ struct PackageDetailView: View {
     let package: BrewPackage
     @State private var detailedInfo: String = ""
     @State private var isLoadingInfo = false
+    // periphery:ignore - Read and written through ActionBar and confirmationDialog bindings.
     @State private var showUninstallConfirm = false
     @State private var enrichedPackage: BrewPackage?
 

--- a/Brewy/Views/PackageListView.swift
+++ b/Brewy/Views/PackageListView.swift
@@ -14,6 +14,7 @@ struct PackageListView: View {
     @State private var searchScope: SearchScope = .installed
     @State private var searchTask: Task<Void, Never>?
     @State private var isSearchPresented = false
+    // periphery:ignore - Read and written through toolbar and row-selection bindings.
     @State private var selectedForUpgrade: Set<String> = []
     @State private var isSelectingForUpgrade = false
 


### PR DESCRIPTION
Replaces the `redundant_self_in_closure` SwiftLint rule with the broader `redundant_self` rule, and annotates the SwiftUI `@State` properties that are only mutated through projected bindings with `periphery:ignore` so the dead-code scan stops flagging them as unused.
