### PR TITLE
ci: audit via pinprick-action instead of brew-installing pinprick

### DIFF
--- a/.github/workflows/pinprick-audit.yml
+++ b/.github/workflows/pinprick-audit.yml
@@ -30,34 +30,9 @@ jobs:
         with:
           persist-credentials: false
 
-      - name: Install pinprick
-        run: |
-          /home/linuxbrew/.linuxbrew/bin/brew tap starhaven-io/tap
-          /home/linuxbrew/.linuxbrew/bin/brew trust starhaven-io/tap
-          /home/linuxbrew/.linuxbrew/bin/brew install starhaven-io/tap/pinprick
-
-      - name: Run pinprick audit
-        env:
-          GITHUB_TOKEN: ${{ github.token }}
-        run: |
-          set +e
-          /home/linuxbrew/.linuxbrew/bin/pinprick audit --sarif . > pinprick.sarif
-          EXIT=$?
-          echo "PINPRICK_EXIT=${EXIT}" >> "${GITHUB_ENV}"
-          # 0 = clean, 1 = findings (still upload), 2+ = real error
-          if [[ "${EXIT}" -gt 1 ]]; then
-            echo "::error::pinprick audit errored with exit code ${EXIT}"
-            exit "${EXIT}"
-          fi
-
-      - name: Upload SARIF
-        uses: github/codeql-action/upload-sarif@8aad20d150bbac5944a9f9d289da16a4b0d87c1e # v4.36.2
+      - name: Run pinprick
+        uses: starhaven-io/pinprick-action@d52684fdf26c13aec4a37eb09029af8fd41b6f01 # v0.1.0
         with:
-          sarif_file: pinprick.sarif
-          category: pinprick
-
-      - name: Fail on pinprick findings
-        if: env.PINPRICK_EXIT == '1'
-        run: |
-          echo "::error::pinprick audit found workflow security findings"
-          exit 1
+          # Fork pull requests cannot upload SARIF with the read-only token.
+          advanced-security: ${{ github.event_name != 'pull_request' || github.event.pull_request.head.repo.full_name == github.repository }}
+          fail-on-findings: true


### PR DESCRIPTION
Replaces the brew tap/trust/install prelude and the hand-rolled SARIF run,
upload, and fail steps with starhaven-io/pinprick-action, pinned to the v0.1.0
SHA.
