### PR TITLE
chore(deps): bump Sparkle to 2.9.3

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -196,8 +196,8 @@ jobs:
         env:
           # Keep in lockstep with the Sparkle version pinned in Package.resolved; verify the
           # download against a known SHA-256 before running sign_update against the private key.
-          SPARKLE_VERSION: "2.9.2"
-          SPARKLE_SHA256: "1cb340cbbef04c6c0d162078610c25e2221031d794a3449d89f2f56f4df77c95"
+          SPARKLE_VERSION: "2.9.3"
+          SPARKLE_SHA256: "74a07da821f92b79310009954c0e15f350173374a3abe39095b4fc5096916be6"
         run: |
           curl -fsSL -o "${RUNNER_TEMP}/sparkle.tar.xz" \
             "https://github.com/sparkle-project/Sparkle/releases/download/${SPARKLE_VERSION}/Sparkle-${SPARKLE_VERSION}.tar.xz"

--- a/Brewy.xcodeproj/project.xcworkspace/xcshareddata/swiftpm/Package.resolved
+++ b/Brewy.xcodeproj/project.xcworkspace/xcshareddata/swiftpm/Package.resolved
@@ -6,8 +6,8 @@
       "kind" : "remoteSourceControl",
       "location" : "https://github.com/sparkle-project/Sparkle",
       "state" : {
-        "revision" : "6276ba2b404829d139c45ff98427cf90e2efc59b",
-        "version" : "2.9.2"
+        "revision" : "d46d456107feacc80711b21847b82b07bd9fb46e",
+        "version" : "2.9.3"
       }
     }
   ],


### PR DESCRIPTION
Updates the resolved Swift package and the release workflow's pinned version and SHA-256 checksum from 2.9.2 to 2.9.3.
