### PR TITLE
chore: ignore DerivedData* build output

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -18,5 +18,5 @@ appcast.xml
 *.xccheckout
 *.xcscmblueprint
 build/
-DerivedData/
+DerivedData*/
 xcuserdata/

--- a/.swiftlint.yml
+++ b/.swiftlint.yml
@@ -2,6 +2,7 @@ excluded:
   - .build
   - Brewy.xcodeproj
   - DerivedData
+  - DerivedDataUnit
 
 opt_in_rules:
   # Performance

--- a/_typos.toml
+++ b/_typos.toml
@@ -1,2 +1,2 @@
 [files]
-extend-exclude = ["*.xcodeproj/**"]
+extend-exclude = ["*.xcodeproj/**", "DerivedData*/**"]


### PR DESCRIPTION
Broadens the git and typos ignores to `DerivedData*` and adds the `DerivedDataUnit` path to SwiftLint excludes, so alternate derived-data locations used by local and CI runs stay out of version control, linting, and spell-checking.