### PR TITLE
ci: drop inert defaults.run.shell from pinprick-audit

### DIFF
--- a/.github/workflows/pinprick-audit.yml
+++ b/.github/workflows/pinprick-audit.yml
@@ -12,10 +12,6 @@ concurrency:
   group: "pinprick-audit-${{ github.ref }}"
   cancel-in-progress: true
 
-defaults:
-  run:
-    shell: bash -xeuo pipefail {0}
-
 permissions: {}
 
 jobs:


### PR DESCRIPTION
Removes the now-inert defaults.run.shell block from pinprick-audit.yml. The pinprick-action migration replaced every run: step in this workflow with the composite action, so the bash -xeuo pipefail run default no longer applies to any step; the action sets its own shell internally. No behavior change.