### PR TITLE
fix: preserve cached package data when a brew fetch fails

### DIFF
--- a/Brewy/Models/BrewService+Fetching.swift
+++ b/Brewy/Models/BrewService+Fetching.swift
@@ -18,15 +18,19 @@ extension BrewService {
             return result.success ? [] : nil
         }
 
-        return await Task.detached(priority: .userInitiated) {
+        let packages: [BrewPackage]? = await Task.detached(priority: .userInitiated) { () -> [BrewPackage]? in
             do {
                 let response = try JSONDecoder().decode(BrewInfoResponse.self, from: data)
                 return (response.formulae ?? []).map { $0.toPackage() }
             } catch {
                 logger.error("Failed to parse formulae JSON: \(error.localizedDescription)")
-                return []
+                return nil
             }
         }.value
+        if packages == nil {
+            lastError = .commandFailed(command: "info --installed --json=v2", output: "Failed to parse Homebrew formulae JSON.")
+        }
+        return packages
     }
 
     func fetchInstalledCasks() async -> [BrewPackage]? {
@@ -38,15 +42,19 @@ extension BrewService {
             return result.success ? [] : nil
         }
 
-        return await Task.detached(priority: .userInitiated) {
+        let packages: [BrewPackage]? = await Task.detached(priority: .userInitiated) { () -> [BrewPackage]? in
             do {
                 let response = try JSONDecoder().decode(BrewInfoResponse.self, from: data)
                 return (response.casks ?? []).map { $0.toPackage() }
             } catch {
                 logger.error("Failed to parse casks JSON: \(error.localizedDescription)")
-                return []
+                return nil
             }
         }.value
+        if packages == nil {
+            lastError = .commandFailed(command: "info --installed --cask --json=v2", output: "Failed to parse Homebrew casks JSON.")
+        }
+        return packages
     }
 
     func fetchOutdatedPackages() async -> [BrewPackage]? {
@@ -58,7 +66,7 @@ extension BrewService {
             return result.success ? [] : nil
         }
 
-        return await Task.detached(priority: .userInitiated) {
+        let packages: [BrewPackage]? = await Task.detached(priority: .userInitiated) { () -> [BrewPackage]? in
             do {
                 let response = try JSONDecoder().decode(BrewOutdatedResponse.self, from: data)
                 let formulae = (response.formulae ?? []).compactMap { $0.toPackage() }
@@ -66,29 +74,37 @@ extension BrewService {
                 return formulae + casks
             } catch {
                 logger.error("Failed to parse outdated JSON: \(error.localizedDescription)")
-                return []
+                return nil
             }
         }.value
+        if packages == nil {
+            lastError = .commandFailed(command: "outdated --json=v2", output: "Failed to parse Homebrew outdated JSON.")
+        }
+        return packages
     }
 
-    func fetchTaps() async -> [BrewTap] {
+    func fetchTaps() async -> [BrewTap]? {
         let result = await runBrewCommand(["tap-info", "--json=v1", "--installed"])
         guard result.success, let data = result.output.data(using: .utf8) else {
             if !result.success {
                 lastError = .commandFailed(command: "tap-info", output: result.output)
             }
-            return []
+            return result.success ? [] : nil
         }
 
-        return await Task.detached(priority: .userInitiated) {
+        let taps: [BrewTap]? = await Task.detached(priority: .userInitiated) { () -> [BrewTap]? in
             do {
                 let taps = try JSONDecoder().decode([TapJSON].self, from: data)
                 return taps.map { $0.toTap() }
             } catch {
                 logger.error("Failed to parse taps JSON: \(error.localizedDescription)")
-                return []
+                return nil
             }
         }.value
+        if taps == nil {
+            lastError = .commandFailed(command: "tap-info --json=v1 --installed", output: "Failed to parse Homebrew taps JSON.")
+        }
+        return taps
     }
 
     // MARK: - Search

--- a/Brewy/Models/BrewService+Taps.swift
+++ b/Brewy/Models/BrewService+Taps.swift
@@ -10,7 +10,7 @@ extension BrewService {
     func ensureTapsLoaded() async {
         guard !tapsLoaded else { return }
         tapsLoaded = true
-        installedTaps = await fetchTaps()
+        installedTaps = await fetchTaps() ?? installedTaps
         saveToCache()
     }
 

--- a/Brewy/Models/BrewService.swift
+++ b/Brewy/Models/BrewService.swift
@@ -274,10 +274,10 @@ final class BrewService {
         // to empty — a transient `brew` failure shouldn't blank out (and then cache) good data.
         let fetchedFormulae = await formulae ?? installedFormulae
         let fetchedCasks = await casks ?? installedCasks
-        let fetchedOutdated = await outdated ?? outdatedPackages
-        let fetchedMasApps = await masApps
-        let fetchedMasOutdated = await masOutdated
-        let fetchedTaps = await taps
+        let fetchedOutdated = await outdated ?? outdatedPackages.filter { $0.source != .mas }
+        let fetchedMasApps = await masApps ?? installedMasApps
+        let fetchedMasOutdated = await masOutdated ?? outdatedPackages.filter(\.isMas)
+        let fetchedTaps = await taps ?? installedTaps
         let allOutdated = fetchedOutdated + fetchedMasOutdated
         let outdatedByID = Dictionary(allOutdated.map { ($0.id, $0) }, uniquingKeysWith: { _, last in last })
 

--- a/Brewy/Models/MasService.swift
+++ b/Brewy/Models/MasService.swift
@@ -105,7 +105,7 @@ enum MasParser {
 
 extension BrewService {
 
-    func fetchInstalledMasApps() async -> [BrewPackage] {
+    func fetchInstalledMasApps() async -> [BrewPackage]? {
         let masPath = CommandRunner.resolvedMasPath()
         guard FileManager.default.isExecutableFile(atPath: masPath) else {
             isMasAvailable = false
@@ -116,19 +116,19 @@ extension BrewService {
         let result = await commandRunner.runExecutable(masPath, arguments: ["list"])
         guard result.success else {
             logger.warning("Failed to fetch installed mas apps")
-            return []
+            return nil
         }
         return MasParser.parseList(result.output)
     }
 
-    func fetchOutdatedMasApps() async -> [BrewPackage] {
+    func fetchOutdatedMasApps() async -> [BrewPackage]? {
         let masPath = CommandRunner.resolvedMasPath()
         guard FileManager.default.isExecutableFile(atPath: masPath) else { return [] }
 
         let result = await commandRunner.runExecutable(masPath, arguments: ["outdated"])
         guard result.success else {
             logger.warning("Failed to fetch outdated mas apps")
-            return []
+            return nil
         }
         return MasParser.parseOutdated(result.output)
     }

--- a/BrewyTests/BrewServiceAsyncTests.swift
+++ b/BrewyTests/BrewServiceAsyncTests.swift
@@ -98,6 +98,27 @@ struct RefreshTests {
         #expect(service.lastError != nil)
     }
 
+    @Test("refresh preserves the previously loaded lists when JSON parsing fails")
+    func refreshPreservesPreviousOnMalformedJSON() async {
+        let mock = MockCommandRunner()
+        let (service, _) = makeService(mock: mock)
+        setupRefreshMock(mock)
+        await service.refresh()
+
+        mock.setResult(for: ["info", "--installed", "--json=v2"], output: "not json")
+        mock.setResult(for: ["info", "--installed", "--cask", "--json=v2"], output: "not json")
+        mock.setResult(for: ["outdated", "--json=v2"], output: "not json")
+        mock.setResult(for: ["tap-info", "--json=v1", "--installed"], output: "not json")
+
+        await service.refresh()
+
+        #expect(service.installedFormulae.count == 1)
+        #expect(service.installedCasks.count == 1)
+        #expect(service.outdatedPackages.count == 1)
+        #expect(service.installedTaps.count == 1)
+        #expect(service.lastError != nil)
+    }
+
     @Test("refresh invalidates info cache when versions change")
     func refreshInvalidatesInfoCache() async {
         let mock = MockCommandRunner()


### PR DESCRIPTION
The installed, outdated, and tap fetch helpers returned an empty array both when brew genuinely had nothing to report and when the command failed or emitted unparseable JSON, so a single transient brew hiccup could overwrite good cached data with an empty list. The helpers now return `nil` to distinguish failure from empty, and `refresh()` falls back to the last-known formulae, casks, outdated packages, mas apps, and taps instead of clobbering them. JSON parse failures also surface a `commandFailed` error so the UI can report them.
