### PR TITLE
ci: treat Swift warnings as errors and stop tracing the release shell

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -186,6 +186,7 @@ jobs:
             CODE_SIGN_IDENTITY="" \
             CODE_SIGNING_REQUIRED=NO \
             CODE_SIGNING_ALLOWED=NO \
+            SWIFT_TREAT_WARNINGS_AS_ERRORS=YES \
             EXCLUDED_ARCHS=x86_64
 
       - name: Coverage Summary
@@ -289,6 +290,7 @@ jobs:
             CODE_SIGN_IDENTITY="" \
             CODE_SIGNING_REQUIRED=NO \
             CODE_SIGNING_ALLOWED=NO \
+            SWIFT_TREAT_WARNINGS_AS_ERRORS=YES \
             EXCLUDED_ARCHS=x86_64 \
             build
 

--- a/.github/workflows/codeql.yml
+++ b/.github/workflows/codeql.yml
@@ -46,6 +46,7 @@ jobs:
             CODE_SIGN_IDENTITY="" \
             CODE_SIGNING_REQUIRED=NO \
             CODE_SIGNING_ALLOWED=NO \
+            SWIFT_TREAT_WARNINGS_AS_ERRORS=YES \
             EXCLUDED_ARCHS=x86_64 \
             build
 

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -5,7 +5,7 @@ on:
 
 defaults:
   run:
-    shell: bash -xeuo pipefail {0}
+    shell: bash -euo pipefail {0}
 
 concurrency:
   group: release
@@ -67,8 +67,7 @@ jobs:
 
       - name: Create and unlock temporary macOS keychain
         run: |
-          # Disable xtrace for this step: the default `bash -xeuo` would otherwise trace the
-          # runtime-generated keychain password (not a registered secret, so unmasked) into the log.
+          # Keep xtrace disabled here: this password is generated at runtime and is not a registered secret.
           set +x
           TEMPORARY_KEYCHAIN_PASSWORD="$(openssl rand -base64 20)"
           echo "::add-mask::${TEMPORARY_KEYCHAIN_PASSWORD}"
@@ -109,6 +108,7 @@ jobs:
             CODE_SIGN_STYLE=Manual \
             CODE_SIGN_IDENTITY="Developer ID Application" \
             DEVELOPMENT_TEAM="${DEVELOPMENT_TEAM}" \
+            SWIFT_TREAT_WARNINGS_AS_ERRORS=YES \
             EXCLUDED_ARCHS=x86_64
 
       - name: Export

--- a/justfile
+++ b/justfile
@@ -10,6 +10,7 @@ build:
         CODE_SIGN_IDENTITY="" \
         CODE_SIGNING_REQUIRED=NO \
         CODE_SIGNING_ALLOWED=NO \
+        SWIFT_TREAT_WARNINGS_AS_ERRORS=YES \
         EXCLUDED_ARCHS=x86_64 \
         build
 
@@ -38,6 +39,7 @@ test:
         CODE_SIGN_IDENTITY="" \
         CODE_SIGNING_REQUIRED=NO \
         CODE_SIGNING_ALLOWED=NO \
+        SWIFT_TREAT_WARNINGS_AS_ERRORS=YES \
         EXCLUDED_ARCHS=x86_64
 
 # Lint
@@ -105,6 +107,7 @@ check:
         CODE_SIGN_IDENTITY="" \
         CODE_SIGNING_REQUIRED=NO \
         CODE_SIGNING_ALLOWED=NO \
+        SWIFT_TREAT_WARNINGS_AS_ERRORS=YES \
         EXCLUDED_ARCHS=x86_64
     if [ ${#skipped[@]} -gt 0 ]; then
         echo ""


### PR DESCRIPTION
Passes `SWIFT_TREAT_WARNINGS_AS_ERRORS=YES` to every xcodebuild invocation across the CI, CodeQL, and release workflows and the justfile recipes, so local and CI builds fail on warnings consistently. Also drops the global `-x` xtrace from the release workflow's default shell so it no longer traces command arguments into the logs by default; the keychain step keeps its explicit `set +x` for the runtime-generated password.
