### PR TITLE
ci: run periphery dead-code scan

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -65,6 +65,11 @@ jobs:
             MATRIX+=',{"name":"Test (Address Sanitizer)","check":"test-asan","runner":"macos-26","xcodebuild_flags":"-enableAddressSanitizer YES -skip-testing:BrewyUITests","result_bundle":"TestResults-ASAN"}'
           fi
 
+          # Source or periphery-config changes: dead-code scan
+          if echo "${CHANGED}" | grep -qE '\.swift$|^Brewy\.xcodeproj/|^\.periphery\.yml$|^\.github/workflows/ci\.yml$'; then
+            MATRIX+=',{"name":"Periphery","check":"periphery","runner":"macos-26"}'
+          fi
+
           # Source changes: CodeQL (excludes xcodeproj-only changes like version bumps)
           if echo "${CHANGED}" | grep -qE '^Brewy/|^BrewyTests/|^BrewyUITests/'; then
             MATRIX+=',{"name":"CodeQL","check":"codeql","runner":"macos-26"}'
@@ -167,6 +172,23 @@ jobs:
       - name: Typos
         if: matrix.check == 'lint'
         run: typos
+
+      # --- Periphery (dead-code scan) ---
+
+      - name: Install Periphery
+        if: matrix.check == 'periphery'
+        env:
+          HOMEBREW_NO_AUTO_UPDATE: 1
+          HOMEBREW_NO_ENV_HINTS: 1
+        run: brew install periphery
+
+      - name: Periphery
+        if: matrix.check == 'periphery'
+        # --no-superfluous-ignore-comments: CI's toolchain resolves the SwiftUI $-binding refs the
+        # local one misses, so it would otherwise flag the periphery:ignore comments as redundant.
+        run: |
+          periphery scan --strict --disable-update-check --no-superfluous-ignore-comments \
+            -- CODE_SIGNING_REQUIRED=NO CODE_SIGNING_ALLOWED=NO EXCLUDED_ARCHS=x86_64
 
       # --- Tests ---
 

--- a/justfile
+++ b/justfile
@@ -92,7 +92,8 @@ check:
         skip audit zizmor zizmor
     fi
     if command -v periphery &>/dev/null; then
-        run periphery scan --strict --disable-update-check
+        # Match CI: tolerate periphery:ignore comments CI sees as redundant (SwiftUI $-binding refs).
+        run periphery scan --strict --disable-update-check --no-superfluous-ignore-comments
     else
         skip periphery periphery periphery
     fi


### PR DESCRIPTION
Periphery (dead-code detection) already runs in `just check` and the pre-push hook, but no workflow enforced it — the hook's "runs the same checks as CI" comment was inaccurate. This adds Periphery as a path-gated entry in the CI matrix, triggered on Swift, xcodeproj, `.periphery.yml`, and `ci.yml` changes (mirroring how Lint is gated), running `periphery scan --strict` with code signing disabled via the build settings after `--`.

It also passes `--no-superfluous-ignore-comments` in both the workflow and the justfile recipe: the CI toolchain resolves the SwiftUI `$`-binding references that the local toolchain misses, so the `periphery:ignore` annotations that keep the local scan quiet would otherwise be flagged as redundant in CI. Tolerating them lets the same annotations pass `--strict` in both environments while still failing on genuinely unused code.
