### PR TITLE
fix(security): restrict external metadata URLs

### DIFF
--- a/Brewy/Models/ExternalURLPolicy.swift
+++ b/Brewy/Models/ExternalURLPolicy.swift
@@ -1,0 +1,19 @@
+import Foundation
+
+enum ExternalURLPolicy {
+    private static let allowedSchemes: Set<String> = ["http", "https"]
+
+    static func url(from string: String) -> URL? {
+        url(from: URL(string: string.trimmingCharacters(in: .whitespacesAndNewlines)))
+    }
+
+    static func url(from url: URL?) -> URL? {
+        guard let url,
+              let scheme = url.scheme?.lowercased(),
+              allowedSchemes.contains(scheme),
+              url.host?.isEmpty == false else {
+            return nil
+        }
+        return url
+    }
+}

--- a/Brewy/Models/PackageModel.swift
+++ b/Brewy/Models/PackageModel.swift
@@ -91,7 +91,7 @@ struct TapHealthStatus: Codable, Equatable {
     }
 
     static func parseGitHubRepo(from remote: String) -> (owner: String, repo: String)? {
-        guard let url = URL(string: remote),
+        guard let url = ExternalURLPolicy.url(from: remote),
               url.host == "github.com" || url.host == "www.github.com" else {
             return nil
         }

--- a/Brewy/Views/MasSetupView.swift
+++ b/Brewy/Views/MasSetupView.swift
@@ -45,12 +45,14 @@ struct MasSetupView: View {
                 }
             }
 
-            Link(destination: URL(string: "https://github.com/mas-cli/mas")!) {
-                Label("Learn more about mas", systemImage: "globe")
-                    .font(.callout)
+            if let masURL = ExternalURLPolicy.url(from: "https://github.com/mas-cli/mas") {
+                Link(destination: masURL) {
+                    Label("Learn more about mas", systemImage: "globe")
+                        .font(.callout)
+                }
+                .buttonStyle(.plain)
+                .foregroundStyle(.secondary)
             }
-            .buttonStyle(.plain)
-            .foregroundStyle(.secondary)
         }
         .frame(maxWidth: .infinity, maxHeight: .infinity)
         .background(.background)

--- a/Brewy/Views/PackageDetailView.swift
+++ b/Brewy/Views/PackageDetailView.swift
@@ -193,7 +193,7 @@ private struct ActionBar: View {
                 notInstalledActionsMenu
             }
 
-            if !package.homepage.isEmpty, let url = URL(string: package.homepage) {
+            if let url = ExternalURLPolicy.url(from: package.homepage) {
                 Link(destination: url) {
                     Label(package.isMas ? "App Store" : "Homepage", systemImage: package.isMas ? "app.badge.fill" : "globe")
                 }

--- a/Brewy/Views/ReleaseNotesHTML.swift
+++ b/Brewy/Views/ReleaseNotesHTML.swift
@@ -1,0 +1,61 @@
+import SwiftUI
+
+enum ReleaseNotesHTML {
+    private static let blockedTagPattern = [
+        #"<\s*(script|style|iframe|object|embed|img|source|"#,
+        #"video|audio|link|meta|base)\b[^>]*(?:>.*?<\s*/\s*\1\s*>|/?>)"#
+    ].joined()
+
+    static func attributedString(from html: String) -> AttributedString? {
+        let safeHTML = stripUnsafeMarkup(from: html)
+        guard let data = safeHTML.data(using: .utf8),
+              let nsAttr = try? NSAttributedString(
+                data: data,
+                options: [
+                    .documentType: NSAttributedString.DocumentType.html,
+                    .characterEncoding: String.Encoding.utf8.rawValue
+                ],
+                documentAttributes: nil
+              )
+        else { return nil }
+
+        let sanitized = NSMutableAttributedString(attributedString: nsAttr)
+        let fullRange = NSRange(location: 0, length: sanitized.length)
+        sanitized.enumerateAttribute(.link, in: fullRange) { value, range, _ in
+            guard safeLink(from: value) != nil else {
+                sanitized.removeAttribute(.link, range: range)
+                return
+            }
+        }
+        sanitized.removeAttribute(.attachment, range: fullRange)
+        return try? AttributedString(sanitized, including: \.swiftUI)
+    }
+
+    static func stripUnsafeMarkup(from html: String) -> String {
+        guard let regex = try? NSRegularExpression(
+            pattern: blockedTagPattern,
+            options: [.caseInsensitive, .dotMatchesLineSeparators]
+        ) else { return html }
+        // Re-run until stable: removing one tag can re-form another
+        // (e.g. "<<img>img src=x>" collapses to "<img src=x>"), so a single
+        // pass leaks. Each pass strips at least one character, so this ends.
+        var current = html
+        while true {
+            let fullRange = NSRange(current.startIndex..., in: current)
+            let stripped = regex.stringByReplacingMatches(in: current, range: fullRange, withTemplate: "")
+            if stripped == current { return current }
+            current = stripped
+        }
+    }
+
+    private static func safeLink(from value: Any?) -> URL? {
+        switch value {
+        case let url as URL:
+            return ExternalURLPolicy.url(from: url)
+        case let string as String:
+            return ExternalURLPolicy.url(from: string)
+        default:
+            return nil
+        }
+    }
+}

--- a/Brewy/Views/TapListView.swift
+++ b/Brewy/Views/TapListView.swift
@@ -256,7 +256,7 @@ struct TapDetailView: View {
                 LabeledContent("Name", value: tap.name)
                 if !tap.remote.isEmpty {
                     LabeledContent("Remote") {
-                        if let url = URL(string: tap.remote) {
+                        if let url = ExternalURLPolicy.url(from: tap.remote) {
                             Link(tap.remote, destination: url)
                                 .foregroundStyle(.link)
                         } else {
@@ -356,7 +356,7 @@ private struct TapHealthWarningSection: View {
                     Text(warningMessage)
                         .font(.callout)
                     if let movedTo = healthStatus.movedTo,
-                       let url = URL(string: movedTo) {
+                       let url = ExternalURLPolicy.url(from: movedTo) {
                         Link("View new repository", destination: url)
                             .font(.callout)
                     }

--- a/Brewy/Views/WhatsNewView.swift
+++ b/Brewy/Views/WhatsNewView.swift
@@ -92,22 +92,6 @@ struct WhatsNewView: View {
         }
     }
 
-    // MARK: - HTML Rendering
-
-    private static func attributedString(from html: String) -> AttributedString? {
-        guard let data = html.data(using: .utf8),
-              let nsAttr = try? NSAttributedString(
-                data: data,
-                options: [
-                    .documentType: NSAttributedString.DocumentType.html,
-                    .characterEncoding: String.Encoding.utf8.rawValue
-                ],
-                documentAttributes: nil
-              )
-        else { return nil }
-        return try? AttributedString(nsAttr, including: \.swiftUI)
-    }
-
     // MARK: - Networking
 
     private func fetchLatestRelease() async {
@@ -115,7 +99,7 @@ struct WhatsNewView: View {
         errorMessage = nil
 
         guard let feedURL = Bundle.main.object(forInfoDictionaryKey: "SUFeedURL") as? String,
-              let url = URL(string: feedURL) else {
+              let url = ExternalURLPolicy.url(from: feedURL) else {
             errorMessage = "No update feed configured."
             isLoading = false
             return
@@ -137,7 +121,7 @@ struct WhatsNewView: View {
             release = loaded
 
             if let html = loaded?.descriptionHTML {
-                parsedNotes = Self.attributedString(from: html)
+                parsedNotes = ReleaseNotesHTML.attributedString(from: html)
             }
             if loaded == nil {
                 errorMessage = "No release notes found."

--- a/BrewyTests/SecurityHelpersTests.swift
+++ b/BrewyTests/SecurityHelpersTests.swift
@@ -1,0 +1,63 @@
+@testable import Brewy
+import Foundation
+import SwiftUI
+import Testing
+
+@Suite("ExternalURLPolicy")
+struct ExternalURLPolicyTests {
+
+    @Test("Allows HTTP and HTTPS URLs with hosts")
+    func allowsWebURLs() {
+        #expect(ExternalURLPolicy.url(from: "https://example.com/path")?.host == "example.com")
+        #expect(ExternalURLPolicy.url(from: "http://example.com/path")?.scheme == "http")
+    }
+
+    @Test("Rejects local custom and malformed URLs")
+    func rejectsUnsafeURLs() {
+        #expect(ExternalURLPolicy.url(from: "file:///etc/passwd") == nil)
+        #expect(ExternalURLPolicy.url(from: "javascript:alert(1)") == nil)
+        #expect(ExternalURLPolicy.url(from: "data:text/plain,hello") == nil)
+        #expect(ExternalURLPolicy.url(from: "https:///missing-host") == nil)
+    }
+}
+
+@Suite("ReleaseNotesHTML")
+struct ReleaseNotesHTMLTests {
+
+    @Test("Removes unsafe link attributes")
+    func removesUnsafeLinks() throws {
+        let html = #"""
+        <p>
+          <a href="javascript:alert(1)">bad</a>
+          <a href="file:///tmp/bad">file</a>
+          <a href="https://example.com/release">good</a>
+        </p>
+        """#
+
+        let attributed = try #require(ReleaseNotesHTML.attributedString(from: html))
+        let links = attributed.runs.compactMap(\.link)
+
+        #expect(links == [URL(string: "https://example.com/release")])
+    }
+
+    @Test("Strips external resource tags")
+    func stripsExternalResourceTags() throws {
+        let html = #"<p>Before</p><img src="https://example.com/tracker.png"><p>After</p>"#
+        let attributed = try #require(ReleaseNotesHTML.attributedString(from: html))
+
+        #expect(String(attributed.characters).contains("Before"))
+        #expect(String(attributed.characters).contains("After"))
+        #expect(String(attributed.characters).contains("\u{fffc}") == false)
+    }
+
+    @Test("Strips resource tags that re-form after a single pass")
+    func stripsReformingResourceTags() {
+        // A naive single pass turns this into a live "<img src=...>" that would
+        // trigger a network load; the fixed-point strip must remove it entirely.
+        let payload = #"<<img>img src="https://evil.example/beacon.png">"#
+        let stripped = ReleaseNotesHTML.stripUnsafeMarkup(from: payload)
+
+        #expect(stripped.range(of: "<img", options: .caseInsensitive) == nil)
+        #expect(stripped.range(of: "src=", options: .caseInsensitive) == nil)
+    }
+}

--- a/BrewyTests/TapAndConfigTests.swift
+++ b/BrewyTests/TapAndConfigTests.swift
@@ -78,6 +78,12 @@ struct ParseGitHubRepoTests {
         #expect(result == nil)
     }
 
+    @Test("Returns nil for non-web GitHub-looking URLs")
+    func nonWebGitHubURL() {
+        #expect(TapHealthStatus.parseGitHubRepo(from: "file://github.com/Homebrew/homebrew-core") == nil)
+        #expect(TapHealthStatus.parseGitHubRepo(from: "javascript://github.com/Homebrew/homebrew-core") == nil)
+    }
+
     @Test("Returns nil for empty string")
     func emptyString() {
         let result = TapHealthStatus.parseGitHubRepo(from: "")


### PR DESCRIPTION
Adds `ExternalURLPolicy` (http/https with a non-empty host only) and routes every externally-opened link from package, tap, and appcast metadata through it. Adds `ReleaseNotesHTML` to strip resource-loading tags (to a fixed point, so a tag re-forming after one pass cannot slip through) and non-web links before rendering Sparkle release notes.