### PR TITLE
fix(command): preserve failure diagnostics

### DIFF
--- a/Brewy/Models/CommandRunner.swift
+++ b/Brewy/Models/CommandRunner.swift
@@ -214,19 +214,50 @@ enum CommandRunner {
         timeoutWork.cancel()
         let out = stdoutData.wait()
         let err = stderrData.wait()
+        let stdout = String(data: out, encoding: .utf8) ?? ""
+        let stderr = String(data: err, encoding: .utf8) ?? ""
 
         if timedOut.isSet {
             return CommandResult(
-                output: "Command timed out after \(timeout).",
+                output: timeoutOutput(stdout: stdout, stderr: stderr, timeout: timeout),
                 success: false
             )
         }
-        let stdout = String(data: out, encoding: .utf8) ?? ""
-        let stderr = String(data: err, encoding: .utf8) ?? ""
         return CommandResult(
-            output: stdout.isEmpty ? stderr : stdout,
+            output: commandOutput(stdout: stdout, stderr: stderr, terminationStatus: process.terminationStatus),
             success: process.terminationStatus == 0
         )
+    }
+
+    private static func commandOutput(stdout: String, stderr: String, terminationStatus: Int32) -> String {
+        if terminationStatus == 0 {
+            return stdout.isEmpty ? stderr : stdout
+        }
+        let combined = combinedStreams(stdout: stdout, stderr: stderr)
+        return combined.isEmpty ? "Command failed with exit code \(terminationStatus)." : combined
+    }
+
+    private static func combinedStreams(stdout: String, stderr: String) -> String {
+        switch (stdout.isEmpty, stderr.isEmpty) {
+        case (true, true):
+            return ""
+        case (true, false):
+            return stderr
+        case (false, true):
+            return stdout
+        case (false, false):
+            let separator = stdout.hasSuffix("\n") || stderr.hasPrefix("\n") ? "" : "\n"
+            return stdout + separator + stderr
+        }
+    }
+
+    private static func timeoutOutput(stdout: String, stderr: String, timeout: Duration) -> String {
+        let partialOutput = combinedStreams(stdout: stdout, stderr: stderr)
+            .trimmingCharacters(in: .whitespacesAndNewlines)
+        guard !partialOutput.isEmpty else {
+            return "Command timed out after \(timeout)."
+        }
+        return "Command timed out after \(timeout).\n\(partialOutput)"
     }
 
     private static func drainPipesInParallel(stdout: Pipe, stderr: Pipe) -> (stdout: PipeReader, stderr: PipeReader) {

--- a/BrewyTests/CommandRunnerTests.swift
+++ b/BrewyTests/CommandRunnerTests.swift
@@ -86,6 +86,28 @@ struct CommandRunnerProcessTests {
         )
         #expect(result.success)
         #expect(result.output.contains("stdout-line"))
+        #expect(!result.output.contains("stderr-line"))
+    }
+
+    @Test("runExecutable includes stderr on failure when stdout exists")
+    func failureCombinesStdoutAndStderr() async {
+        let result = await CommandRunner.runExecutable(
+            "/bin/sh",
+            arguments: ["-c", "echo stdout-line; echo stderr-line >&2; exit 2"]
+        )
+        #expect(!result.success)
+        #expect(result.output.contains("stdout-line"))
+        #expect(result.output.contains("stderr-line"))
+    }
+
+    @Test("runExecutable reports the exit code when failure has no output")
+    func failureWithNoOutputReportsExitCode() async {
+        let result = await CommandRunner.runExecutable(
+            "/bin/sh",
+            arguments: ["-c", "exit 3"]
+        )
+        #expect(!result.success)
+        #expect(result.output.contains("exit code 3"))
     }
 
     @Test("runExecutable times out a long-running process")
@@ -99,6 +121,18 @@ struct CommandRunnerProcessTests {
         let elapsed = ContinuousClock.now - start
         #expect(!result.success)
         #expect(elapsed < .seconds(15))
+    }
+
+    @Test("runExecutable includes partial output on timeout")
+    func timeoutIncludesPartialOutput() async {
+        let result = await CommandRunner.runExecutable(
+            "/bin/sh",
+            arguments: ["-c", "echo before-timeout; sleep 30"],
+            timeout: .seconds(1)
+        )
+        #expect(!result.success)
+        #expect(result.output.contains("Command timed out"))
+        #expect(result.output.contains("before-timeout"))
     }
 
     @Test("runExecutable handles missing executable gracefully")


### PR DESCRIPTION
On a non-zero exit, `CommandRunner` surfaced only stdout and dropped stderr — where the real error usually is. Failures now combine both streams, fall back to the exit code when a command produces no output, and timeouts include any partial output captured before the process was killed. Success output is unchanged (stdout only).