### PR TITLE
fix: run privileged brew services only from a standard Homebrew path

### DIFF
--- a/Brewy/Models/CommandRunner.swift
+++ b/Brewy/Models/CommandRunner.swift
@@ -80,15 +80,24 @@ struct DefaultCommandRunner: CommandRunning {
 enum CommandRunner {
 
     static let defaultTimeout: Duration = .seconds(300)
+    private static let standardBrewPaths = ["/opt/homebrew/bin/brew", "/usr/local/bin/brew"]
 
     /// Grace period between SIGTERM and SIGKILL when a process exceeds its timeout.
     private static let killGracePeriod: Duration = .seconds(3)
 
     static func resolvedBrewPath(preferred: String) -> String {
-        let fallback = "/usr/local/bin/brew"
         if FileManager.default.isExecutableFile(atPath: preferred) { return preferred }
-        if FileManager.default.isExecutableFile(atPath: fallback) { return fallback }
+        for path in standardBrewPaths where FileManager.default.isExecutableFile(atPath: path) {
+            return path
+        }
         return preferred
+    }
+
+    static func resolvedPrivilegedBrewPath(preferred: String) -> String? {
+        if FileManager.default.isExecutableFile(atPath: preferred) {
+            return standardBrewPath(matching: preferred)
+        }
+        return standardBrewPaths.first { FileManager.default.isExecutableFile(atPath: $0) }
     }
 
     static func run(
@@ -153,6 +162,14 @@ enum CommandRunner {
 
         env["PATH"] = pathComponents.joined(separator: ":")
         return env
+    }
+
+    private static func standardBrewPath(matching path: String) -> String? {
+        let resolvedPath = URL(fileURLWithPath: path).resolvingSymlinksInPath().path
+        return standardBrewPaths.first { standardPath in
+            FileManager.default.isExecutableFile(atPath: standardPath)
+                && URL(fileURLWithPath: standardPath).resolvingSymlinksInPath().path == resolvedPath
+        }
     }
 
     /// Convert a `Duration` into a `DispatchTimeInterval` that preserves sub-second precision.

--- a/Brewy/Models/ServicesService.swift
+++ b/Brewy/Models/ServicesService.swift
@@ -61,8 +61,13 @@ extension BrewService {
     }
 
     private func runServiceCommand(_ arguments: [String], asSudo: Bool) async -> CommandResult {
-        let brewPath = CommandRunner.resolvedBrewPath(preferred: customBrewPath)
         if asSudo {
+            guard let brewPath = CommandRunner.resolvedPrivilegedBrewPath(preferred: customBrewPath) else {
+                return CommandResult(
+                    output: "Run as root requires Homebrew at /opt/homebrew/bin/brew or /usr/local/bin/brew.",
+                    success: false
+                )
+            }
             // Run brew as root via the native admin auth dialog. Args pass through osascript's argv
             // and are shell-quoted with `quoted form of`, so nothing is interpolated into the script.
             let script = """
@@ -79,6 +84,7 @@ extension BrewService {
                 arguments: ["-e", script, brewPath] + arguments
             )
         }
+        let brewPath = CommandRunner.resolvedBrewPath(preferred: customBrewPath)
         return await commandRunner.run(arguments, brewPath: brewPath)
     }
 }

--- a/BrewyTests/BrewServiceTests.swift
+++ b/BrewyTests/BrewServiceTests.swift
@@ -294,10 +294,22 @@ struct CommandRunnerTests {
         #expect(path == "/bin/sh")
     }
 
-    @Test("resolvedBrewPath returns preferred path when neither exists")
-    func neitherExists() {
+    @Test("resolvedBrewPath falls back to a standard Homebrew path when preferred is missing")
+    func fallbackPath() {
         let path = CommandRunner.resolvedBrewPath(preferred: "/nonexistent/brew")
-        #expect(path == "/nonexistent/brew")
+        if FileManager.default.isExecutableFile(atPath: "/opt/homebrew/bin/brew") {
+            #expect(path == "/opt/homebrew/bin/brew")
+        } else if FileManager.default.isExecutableFile(atPath: "/usr/local/bin/brew") {
+            #expect(path == "/usr/local/bin/brew")
+        } else {
+            #expect(path == "/nonexistent/brew")
+        }
+    }
+
+    @Test("resolvedPrivilegedBrewPath rejects non-standard executables")
+    func privilegedPathRejectsNonStandardExecutable() {
+        let path = CommandRunner.resolvedPrivilegedBrewPath(preferred: "/bin/sh")
+        #expect(path == nil)
     }
 }
 


### PR DESCRIPTION
Service actions run as root previously went through the user-configurable brew path, which meant an arbitrary executable could be launched with elevated privileges via the admin auth dialog. The privileged path now resolves only to a standard Homebrew location (`/opt/homebrew/bin/brew` or `/usr/local/bin/brew`), and the sudo branch fails closed with a clear message when no standard brew is found. Non-privileged commands continue to honor the configured path.
