### PR TITLE
ci: pin Linux runners to ubuntu-24.04

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -75,7 +75,7 @@ jobs:
 
           # Workflow changes: Actions security audit
           if echo "${CHANGED}" | grep -qE '^\.github/workflows/'; then
-            MATRIX+=',{"name":"zizmor","check":"zizmor","runner":"ubuntu-latest"}'
+            MATRIX+=',{"name":"zizmor","check":"zizmor","runner":"ubuntu-24.04"}'
           fi
 
           echo "matrix=${MATRIX}]" >> "${GITHUB_OUTPUT}"

--- a/.github/workflows/pinprick-audit.yml
+++ b/.github/workflows/pinprick-audit.yml
@@ -21,7 +21,7 @@ permissions: {}
 jobs:
   audit:
     name: Audit
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-24.04
     permissions:
       contents: read
       security-events: write # required to upload SARIF results

--- a/.github/workflows/zizmor.yml
+++ b/.github/workflows/zizmor.yml
@@ -16,7 +16,7 @@ permissions: {}
 jobs:
   zizmor:
     name: Analyze
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-24.04
     permissions:
       contents: read
       security-events: write # required to upload SARIF results


### PR DESCRIPTION
Pin the CI runners to an explicit `ubuntu-24.04` rather than the floating `ubuntu-latest` label, so these workflows run on a fixed OS image and don't silently roll when GitHub repoints `ubuntu-latest`. It resolves to 24.04 today, so the change is behavior-preserving now — and with `ubuntu-26.04` already shipping in preview, pinning keeps the jobs on 24.04 until we bump deliberately.
