### PR TITLE
ci: open a tap cask bump on release

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -281,3 +281,39 @@ jobs:
           git diff --cached --quiet && exit 0
           git commit -m "Update appcast for ${TAG}"
           git push origin appcast
+
+  bump-cask:
+    name: Bump tap cask
+    needs: [build, release]
+    runs-on: macos-26
+    environment:
+      name: release
+      deployment: false
+    permissions: {}
+    env:
+      VERSION: ${{ needs.build.outputs.tag }}
+    steps:
+      - name: Mint bot token for tap
+        id: tap-token
+        uses: actions/create-github-app-token@bcd2ba49218906704ab6c1aa796996da409d3eb1 # v3.2.0
+        with:
+          client-id: ${{ vars.APP_CLIENT_ID }}
+          private-key: ${{ secrets.APP_PRIVATE_KEY }}
+          owner: ${{ github.repository_owner }}
+          repositories: homebrew-tap
+          permission-contents: write
+          permission-pull-requests: write
+
+      - name: Bump Homebrew cask
+        env:
+          HOMEBREW_GITHUB_API_TOKEN: ${{ steps.tap-token.outputs.token }}
+          HOMEBREW_NO_AUTO_UPDATE: 1
+          HOMEBREW_NO_ENV_HINTS: 1
+          APP_SLUG: ${{ steps.tap-token.outputs.app-slug }}
+        run: |
+          BOT_USER="${APP_SLUG}[bot]"
+          BOT_ID=$(GH_TOKEN="${HOMEBREW_GITHUB_API_TOKEN}" gh api "/users/${BOT_USER}" --jq .id)
+          export HOMEBREW_GIT_NAME="${BOT_USER}"
+          export HOMEBREW_GIT_EMAIL="${BOT_ID}+${BOT_USER}@users.noreply.github.com"
+          brew tap starhaven-io/homebrew-tap
+          brew bump-cask-pr --no-fork --version "${VERSION}" starhaven-io/tap/brewy

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -73,7 +73,7 @@ Brewy/
 ├── .github/
 │   ├── workflows/
 │   │   ├── ci.yml                          # Unified PR checks: dynamic matrix runs lint, TSAN, ASAN, CodeQL, zizmor, Conventional Commits
-│   │   ├── release.yml                     # Manual dispatch: archive, sign, notarize, Sparkle EdDSA, appcast, GitHub release, auto-bump Homebrew cask
+│   │   ├── release.yml                     # Manual dispatch: archive, sign, notarize, Sparkle EdDSA, appcast, GitHub release, bump tap cask
 │   │   ├── codeql.yml                      # Scheduled CodeQL analysis (on-push/scheduled, separate from PR matrix)
 │   │   ├── pinprick-audit.yml              # Audits dependency permissions via pinprick
 │   │   └── zizmor.yml                      # Scheduled GitHub Actions security scanning
@@ -250,7 +250,7 @@ mas install ID                               # Install Mac App Store app
 6. Sign with Sparkle EdDSA key
 7. Create GitHub release with auto-generated + formatted notes
 8. Update appcast.xml on the `appcast` branch
-9. Auto-bump the Homebrew cask via `brew bump --open-pr --casks brewy`
+9. Open a version-bump PR for the cask in the `starhaven-io/homebrew-tap` tap (the `bump-cask` job, via `brew bump-cask-pr --no-fork`). Brewy is also published in `Homebrew/homebrew-cask`, which `BrewTestBot` autobumps independently from the Sparkle appcast.
 
 ## Commit conventions
 


### PR DESCRIPTION
Adds a bump-cask job to the release workflow: on each release it mints a GitHub App token scoped to homebrew-tap and runs brew bump-cask-pr --no-fork to open a version-bump PR for starhaven-io/homebrew-tap/brewy, matching macOSdb/pinprick/midden. Brewy stays in Homebrew/homebrew-cask too (autobumped by BrewTestBot), so the two run in parallel. Also corrects the CLAUDE.md release section, which referenced a brew bump --open-pr step the workflow never actually had.