### PR TITLE
ci: exclude gnu.org from lychee link check

### DIFF
--- a/lychee.toml
+++ b/lychee.toml
@@ -5,3 +5,7 @@
 max_concurrency = 20
 timeout = 20
 max_retries = 3
+
+# gnu.org can time out or block automated link checkers from hosted runners.
+# The AGPL license URL is canonical; skip verifying it.
+exclude = ["^https://www\\.gnu\\.org/"]


### PR DESCRIPTION
gnu.org rate-limits and returns 403 to automated link checkers from hosted CI runners. Brewy references it for the AGPL-3.0 license, so this excludes it from the lychee check to prevent flakes. The URL is a canonical FSF permalink. Brings the config in line with the rest of the fleet.
