### PR TITLE
fix: address package refresh correctness

### DIFF
--- a/Brewy/BrewyApp.swift
+++ b/Brewy/BrewyApp.swift
@@ -5,6 +5,12 @@ import SwiftUI
 @main
 struct BrewyApp: App {
     @State private var brewService = BrewService()
+    // HACK: there is a known color scheme bug in SwiftUI where passing `nil` to `.preferredColorScheme`
+    // doesn't change the color of some elements:
+    // https://stackoverflow.com/questions/76123702/preferredcolorschemenil-visual-bug-when-switching-to-system-light-dark-more
+    // NSApplication.shared, not NSApp: this initializer can run before NSApp is set (seen on CI
+    // test hosts), and .shared creates the instance instead of unwrapping nil.
+    @State private var systemColorScheme = Self.colorScheme(for: NSApplication.shared.effectiveAppearance)
     private let updaterController: SPUStandardUpdaterController
 
     init() {
@@ -16,11 +22,8 @@ struct BrewyApp: App {
     @AppStorage("appIcon")
     private var appIcon = AppIconSelection.current.rawValue
 
-    // HACK: there is a known color scheme bug in SwiftUI where passing `nil` to `.preferredColorScheme`
-    // doesn't change the color of some elements:
-    // https://stackoverflow.com/questions/76123702/preferredcolorschemenil-visual-bug-when-switching-to-system-light-dark-more
-    private var systemColorScheme: ColorScheme? {
-        switch NSApp.effectiveAppearance.bestMatch(from: [.aqua, .darkAqua]) {
+    private static func colorScheme(for appearance: NSAppearance) -> ColorScheme? {
+        switch appearance.bestMatch(from: [.aqua, .darkAqua]) {
         case .aqua: .light
         case .darkAqua: .dark
         default: nil
@@ -36,6 +39,9 @@ struct BrewyApp: App {
             ContentView()
                 .environment(brewService)
                 .preferredColorScheme(preferredColorScheme ?? systemColorScheme)
+                .onReceive(NSApplication.shared.publisher(for: \.effectiveAppearance)) { appearance in
+                    systemColorScheme = Self.colorScheme(for: appearance)
+                }
                 .onChange(of: appIcon, initial: true) {
                     AppIconSelection.apply(rawValue: appIcon)
                 }

--- a/Brewy/Models/ActionHistoryEntry+Commands.swift
+++ b/Brewy/Models/ActionHistoryEntry+Commands.swift
@@ -6,7 +6,7 @@ extension ActionHistoryEntry {
 
     private static let mutatingCommands: Set<String> = [
         "install", "uninstall", "upgrade", "reinstall",
-        "link", "unlink", "autoremove", "cleanup", "update",
+        "pin", "unpin", "link", "unlink", "autoremove", "cleanup", "update",
         "tap", "untap"
     ]
 }

--- a/Brewy/Models/BrewJSONTypes.swift
+++ b/Brewy/Models/BrewJSONTypes.swift
@@ -31,7 +31,8 @@ struct FormulaJSON: Decodable {
     }
 
     func toPackage() -> BrewPackage {
-        let installedVersion = installed?.first?.version
+        let newestInstalled = installed?.last
+        let installedVersion = newestInstalled?.version
         let stable = versions?.stable ?? "unknown"
         return BrewPackage(
             id: "formula-\(name)",
@@ -45,7 +46,7 @@ struct FormulaJSON: Decodable {
             latestVersion: stable,
             source: .formula,
             pinned: pinned ?? false,
-            installedOnRequest: installed?.first?.installedOnRequest ?? false,
+            installedOnRequest: newestInstalled?.installedOnRequest ?? false,
             dependencies: dependencies ?? []
         )
     }
@@ -123,15 +124,16 @@ struct OutdatedFormulaJSON: Decodable {
 
     func toPackage() -> BrewPackage? {
         guard let currentVersion else { return nil }
+        let installedVersion = installedVersions?.last
         return BrewPackage(
             id: "formula-\(name)",
             name: name,
-            version: installedVersions?.first ?? "unknown",
+            version: installedVersion ?? "unknown",
             description: "",
             homepage: "",
             isInstalled: true,
             isOutdated: true,
-            installedVersion: installedVersions?.first,
+            installedVersion: installedVersion,
             latestVersion: currentVersion,
             source: .formula,
             pinned: pinned ?? false,
@@ -154,7 +156,7 @@ struct OutdatedCaskJSON: Decodable {
 
     func toPackage() -> BrewPackage? {
         guard let currentVersion,
-              let installedVersion = installedVersions?.first else { return nil }
+              let installedVersion = installedVersions?.last else { return nil }
         return BrewPackage(
             id: "cask-\(name)",
             name: name,

--- a/Brewy/Models/BrewService+PackageDetail.swift
+++ b/Brewy/Models/BrewService+PackageDetail.swift
@@ -1,4 +1,7 @@
 import Foundation
+import OSLog
+
+private let logger = Logger(subsystem: "io.linnane.brewy", category: "BrewService+PackageDetail")
 
 // MARK: - Package Detail Fetching
 
@@ -20,7 +23,7 @@ extension BrewService {
                         name: cask.token,
                         version: cask.version ?? package.version,
                         description: cask.desc ?? package.description,
-                        homepage: cask.homepage ?? "",
+                        homepage: cask.homepage ?? package.homepage,
                         isInstalled: package.isInstalled,
                         isOutdated: package.isOutdated,
                         installedVersion: package.installedVersion,
@@ -37,7 +40,7 @@ extension BrewService {
                         name: formula.name,
                         version: formula.versions?.stable ?? package.version,
                         description: formula.desc ?? package.description,
-                        homepage: formula.homepage ?? "",
+                        homepage: formula.homepage ?? package.homepage,
                         isInstalled: package.isInstalled,
                         isOutdated: package.isOutdated,
                         installedVersion: package.installedVersion,
@@ -50,6 +53,7 @@ extension BrewService {
                 }
                 return nil
             } catch {
+                logger.error("Failed to parse package detail JSON for \(package.name): \(error.localizedDescription)")
                 return nil
             }
         }.value

--- a/Brewy/Models/BrewService+Taps.swift
+++ b/Brewy/Models/BrewService+Taps.swift
@@ -9,27 +9,35 @@ extension BrewService {
 
     func ensureTapsLoaded() async {
         guard !tapsLoaded else { return }
+        guard let fetchedTaps = await fetchTaps() else {
+            tapsLoaded = false
+            return
+        }
+        installedTaps = fetchedTaps
         tapsLoaded = true
-        installedTaps = await fetchTaps() ?? installedTaps
         saveToCache()
     }
 
     // MARK: - Tap Management
 
-    func addTap(name: String) async {
+    @discardableResult
+    func addTap(name: String) async -> CommandResult {
         await performTapAction { await runTapCommand(["tap", name]) }
     }
 
-    func removeTap(name: String) async {
+    @discardableResult
+    func removeTap(name: String) async -> CommandResult {
         await performTapAction { await runTapCommand(["untap", name]) }
     }
 
-    func migrateTap(from oldName: String, to newName: String) async {
+    @discardableResult
+    func migrateTap(from oldName: String, to newName: String) async -> CommandResult {
         await performTapAction {
             logger.info("Migrating tap \(oldName) → \(newName)")
-            guard await runTapCommand(["untap", oldName]) else { return false }
+            let untapped = await runTapCommand(["untap", oldName])
+            guard untapped.success else { return untapped }
             let tapped = await runTapCommand(["tap", newName])
-            if tapped {
+            if tapped.success {
                 // Drop the old tap's cached health only once the new tap is in place; on rollback
                 // it stays installed and keeps its status.
                 tapHealthStatuses.removeValue(forKey: oldName)
@@ -41,29 +49,30 @@ extension BrewService {
         }
     }
 
-    private func performTapAction(_ action: () async -> Bool) async {
+    private func performTapAction(_ action: () async -> CommandResult) async -> CommandResult {
         guard !isPerformingAction else {
             logger.info("Tap action skipped, action already in progress")
-            return
+            return CommandResult(output: "Another action is already in progress.", success: false)
         }
         isPerformingAction = true
         actionOutput = ""
         lastError = nil
         defer { isPerformingAction = false }
-        _ = await action()
+        let result = await action()
         tapsLoaded = false
         await ensureTapsLoaded()
         await refresh()
+        return result
     }
 
     @discardableResult
-    private func runTapCommand(_ arguments: [String]) async -> Bool {
+    private func runTapCommand(_ arguments: [String]) async -> CommandResult {
         let result = await runBrewCommand(arguments)
         actionOutput += actionOutput.isEmpty ? result.output : "\n" + result.output
         if !result.success {
             lastError = .commandFailed(command: arguments.first ?? "", output: result.output)
         }
         recordAction(arguments: arguments, packageName: nil, packageSource: nil, success: result.success, output: result.output)
-        return result.success
+        return result
     }
 }

--- a/Brewy/Models/BrewService.swift
+++ b/Brewy/Models/BrewService.swift
@@ -81,6 +81,7 @@ final class BrewService {
 
     var tapsLoaded = false
     private var isRefreshing = false
+    private var needsRefresh = false
     @ObservationIgnored private var isBatchingUpdates = false
     @ObservationIgnored var infoCache: [String: String] = [:]
     @ObservationIgnored private var tapHealthTask: Task<Void, Never>?
@@ -250,11 +251,19 @@ final class BrewService {
 
     func refresh() async {
         guard !isRefreshing else {
-            logger.info("Refresh already in progress, skipping")
+            needsRefresh = true
+            logger.info("Refresh already in progress, queuing follow-up")
             return
         }
         isRefreshing = true
         defer { isRefreshing = false }
+        repeat {
+            needsRefresh = false
+            await performRefresh()
+        } while needsRefresh
+    }
+
+    private func performRefresh() async {
         logger.info("Starting full refresh")
         let previousVersions = Dictionary(allInstalled.map { ($0.id, $0.version) }, uniquingKeysWith: { _, last in last })
         let hadCachedData = !installedFormulae.isEmpty || !installedCasks.isEmpty
@@ -262,7 +271,6 @@ final class BrewService {
         // search() from clearing it early (and vice versa).
         let showsSpinner = !hadCachedData
         if showsSpinner { loadingCount += 1 }
-        lastError = nil
         defer {
             if showsSpinner { loadingCount -= 1 }
         }
@@ -284,12 +292,20 @@ final class BrewService {
         let fetchedTaps = await taps ?? installedTaps
         let allOutdated = fetchedOutdated + fetchedMasOutdated
         let outdatedByID = Dictionary(allOutdated.map { ($0.id, $0) }, uniquingKeysWith: { _, last in last })
+        let mergedFormulae = fetchedFormulae.map { Self.mergeOutdatedStatus($0, outdatedByID: outdatedByID) }
+        let mergedCasks = fetchedCasks.map { Self.mergeOutdatedStatus($0, outdatedByID: outdatedByID) }
+        let mergedMasApps = fetchedMasApps.map { Self.mergeOutdatedStatus($0, outdatedByID: outdatedByID) }
+        let mergedByID = Dictionary(
+            (mergedFormulae + mergedCasks + mergedMasApps).filter(\.isOutdated).map { ($0.id, $0) },
+            uniquingKeysWith: { _, last in last }
+        )
+        let displayedOutdated = allOutdated.map { mergedByID[$0.id] ?? $0 }
 
         applyRefreshResults(
-            formulae: fetchedFormulae.map { Self.mergeOutdatedStatus($0, outdatedByID: outdatedByID) },
-            casks: fetchedCasks.map { Self.mergeOutdatedStatus($0, outdatedByID: outdatedByID) },
-            masApps: fetchedMasApps.map { Self.mergeOutdatedStatus($0, outdatedByID: outdatedByID) },
-            outdated: allOutdated
+            formulae: mergedFormulae,
+            casks: mergedCasks,
+            masApps: mergedMasApps,
+            outdated: displayedOutdated
         )
         lastUpdated = Date()
 

--- a/Brewy/Models/PackageModel.swift
+++ b/Brewy/Models/PackageModel.swift
@@ -85,9 +85,11 @@ struct TapHealthStatus: Codable, Equatable {
     let lastChecked: Date
 
     static let cacheTTL: TimeInterval = 24 * 60 * 60 // 1 day
+    static let unknownCacheTTL: TimeInterval = 30 * 60
 
     var isStale: Bool {
-        Date().timeIntervalSince(lastChecked) > Self.cacheTTL
+        let ttl = status == .unknown ? Self.unknownCacheTTL : Self.cacheTTL
+        return Date().timeIntervalSince(lastChecked) > ttl
     }
 
     static func parseGitHubRepo(from remote: String) -> (owner: String, repo: String)? {

--- a/Brewy/Views/MaintenanceView.swift
+++ b/Brewy/Views/MaintenanceView.swift
@@ -11,6 +11,7 @@ struct MaintenanceView: View {
     @State private var isLoadingConfig = true
     @State private var showRemoveOrphansConfirm = false
     @State private var showClearCacheConfirm = false
+    @State private var doctorTask: Task<Void, Never>?
 
     var body: some View {
         Form {
@@ -41,6 +42,11 @@ struct MaintenanceView: View {
             async let configTask: () = loadConfig()
             _ = await (cacheTask, configTask)
         }
+        .onDisappear {
+            doctorTask?.cancel()
+            doctorTask = nil
+            isRunningDoctor = false
+        }
     }
 
     // MARK: - Health Check
@@ -57,10 +63,14 @@ struct MaintenanceView: View {
                             .controlSize(.small)
                     }
                     Button("Run brew doctor") {
+                        doctorTask?.cancel()
                         isRunningDoctor = true
-                        Task {
-                            doctorOutput = await brewService.doctor()
+                        doctorTask = Task {
+                            let output = await brewService.doctor()
+                            guard !Task.isCancelled else { return }
+                            doctorOutput = output
                             isRunningDoctor = false
+                            doctorTask = nil
                         }
                     }
                     .disabled(isRunningDoctor)

--- a/Brewy/Views/PackageListView.swift
+++ b/Brewy/Views/PackageListView.swift
@@ -55,9 +55,12 @@ struct PackageListView: View {
                 }
             }
             .onChange(of: searchText) {
-                guard isSearchingAll else { return }
                 searchTask?.cancel()
-                guard !searchText.isEmpty else { return }
+                guard isSearchingAll else { return }
+                guard !searchText.isEmpty else {
+                    brewService.searchResults = []
+                    return
+                }
                 searchTask = Task {
                     try? await Task.sleep(for: .milliseconds(300))
                     guard !Task.isCancelled else { return }
@@ -65,17 +68,27 @@ struct PackageListView: View {
                 }
             }
             .onChange(of: searchScope) {
-                if isSearchingAll, !searchText.isEmpty {
+                guard isSearchingAll else {
+                    brewService.searchResults = []
+                    return
+                }
+                if !searchText.isEmpty {
                     searchTask?.cancel()
                     searchTask = Task {
                         await brewService.search(query: searchText)
                     }
                 }
             }
+            .onChange(of: isSearchPresented) {
+                guard !isSearchPresented else { return }
+                searchTask?.cancel()
+                brewService.searchResults = []
+            }
             .onChange(of: selectedCategory) {
                 searchScope = .installed
                 searchText = ""
                 searchTask?.cancel()
+                brewService.searchResults = []
                 // selectedPackage is cleared centrally in ContentView.onChange(of: selectedCategory).
             }
             .overlay {

--- a/Brewy/Views/TapListView.swift
+++ b/Brewy/Views/TapListView.swift
@@ -185,9 +185,11 @@ private struct AddTapSheet: View {
                     isAdding = true
                     errorMessage = nil
                     Task {
-                        await brewService.addTap(name: name)
-                        if let error = brewService.lastError {
-                            errorMessage = error.localizedDescription
+                        let result = await brewService.addTap(name: name)
+                        if !result.success {
+                            errorMessage = BrewError.commandFailed(command: "tap \(name)", output: result.output)
+                                .localizedDescription
+                            brewService.lastError = nil
                             isAdding = false
                         } else {
                             dismiss()

--- a/BrewyTests/BrewServiceDetailTests.swift
+++ b/BrewyTests/BrewServiceDetailTests.swift
@@ -263,6 +263,29 @@ struct PackageDetailTests {
         #expect(enriched?.installedVersion == "1.24.5")
         #expect(enriched?.latestVersion == "1.25.0")
     }
+
+    @Test("fetchPackageDetail preserves homepage when JSON omits it")
+    func fetchDetailPreservesHomepage() async {
+        let mock = MockCommandRunner()
+        let (service, _) = makeService(mock: mock)
+        let pkg = BrewPackage(
+            id: "cask-firefox", name: "firefox", version: "122.0",
+            description: "Browser", homepage: "https://example.com/firefox",
+            isInstalled: true, isOutdated: false,
+            installedVersion: "122.0", latestVersion: nil,
+            source: .cask, pinned: false, installedOnRequest: true,
+            dependencies: []
+        )
+        let detail = """
+        {"formulae":[],"casks":[{"token":"firefox","version":"123.0",\
+        "desc":"Fast web browser"}]}
+        """
+        mock.setResult(for: ["info", "--cask", "--json=v2", "firefox"], output: detail)
+
+        let enriched = await service.fetchPackageDetail(for: pkg)
+
+        #expect(enriched?.homepage == "https://example.com/firefox")
+    }
 }
 
 // MARK: - Tap Management Tests
@@ -281,6 +304,19 @@ struct TapManagementTests {
         await service.addTap(name: "user/repo")
 
         #expect(mock.executedCommands.contains(["tap", "user/repo"]))
+    }
+
+    @Test("addTap returns command failure even when refresh clears shared error")
+    func addTapReturnsFailure() async {
+        let mock = MockCommandRunner()
+        let (service, _) = makeService(mock: mock)
+        setupRefreshMock(mock)
+        mock.setResult(for: ["tap", "bad/repo"], output: "Error: tap failed", success: false)
+
+        let result = await service.addTap(name: "bad/repo")
+
+        #expect(!result.success)
+        #expect(result.output.contains("tap failed"))
     }
 
     @Test("removeTap calls brew untap")
@@ -325,6 +361,23 @@ struct TapManagementTests {
 
         let tapCommands = mock.executedCommands.filter { $0 == ["tap-info", "--json=v1", "--installed"] }
         #expect(tapCommands.count == 1)
+    }
+
+    @Test("ensureTapsLoaded retries after failed load")
+    func ensureTapsLoadedRetriesAfterFailure() async {
+        let mock = MockCommandRunner()
+        let (service, _) = makeService(mock: mock)
+        mock.setResult(for: ["tap-info", "--json=v1", "--installed"], output: "Error", success: false)
+
+        await service.ensureTapsLoaded()
+        #expect(!service.tapsLoaded)
+
+        mock.setResult(for: ["tap-info", "--json=v1", "--installed"], output: TestJSON.taps)
+        await service.ensureTapsLoaded()
+
+        let tapCommands = mock.executedCommands.filter { $0 == ["tap-info", "--json=v1", "--installed"] }
+        #expect(tapCommands.count == 2)
+        #expect(service.installedTaps.count == 1)
     }
 }
 

--- a/BrewyTests/ErrorPersistenceTests.swift
+++ b/BrewyTests/ErrorPersistenceTests.swift
@@ -1,0 +1,44 @@
+@testable import Brewy
+import Foundation
+import Testing
+
+@Suite("BrewService error persistence")
+@MainActor
+struct ErrorPersistenceTests {
+
+    @Test("removeTap preserves command failure after refresh")
+    func removeTapPreservesFailure() async {
+        let mock = MockCommandRunner()
+        let (service, _) = makeService(mock: mock)
+        setupRefreshMock(mock)
+        mock.setResult(for: ["untap", "user/repo"], output: "Refusing to untap", success: false)
+
+        let result = await service.removeTap(name: "user/repo")
+
+        #expect(!result.success)
+        #expect(service.lastError != nil)
+        #expect(service.lastError?.localizedDescription.contains("Refusing to untap") == true)
+    }
+
+    @Test("queued refresh preserves an error set while waiting")
+    func queuedRefreshPreservesLateError() async {
+        let mock = MockCommandRunner()
+        let (service, _) = makeService(mock: mock)
+        setupRefreshMock(mock)
+        let delayedCommand = ["info", "--installed", "--json=v2"]
+        mock.setDelay(for: delayedCommand, duration: .milliseconds(100))
+
+        let refreshTask = Task { await service.refresh() }
+        while !mock.executedCommands.contains(delayedCommand) {
+            try? await Task.sleep(for: .milliseconds(1))
+        }
+
+        await service.refresh()
+        service.lastError = .commandFailed(command: "late", output: "late failure")
+
+        await refreshTask.value
+
+        #expect(service.lastError != nil)
+        #expect(service.lastError?.localizedDescription.contains("late failure") == true)
+    }
+}

--- a/BrewyTests/HistoryTests.swift
+++ b/BrewyTests/HistoryTests.swift
@@ -123,12 +123,14 @@ struct ActionHistoryEntryTests {
 
     @Test("isMutatingCommand is true for mutating commands")
     func isMutatingCommandForMutations() {
-        let entry = ActionHistoryEntry(
-            id: UUID(), command: "cleanup", arguments: ["cleanup", "--prune=all"],
-            packageName: nil, packageSource: nil,
-            status: .failure, output: "Error", timestamp: Date()
-        )
-        #expect(entry.isMutatingCommand)
+        for command in ["cleanup", "pin", "unpin"] {
+            let entry = ActionHistoryEntry(
+                id: UUID(), command: command, arguments: [command, "wget"],
+                packageName: command == "cleanup" ? nil : "wget", packageSource: .formula,
+                status: .failure, output: "Error", timestamp: Date()
+            )
+            #expect(entry.isMutatingCommand)
+        }
     }
 
     @Test("isMutatingCommand is false for read-only commands")

--- a/BrewyTests/JSONAndServicesTests.swift
+++ b/BrewyTests/JSONAndServicesTests.swift
@@ -84,6 +84,43 @@ struct JSONParsingEdgeCaseTests {
         #expect(pkg.installedOnRequest == false)
         #expect(pkg.dependencies == ["openssl"])
     }
+
+    @Test("Formula JSON uses newest installed keg")
+    func formulaUsesNewestInstalledKeg() throws {
+        let json = """
+        {"formulae":[{"name":"node","desc":"","homepage":"","versions":{"stable":"24.0.0"},\
+        "pinned":false,"installed":[\
+        {"version":"22.0.0","installed_on_request":false},\
+        {"version":"24.0.0","installed_on_request":true}],\
+        "dependencies":[]}],"casks":[]}
+        """
+        let data = try #require(json.data(using: .utf8))
+        let response = try JSONDecoder().decode(BrewInfoResponse.self, from: data)
+        let pkg = try #require(response.formulae?.first?.toPackage())
+
+        #expect(pkg.version == "24.0.0")
+        #expect(pkg.installedVersion == "24.0.0")
+        #expect(pkg.installedOnRequest)
+    }
+
+    @Test("Outdated JSON uses newest installed version")
+    func outdatedUsesNewestInstalledVersion() throws {
+        let json = """
+        {"formulae":[{"name":"node","installed_versions":["22.0.0","24.0.0"],\
+        "current_version":"24.1.0","pinned":false}],\
+        "casks":[{"name":"firefox","installed_versions":["122.0","123.0"],\
+        "current_version":"124.0"}]}
+        """
+        let data = try #require(json.data(using: .utf8))
+        let response = try JSONDecoder().decode(BrewOutdatedResponse.self, from: data)
+        let formula = try #require(response.formulae?.first?.toPackage())
+        let cask = try #require(response.casks?.first?.toPackage())
+
+        #expect(formula.version == "24.0.0")
+        #expect(formula.installedVersion == "24.0.0")
+        #expect(cask.version == "123.0")
+        #expect(cask.installedVersion == "123.0")
+    }
 }
 
 // MARK: - Services Integration Tests

--- a/BrewyTests/TestHelpers.swift
+++ b/BrewyTests/TestHelpers.swift
@@ -7,6 +7,7 @@ import Testing
 final class MockCommandRunner: CommandRunning, @unchecked Sendable {
     private let lock = NSLock()
     private var _results: [[String]: CommandResult] = [:]
+    private var _delays: [[String]: Duration] = [:]
     private var _executedCommands: [[String]] = []
     private var _executedExecutables: [(path: String, arguments: [String])] = []
 
@@ -26,20 +27,34 @@ final class MockCommandRunner: CommandRunning, @unchecked Sendable {
         }
     }
 
-    func run(_ arguments: [String], brewPath: String, timeout: Duration) async -> CommandResult {
+    func setDelay(for arguments: [String], duration: Duration) {
         lock.withLock {
-            _executedCommands.append(arguments)
-            _executedExecutables.append((path: brewPath, arguments: arguments))
-            return _results[arguments] ?? CommandResult(output: "", success: false)
+            _delays[arguments] = duration
         }
     }
 
+    func run(_ arguments: [String], brewPath: String, timeout: Duration) async -> CommandResult {
+        let (delay, result) = lock.withLock {
+            _executedCommands.append(arguments)
+            _executedExecutables.append((path: brewPath, arguments: arguments))
+            return (_delays[arguments], _results[arguments] ?? CommandResult(output: "", success: false))
+        }
+        if let delay {
+            try? await Task.sleep(for: delay)
+        }
+        return result
+    }
+
     func runExecutable(_ executablePath: String, arguments: [String], timeout: Duration) async -> CommandResult {
-        lock.withLock {
+        let (delay, result) = lock.withLock {
             _executedCommands.append(arguments)
             _executedExecutables.append((path: executablePath, arguments: arguments))
-            return _results[arguments] ?? CommandResult(output: "", success: false)
+            return (_delays[arguments], _results[arguments] ?? CommandResult(output: "", success: false))
         }
+        if let delay {
+            try? await Task.sleep(for: delay)
+        }
+        return result
     }
 }
 


### PR DESCRIPTION
Fixes a batch of package refresh correctness bugs:

- Concurrent refreshes coalesce instead of being skipped, so a post-action refresh can no longer apply data fetched before the mutation.
- `performRefresh` no longer clears `lastError`, so action failures survive their trailing refresh; regression tests cover the coalesced case.
- Installed versions come from the newest keg instead of the oldest, in both installed and outdated JSON decoding.
- Tap commands return their `CommandResult` to callers; the Add Tap sheet reports failures inline instead of reading shared state that the refresh already cleared.
- Stale All Packages search results clear when the query, scope, or category changes, restoring the empty search state.
- Package detail fetches preserve a known homepage when `brew info` omits it, and decode failures are logged.
- `ensureTapsLoaded` retries after a failed fetch instead of latching `tapsLoaded`.
- `brew doctor` is tied to the Maintenance view's lifetime.
- Unknown tap-health results cache for 30 minutes instead of 24 hours, so rate-limited GitHub checks retry sooner.
- `pin` and `unpin` count as mutating commands for history retry refreshes.
- The Outdated category is rebuilt from merged models, so its detail views keep descriptions and dependencies.
- System appearance changes propagate while the theme is set to System.