### PR TITLE
ci: trust the starhaven-io tap for Homebrew 6

### DIFF
--- a/.github/workflows/pinprick-audit.yml
+++ b/.github/workflows/pinprick-audit.yml
@@ -27,7 +27,10 @@ jobs:
           persist-credentials: false
 
       - name: Install pinprick
-        run: /home/linuxbrew/.linuxbrew/bin/brew install starhaven-io/tap/pinprick
+        run: |
+          /home/linuxbrew/.linuxbrew/bin/brew tap starhaven-io/tap
+          /home/linuxbrew/.linuxbrew/bin/brew trust starhaven-io/tap
+          /home/linuxbrew/.linuxbrew/bin/brew install starhaven-io/tap/pinprick
 
       - name: Run pinprick audit
         env:

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -315,5 +315,6 @@ jobs:
           BOT_ID=$(GH_TOKEN="${HOMEBREW_GITHUB_API_TOKEN}" gh api "/users/${BOT_USER}" --jq .id)
           export HOMEBREW_GIT_NAME="${BOT_USER}"
           export HOMEBREW_GIT_EMAIL="${BOT_ID}+${BOT_USER}@users.noreply.github.com"
-          brew tap starhaven-io/homebrew-tap
+          brew tap starhaven-io/tap
+          brew trust starhaven-io/tap
           brew bump-cask-pr --no-fork --version "${VERSION}" starhaven-io/tap/brewy


### PR DESCRIPTION
Homebrew 6 requires third-party taps to be trusted before installing from them; without it brew falls into an interactive trust path with no TTY in CI and the pinprick install aborts with a broken pipe. Adds `brew tap` + `brew trust starhaven-io/tap` before installing pinprick (audit workflow) and before `brew bump-cask-pr` (release workflow). Fixes the failing pinprick audit check.