### PR TITLE
fix(app): guard destructive package actions

### DIFF
--- a/Brewy/BrewyApp.swift
+++ b/Brewy/BrewyApp.swift
@@ -53,9 +53,10 @@ struct BrewyApp: App {
                     Task { await brewService.upgradeAll() }
                 }
                 .keyboardShortcut("u", modifiers: .command)
+                .disabled(brewService.homebrewOutdatedPackages.isEmpty)
 
                 Button("Cleanup...") {
-                    Task { await brewService.cleanup() }
+                    NotificationCenter.default.post(name: .showCleanupPreview, object: nil)
                 }
             }
             CommandGroup(replacing: .help) {
@@ -124,12 +125,15 @@ private struct MenuBarView: View {
 
     var body: some View {
         let outdatedCount = brewService.outdatedPackages.count
+        let homebrewOutdatedCount = brewService.homebrewOutdatedPackages.count
 
         if outdatedCount > 0 {
             Text("\(outdatedCount) package\(outdatedCount == 1 ? "" : "s") outdated")
-            Divider()
-            Button("Upgrade All") {
-                Task { await brewService.upgradeAll() }
+            if homebrewOutdatedCount > 0 {
+                Divider()
+                Button("Upgrade Homebrew Packages") {
+                    Task { await brewService.upgradeAll() }
+                }
             }
         } else {
             Text("All packages up to date")

--- a/Brewy/Models/ActionHistoryEntry+Commands.swift
+++ b/Brewy/Models/ActionHistoryEntry+Commands.swift
@@ -1,0 +1,12 @@
+extension ActionHistoryEntry {
+    var isMutatingCommand: Bool {
+        guard let command = arguments.first else { return false }
+        return Self.mutatingCommands.contains(command)
+    }
+
+    private static let mutatingCommands: Set<String> = [
+        "install", "uninstall", "upgrade", "reinstall",
+        "link", "unlink", "autoremove", "cleanup", "update",
+        "tap", "untap"
+    ]
+}

--- a/Brewy/Models/BrewService+Actions.swift
+++ b/Brewy/Models/BrewService+Actions.swift
@@ -30,10 +30,6 @@ extension BrewService {
     func link(package: BrewPackage) async { await performAction("link", package: package) }
     func unlink(package: BrewPackage) async { await performAction("unlink", package: package) }
 
-    func cleanup() async {
-        await performBrewAction(["cleanup", "--prune=all"])
-    }
-
     // MARK: - Action Helpers
 
     func performBrewAction(_ arguments: [String], refreshAfter: Bool = false) async {

--- a/Brewy/Models/BrewService+Actions.swift
+++ b/Brewy/Models/BrewService+Actions.swift
@@ -60,6 +60,10 @@ extension BrewService {
     func performAction(_ action: String, package: BrewPackage) async {
         guard !package.isMas else {
             logger.warning("Cannot perform brew action \(action) on mas package \(package.name)")
+            lastError = .commandFailed(
+                command: action,
+                output: "Mac App Store apps are managed outside Homebrew. Open the App Store to update \(package.name)."
+            )
             return
         }
         guard !isPerformingAction else {

--- a/Brewy/Models/BrewService+DryRun.swift
+++ b/Brewy/Models/BrewService+DryRun.swift
@@ -1,13 +1,11 @@
 extension BrewService {
     // MARK: - Dry-Run Previews
 
-    func dryRunAutoremove() async -> String {
-        let result = await runBrewCommand(["autoremove", "--dry-run"])
-        return result.output
+    func dryRunAutoremove() async -> CommandResult {
+        await runBrewCommand(["autoremove", "--dry-run"])
     }
 
-    func dryRunCleanup() async -> String {
-        let result = await runBrewCommand(["cleanup", "--prune=all", "-s", "--dry-run"])
-        return result.output
+    func dryRunCleanup() async -> CommandResult {
+        await runBrewCommand(["cleanup", "--prune=all", "-s", "--dry-run"])
     }
 }

--- a/Brewy/Models/BrewService+History.swift
+++ b/Brewy/Models/BrewService+History.swift
@@ -91,12 +91,7 @@ extension BrewService {
             output: result.output
         )
 
-        let mutatingCommands: Set<String> = [
-            "install", "uninstall", "upgrade", "reinstall",
-            "link", "unlink", "autoremove", "cleanup", "update",
-            "tap", "untap"
-        ]
-        if let cmd = entry.arguments.first, mutatingCommands.contains(cmd) {
+        if entry.isMutatingCommand {
             await refresh()
         }
     }

--- a/Brewy/Models/BrewService.swift
+++ b/Brewy/Models/BrewService.swift
@@ -156,6 +156,10 @@ final class BrewService {
         }
     }
 
+    var homebrewOutdatedPackages: [BrewPackage] {
+        outdatedPackages.filter { !$0.isMas }
+    }
+
     // MARK: - Cache
 
     nonisolated static let cacheDirectory: URL? = {

--- a/Brewy/Views/ContentView.swift
+++ b/Brewy/Views/ContentView.swift
@@ -126,13 +126,7 @@ struct ContentView: View {
             WhatsNewView()
         }
         .sheet(isPresented: $showCleanupConfirm) {
-            DryRunConfirmationSheet(
-                title: "Clear Download Cache?",
-                message: "The following cached downloads and old versions will be removed.",
-                confirmLabel: "Clear Cache",
-                dryRunAction: { await brewService.dryRunCleanup() },
-                confirmAction: { await brewService.purgeCache() }
-            )
+            DryRunConfirmationSheet.clearCache(brewService: brewService)
         }
         .onReceive(NotificationCenter.default.publisher(for: .showWhatsNew)) { _ in
             showWhatsNew = true

--- a/Brewy/Views/ContentView.swift
+++ b/Brewy/Views/ContentView.swift
@@ -2,6 +2,7 @@ import SwiftUI
 
 extension Notification.Name {
     static let showWhatsNew = Notification.Name("showWhatsNew")
+    static let showCleanupPreview = Notification.Name("showCleanupPreview")
 }
 
 // MARK: - Package Navigation Environment
@@ -29,6 +30,7 @@ struct ContentView: View {
     // periphery:ignore - Mutated through PackageListView's searchable binding.
     @State private var searchText = ""
     @State private var showWhatsNew = false
+    @State private var showCleanupConfirm = false
 
     var body: some View {
         NavigationSplitView {
@@ -123,8 +125,20 @@ struct ContentView: View {
         .sheet(isPresented: $showWhatsNew) {
             WhatsNewView()
         }
+        .sheet(isPresented: $showCleanupConfirm) {
+            DryRunConfirmationSheet(
+                title: "Clear Download Cache?",
+                message: "The following cached downloads and old versions will be removed.",
+                confirmLabel: "Clear Cache",
+                dryRunAction: { await brewService.dryRunCleanup() },
+                confirmAction: { await brewService.purgeCache() }
+            )
+        }
         .onReceive(NotificationCenter.default.publisher(for: .showWhatsNew)) { _ in
             showWhatsNew = true
+        }
+        .onReceive(NotificationCenter.default.publisher(for: .showCleanupPreview)) { _ in
+            showCleanupConfirm = true
         }
     }
 

--- a/Brewy/Views/DryRunConfirmationSheet.swift
+++ b/Brewy/Views/DryRunConfirmationSheet.swift
@@ -6,11 +6,12 @@ struct DryRunConfirmationSheet: View {
     let title: String
     let message: String
     let confirmLabel: String
-    let dryRunAction: @MainActor () async -> String
+    let dryRunAction: @MainActor () async -> CommandResult
     let confirmAction: @MainActor () async -> Void
 
     @State private var isLoadingPreview = true
     @State private var previewOutput = ""
+    @State private var previewSucceeded = false
 
     var body: some View {
         VStack(spacing: 16) {
@@ -31,13 +32,15 @@ struct DryRunConfirmationSheet: View {
                     Task { await confirmAction() }
                 }
                 .keyboardShortcut(.defaultAction)
-                .disabled(isLoadingPreview)
+                .disabled(isLoadingPreview || !previewSucceeded)
             }
         }
         .padding(20)
         .frame(width: 480)
         .task {
-            previewOutput = await dryRunAction()
+            let result = await dryRunAction()
+            previewOutput = result.output
+            previewSucceeded = result.success
             isLoadingPreview = false
         }
     }
@@ -53,6 +56,21 @@ struct DryRunConfirmationSheet: View {
             }
             .frame(maxWidth: .infinity, minHeight: 60)
             .background(.quaternary.opacity(0.5), in: .rect(cornerRadius: 8))
+        } else if !previewSucceeded {
+            VStack(alignment: .leading, spacing: 8) {
+                Label("Preview failed", systemImage: "exclamationmark.triangle.fill")
+                    .font(.callout)
+                    .foregroundStyle(.red)
+                if !previewOutput.isEmpty {
+                    Text(previewOutput)
+                        .font(.system(.caption, design: .monospaced))
+                        .foregroundStyle(.secondary)
+                        .textSelection(.enabled)
+                }
+            }
+            .padding(12)
+            .frame(maxWidth: .infinity, alignment: .leading)
+            .background(.red.opacity(0.08), in: .rect(cornerRadius: 8))
         } else if previewOutput.isEmpty {
             Text("No specific files listed. The operation may still free up space.")
                 .font(.callout)

--- a/Brewy/Views/DryRunConfirmationSheet.swift
+++ b/Brewy/Views/DryRunConfirmationSheet.swift
@@ -92,3 +92,21 @@ struct DryRunConfirmationSheet: View {
         }
     }
 }
+
+extension DryRunConfirmationSheet {
+    static func clearCache(
+        brewService: BrewService,
+        afterConfirm: @escaping @MainActor () async -> Void = {}
+    ) -> DryRunConfirmationSheet {
+        DryRunConfirmationSheet(
+            title: "Clear Download Cache?",
+            message: "The following cached downloads and old versions will be removed.",
+            confirmLabel: "Clear Cache",
+            dryRunAction: { await brewService.dryRunCleanup() },
+            confirmAction: {
+                await brewService.purgeCache()
+                await afterConfirm()
+            }
+        )
+    }
+}

--- a/Brewy/Views/HistoryView.swift
+++ b/Brewy/Views/HistoryView.swift
@@ -73,6 +73,7 @@ struct HistoryDetailView: View {
     @Environment(BrewService.self)
     private var brewService
     let entry: ActionHistoryEntry
+    @State private var showRetryConfirmation = false
 
     var body: some View {
         Form {
@@ -88,6 +89,14 @@ struct HistoryDetailView: View {
             if brewService.isPerformingAction {
                 ActionOverlay(output: brewService.actionOutput)
             }
+        }
+        .confirmationDialog("Retry Command?", isPresented: $showRetryConfirmation) {
+            Button("Retry", role: .destructive) {
+                Task { await brewService.retryAction(entry) }
+            }
+            Button("Cancel", role: .cancel) {}
+        } message: {
+            Text("This will re-run \(entry.displayCommand).")
         }
     }
 
@@ -148,7 +157,11 @@ struct HistoryDetailView: View {
     private var retrySection: some View {
         Section {
             Button("Retry", systemImage: "arrow.clockwise") {
-                Task { await brewService.retryAction(entry) }
+                if entry.isMutatingCommand {
+                    showRetryConfirmation = true
+                } else {
+                    Task { await brewService.retryAction(entry) }
+                }
             }
             .buttonStyle(.borderedProminent)
             .tint(.orange)

--- a/Brewy/Views/MaintenanceView.swift
+++ b/Brewy/Views/MaintenanceView.swift
@@ -32,16 +32,9 @@ struct MaintenanceView: View {
             )
         }
         .sheet(isPresented: $showClearCacheConfirm) {
-            DryRunConfirmationSheet(
-                title: "Clear Download Cache?",
-                message: "The following cached downloads and old versions will be removed.",
-                confirmLabel: "Clear Cache",
-                dryRunAction: { await brewService.dryRunCleanup() },
-                confirmAction: {
-                    await brewService.purgeCache()
-                    await loadCacheSize()
-                }
-            )
+            DryRunConfirmationSheet.clearCache(brewService: brewService) {
+                await loadCacheSize()
+            }
         }
         .task {
             async let cacheTask: () = loadCacheSize()

--- a/Brewy/Views/PackageListView.swift
+++ b/Brewy/Views/PackageListView.swift
@@ -90,7 +90,7 @@ struct PackageListView: View {
                     isOutdated: isOutdatedCategory,
                     isSelecting: $isSelectingForUpgrade,
                     selectedForUpgrade: $selectedForUpgrade,
-                    outdatedPackages: isOutdatedCategory ? packages : []
+                    outdatedPackages: isOutdatedCategory ? packages.filter { !$0.isMas } : []
                 )
             }
     }
@@ -103,10 +103,12 @@ struct PackageListView: View {
                 ForEach(packages) { package in
                     HStack {
                         if isOutdatedCategory, isSelectingForUpgrade {
-                            UpgradeSelectionToggle(
-                                packageID: package.id,
-                                selectedForUpgrade: $selectedForUpgrade
-                            )
+                            if !package.isMas {
+                                UpgradeSelectionToggle(
+                                    packageID: package.id,
+                                    selectedForUpgrade: $selectedForUpgrade
+                                )
+                            }
                         }
                         PackageRow(
                             package: package,
@@ -161,7 +163,7 @@ private struct PackageListToolbar: ToolbarContent {
     let outdatedPackages: [BrewPackage]
 
     var body: some ToolbarContent {
-        if isOutdated {
+        if isOutdated, !outdatedPackages.isEmpty {
             if isSelecting {
                 ToolbarItem(placement: .primaryAction) {
                     Button("Upgrade (\(selectedForUpgrade.count))") {
@@ -192,7 +194,7 @@ private struct PackageListToolbar: ToolbarContent {
                     }
                 }
             }
-        } else if !brewService.outdatedPackages.isEmpty {
+        } else if !brewService.homebrewOutdatedPackages.isEmpty {
             ToolbarItem(placement: .primaryAction) {
                 Button("Upgrade All") {
                     Task { await brewService.upgradeAll() }
@@ -265,7 +267,7 @@ private struct PackageRow: View {
             }
             Spacer()
             versionLabel
-            if showUpgradeButton, package.isOutdated {
+            if showUpgradeButton, package.isOutdated, !package.isMas {
                 Button {
                     Task { await onUpgrade?(package) }
                 } label: {

--- a/BrewyTests/BrewServiceAsyncTests.swift
+++ b/BrewyTests/BrewServiceAsyncTests.swift
@@ -326,6 +326,7 @@ struct PackageActionTests {
         await service.install(package: pkg)
 
         #expect(mock.executedCommands.isEmpty)
+        #expect(service.lastError != nil)
     }
 
     @Test("uninstall calls brew uninstall")

--- a/BrewyTests/BrewServiceDetailTests.swift
+++ b/BrewyTests/BrewServiceDetailTests.swift
@@ -19,17 +19,6 @@ struct MaintenanceTests {
         #expect(output == "Your system is ready to brew.")
     }
 
-    @Test("cleanup calls correct command")
-    func cleanupCallsCommand() async {
-        let mock = MockCommandRunner()
-        let (service, _) = makeService(mock: mock)
-        mock.setResult(for: ["cleanup", "--prune=all"], output: "Cleaned up")
-
-        await service.cleanup()
-
-        #expect(mock.executedCommands.contains(["cleanup", "--prune=all"]))
-    }
-
     @Test("removeOrphans calls autoremove and refreshes")
     func removeOrphansCallsAutoremove() async {
         let mock = MockCommandRunner()
@@ -426,9 +415,9 @@ struct ErrorHandlingTests {
     func brewActionSetsError() async {
         let mock = MockCommandRunner()
         let (service, _) = makeService(mock: mock)
-        mock.setResult(for: ["cleanup", "--prune=all"], output: "Permission denied", success: false)
+        mock.setResult(for: ["cleanup", "--prune=all", "-s"], output: "Permission denied", success: false)
 
-        await service.cleanup()
+        await service.purgeCache()
 
         #expect(service.lastError != nil)
     }
@@ -438,9 +427,9 @@ struct ErrorHandlingTests {
         let mock = MockCommandRunner()
         let (service, _) = makeService(mock: mock)
         service.lastError = .commandFailed(command: "old", output: "old error")
-        mock.setResult(for: ["cleanup", "--prune=all"], output: "Cleaned up")
+        mock.setResult(for: ["cleanup", "--prune=all", "-s"], output: "Cleaned up")
 
-        await service.cleanup()
+        await service.purgeCache()
 
         #expect(service.lastError == nil)
     }

--- a/BrewyTests/BrewServiceDetailTests.swift
+++ b/BrewyTests/BrewServiceDetailTests.swift
@@ -147,43 +147,6 @@ struct MaintenanceTests {
     }
 }
 
-// MARK: - Dry-Run Tests
-
-@Suite("BrewService Dry-Run")
-@MainActor
-struct DryRunTests {
-
-    @Test("dryRunAutoremove calls autoremove --dry-run")
-    func dryRunAutoremoveCallsCommand() async {
-        let mock = MockCommandRunner()
-        let (service, _) = makeService(mock: mock)
-        mock.setResult(
-            for: ["autoremove", "--dry-run"],
-            output: "Would remove: libfoo, libbar"
-        )
-
-        let output = await service.dryRunAutoremove()
-
-        #expect(mock.executedCommands.contains(["autoremove", "--dry-run"]))
-        #expect(output.contains("libfoo"))
-    }
-
-    @Test("dryRunCleanup calls cleanup --dry-run")
-    func dryRunCleanupCallsCommand() async {
-        let mock = MockCommandRunner()
-        let (service, _) = makeService(mock: mock)
-        mock.setResult(
-            for: ["cleanup", "--prune=all", "-s", "--dry-run"],
-            output: "Would remove: /path/to/old-1.0.tar.gz"
-        )
-
-        let output = await service.dryRunCleanup()
-
-        #expect(mock.executedCommands.contains(["cleanup", "--prune=all", "-s", "--dry-run"]))
-        #expect(output.contains("old-1.0"))
-    }
-}
-
 // MARK: - Info & Caching Tests
 
 @Suite("BrewService Info Caching")

--- a/BrewyTests/BrewServiceTests.swift
+++ b/BrewyTests/BrewServiceTests.swift
@@ -146,6 +146,18 @@ struct BrewServiceDerivedStateTests {
         #expect(service.packages(for: .maintenance).isEmpty)
     }
 
+    @Test("homebrewOutdatedPackages excludes Mac App Store apps")
+    func homebrewOutdatedPackagesExcludesMas() {
+        let service = BrewService()
+        let formula = makePackage(name: "wget", source: .formula, isOutdated: true)
+        let cask = makePackage(name: "firefox", source: .cask, isOutdated: true)
+        let mas = makePackage(name: "Xcode", source: .mas, isOutdated: true)
+
+        service.outdatedPackages = [formula, cask, mas]
+
+        #expect(service.homebrewOutdatedPackages.map(\.id) == [formula.id, cask.id])
+    }
+
     @Test("Derived state updates when formulae change")
     func derivedStateUpdatesOnMutation() {
         let service = BrewService()

--- a/BrewyTests/DryRunTests.swift
+++ b/BrewyTests/DryRunTests.swift
@@ -1,0 +1,57 @@
+@testable import Brewy
+import Testing
+
+// MARK: - Dry-Run Tests
+
+@Suite("BrewService Dry-Run")
+@MainActor
+struct DryRunTests {
+
+    @Test("dryRunAutoremove calls autoremove --dry-run")
+    func dryRunAutoremoveCallsCommand() async {
+        let mock = MockCommandRunner()
+        let (service, _) = makeService(mock: mock)
+        mock.setResult(
+            for: ["autoremove", "--dry-run"],
+            output: "Would remove: libfoo, libbar"
+        )
+
+        let result = await service.dryRunAutoremove()
+
+        #expect(mock.executedCommands.contains(["autoremove", "--dry-run"]))
+        #expect(result.success)
+        #expect(result.output.contains("libfoo"))
+    }
+
+    @Test("dryRunCleanup calls cleanup --dry-run")
+    func dryRunCleanupCallsCommand() async {
+        let mock = MockCommandRunner()
+        let (service, _) = makeService(mock: mock)
+        mock.setResult(
+            for: ["cleanup", "--prune=all", "-s", "--dry-run"],
+            output: "Would remove: /path/to/old-1.0.tar.gz"
+        )
+
+        let result = await service.dryRunCleanup()
+
+        #expect(mock.executedCommands.contains(["cleanup", "--prune=all", "-s", "--dry-run"]))
+        #expect(result.success)
+        #expect(result.output.contains("old-1.0"))
+    }
+
+    @Test("dryRunCleanup preserves failure result")
+    func dryRunCleanupPreservesFailure() async {
+        let mock = MockCommandRunner()
+        let (service, _) = makeService(mock: mock)
+        mock.setResult(
+            for: ["cleanup", "--prune=all", "-s", "--dry-run"],
+            output: "Permission denied",
+            success: false
+        )
+
+        let result = await service.dryRunCleanup()
+
+        #expect(!result.success)
+        #expect(result.output == "Permission denied")
+    }
+}

--- a/BrewyTests/HistoryTests.swift
+++ b/BrewyTests/HistoryTests.swift
@@ -121,6 +121,26 @@ struct ActionHistoryEntryTests {
         #expect(entry.isRetryable == false)
     }
 
+    @Test("isMutatingCommand is true for mutating commands")
+    func isMutatingCommandForMutations() {
+        let entry = ActionHistoryEntry(
+            id: UUID(), command: "cleanup", arguments: ["cleanup", "--prune=all"],
+            packageName: nil, packageSource: nil,
+            status: .failure, output: "Error", timestamp: Date()
+        )
+        #expect(entry.isMutatingCommand)
+    }
+
+    @Test("isMutatingCommand is false for read-only commands")
+    func isMutatingCommandForReadOnly() {
+        let entry = ActionHistoryEntry(
+            id: UUID(), command: "doctor", arguments: ["doctor"],
+            packageName: nil, packageSource: nil,
+            status: .failure, output: "Warning", timestamp: Date()
+        )
+        #expect(entry.isMutatingCommand == false)
+    }
+
     @Test("Status raw values encode correctly")
     func statusRawValues() {
         #expect(ActionHistoryEntry.Status.success.rawValue == "success")


### PR DESCRIPTION
Routes the Cleanup menu command through the dry-run preview sheet, excludes Mac App Store apps from bulk and "Upgrade All" paths (they cannot go through `brew upgrade`), confirms history retries of mutating commands, and surfaces a clear error when a brew action targets a MAS app. Dry-run previews return `CommandResult` so a failed preview disables confirm. Also dedupes the clear-cache sheet and removes the now-unused `cleanup()` helper.