### PR TITLE
docs: note the starhaven-io tap as an install option

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -10,6 +10,7 @@ Brewy is a native macOS GUI for managing Homebrew packages, written in Swift/Swi
 - **Only external dependency:** Sparkle via Swift Package Manager for auto-updates
 - **Bundle ID:** `io.linnane.brewy`
 - **License:** AGPL-3.0-only
+- **Distribution:** Homebrew — [homebrew-cask](https://github.com/Homebrew/homebrew-cask) (autobumped by BrewTestBot) and the [`starhaven-io/homebrew-tap`](https://github.com/starhaven-io/homebrew-tap) cask (bumped by `release.yml`)
 
 ## Repository structure
 

--- a/README.md
+++ b/README.md
@@ -34,10 +34,16 @@ A native macOS app for managing [Homebrew](https://brew.sh) packages. Browse, se
 
 ## Installation
 
-The best way to install Brewy is naturally with Homebrew:
+The best way to install Brewy is naturally with Homebrew. It's in [homebrew-cask](https://github.com/Homebrew/homebrew-cask):
 
 ```sh
 brew install brewy
+```
+
+…or from the [starhaven-io tap](https://github.com/starhaven-io/homebrew-tap):
+
+```sh
+brew install starhaven-io/tap/brewy
 ```
 
 You can also grab the latest release from the [GitHub releases page](https://github.com/starhaven-io/Brewy/releases).


### PR DESCRIPTION
Brewy is now available from starhaven-io/homebrew-tap in parallel with homebrew-cask. Documents the tap install command in the README and adds a distribution note to CLAUDE.md (homebrew-cask, autobumped by BrewTestBot; the tap, bumped by the release workflow).