### PR TITLE
fix: add safety guardrails for destructive actions

### DIFF
--- a/Brewy/Models/BrewService+Actions.swift
+++ b/Brewy/Models/BrewService+Actions.swift
@@ -20,7 +20,11 @@ extension BrewService {
     }
 
     func upgradeAll() async {
+        let masOutdatedCount = outdatedPackages.filter(\.isMas).count
         await performBrewAction(["upgrade"], refreshAfter: true)
+        if masOutdatedCount > 0, lastError == nil {
+            lastError = .commandFailed(command: "upgrade", output: Self.masUpgradeMessage(count: masOutdatedCount))
+        }
     }
 
     func pin(package: BrewPackage) async { await performAction("pin", package: package) }
@@ -137,5 +141,12 @@ extension BrewService {
             infoCache[package.id] = result.output
         }
         return result.output
+    }
+
+    static func masUpgradeMessage(count: Int) -> String {
+        if count == 1 {
+            return "1 Mac App Store app must be updated in the App Store."
+        }
+        return "\(count) Mac App Store apps must be updated in the App Store."
     }
 }

--- a/Brewy/Models/BrewService+Fetching.swift
+++ b/Brewy/Models/BrewService+Fetching.swift
@@ -110,8 +110,8 @@ extension BrewService {
     // MARK: - Search
 
     func performSearch(query: String) async -> [BrewPackage] {
-        async let formulaeResult = runBrewCommand(["search", "--formula", query])
-        async let casksResult = runBrewCommand(["search", "--cask", query])
+        async let formulaeResult = runBrewCommand(["search", "--formula", "--", query])
+        async let casksResult = runBrewCommand(["search", "--cask", "--", query])
 
         let formulaeOutput = await formulaeResult
         let casksOutput = await casksResult

--- a/Brewy/Models/BrewService.swift
+++ b/Brewy/Models/BrewService.swift
@@ -358,20 +358,27 @@ final class BrewService {
 
         let formulae = packages.filter { $0.source == .formula }.map(\.name)
         let casks = packages.filter { $0.source == .cask }.map(\.name)
+        let masCount = packages.filter(\.isMas).count
+        var errorOutputs: [String] = []
 
         if !formulae.isEmpty {
             let args = ["upgrade"] + formulae
             let result = await runBrewCommand(args)
             actionOutput += result.output
-            if !result.success { lastError = .commandFailed(command: "upgrade", output: result.output) }
+            if !result.success { errorOutputs.append(result.output) }
             recordAction(arguments: args, packageName: nil, packageSource: .formula, success: result.success, output: result.output)
         }
         if !casks.isEmpty {
             let args = ["upgrade", "--cask"] + casks
             let result = await runBrewCommand(args)
             actionOutput += result.output
-            if !result.success { lastError = .commandFailed(command: "upgrade --cask", output: result.output) }
+            if !result.success { errorOutputs.append(result.output) }
             recordAction(arguments: args, packageName: nil, packageSource: .cask, success: result.success, output: result.output)
+        }
+        if !errorOutputs.isEmpty {
+            lastError = .commandFailed(command: "upgrade", output: errorOutputs.joined(separator: "\n\n"))
+        } else if masCount > 0 {
+            lastError = .commandFailed(command: "upgrade", output: Self.masUpgradeMessage(count: masCount))
         }
         await refresh()
     }

--- a/Brewy/Views/GroupsView.swift
+++ b/Brewy/Views/GroupsView.swift
@@ -5,6 +5,7 @@ struct GroupsView: View {
     private var brewService
     @Binding var selectedGroup: PackageGroup?
     @State private var showCreateSheet = false
+    @State private var groupPendingDeletion: PackageGroup?
 
     var body: some View {
         List(selection: $selectedGroup) {
@@ -20,10 +21,7 @@ struct GroupsView: View {
                         .tag(group)
                         .contextMenu {
                             Button("Delete Group", systemImage: "trash", role: .destructive) {
-                                if selectedGroup?.id == group.id {
-                                    selectedGroup = nil
-                                }
-                                brewService.deleteGroup(group)
+                                groupPendingDeletion = group
                             }
                         }
                 }
@@ -42,6 +40,28 @@ struct GroupsView: View {
         }
         .sheet(isPresented: $showCreateSheet) {
             CreateGroupSheet()
+        }
+        .confirmationDialog(
+            "Delete Group?",
+            isPresented: Binding(
+                get: { groupPendingDeletion != nil },
+                set: { if !$0 { groupPendingDeletion = nil } }
+            ),
+            titleVisibility: .visible,
+            presenting: groupPendingDeletion
+        ) { group in
+            Button("Delete", role: .destructive) {
+                if selectedGroup?.id == group.id {
+                    selectedGroup = nil
+                }
+                brewService.deleteGroup(group)
+                groupPendingDeletion = nil
+            }
+            Button("Cancel", role: .cancel) {
+                groupPendingDeletion = nil
+            }
+        } message: { group in
+            Text("This will delete \(group.name). Your packages will not be affected.")
         }
     }
 }

--- a/Brewy/Views/HistoryView.swift
+++ b/Brewy/Views/HistoryView.swift
@@ -4,6 +4,7 @@ struct HistoryView: View {
     @Environment(BrewService.self)
     private var brewService
     @Binding var selectedEntry: ActionHistoryEntry?
+    @State private var showClearConfirmation = false
 
     var body: some View {
         List(selection: $selectedEntry) {
@@ -25,12 +26,20 @@ struct HistoryView: View {
         .toolbar {
             ToolbarItem(placement: .primaryAction) {
                 Button("Clear History", systemImage: "trash") {
-                    selectedEntry = nil
-                    brewService.clearHistory()
+                    showClearConfirmation = true
                 }
                 .disabled(brewService.actionHistory.isEmpty)
                 .help("Clear all history")
             }
+        }
+        .confirmationDialog("Clear History?", isPresented: $showClearConfirmation, titleVisibility: .visible) {
+            Button("Clear History", role: .destructive) {
+                selectedEntry = nil
+                brewService.clearHistory()
+            }
+            Button("Cancel", role: .cancel) {}
+        } message: {
+            Text("This will permanently clear Brewy's local action history.")
         }
     }
 }

--- a/Brewy/Views/ServicesView.swift
+++ b/Brewy/Views/ServicesView.swift
@@ -6,6 +6,7 @@ struct ServicesView: View {
     @State private var services: [BrewServiceItem] = []
     @State private var isLoading = true
     @State private var errorMessage: String?
+    @State private var showCleanupConfirmation = false
     @Binding var selectedService: BrewServiceItem?
     var refreshTrigger: Int
 
@@ -33,7 +34,7 @@ struct ServicesView: View {
         .toolbar {
             ToolbarItem(placement: .primaryAction) {
                 Button {
-                    Task { await cleanupServices() }
+                    showCleanupConfirmation = true
                 } label: {
                     Label("Cleanup", systemImage: "trash")
                 }
@@ -52,6 +53,18 @@ struct ServicesView: View {
             Button("OK") { errorMessage = nil }
         } message: { message in
             Text(message)
+        }
+        .confirmationDialog(
+            "Clean Up Stale Services?",
+            isPresented: $showCleanupConfirmation,
+            titleVisibility: .visible
+        ) {
+            Button("Cleanup", role: .destructive) {
+                Task { await cleanupServices() }
+            }
+            Button("Cancel", role: .cancel) {}
+        } message: {
+            Text("This will remove stale Homebrew service files.")
         }
     }
 

--- a/Brewy/Views/TapListView.swift
+++ b/Brewy/Views/TapListView.swift
@@ -5,6 +5,7 @@ struct TapListView: View {
     private var brewService
     @Binding var selectedTap: BrewTap?
     @State private var showAddSheet = false
+    @State private var tapPendingRemoval: BrewTap?
 
     var body: some View {
         List(selection: $selectedTap) {
@@ -20,9 +21,7 @@ struct TapListView: View {
                         .tag(tap)
                         .contextMenu {
                             Button("Remove Tap", role: .destructive) {
-                                let name = tap.name
-                                if selectedTap?.name == name { selectedTap = nil }
-                                Task { await brewService.removeTap(name: name) }
+                                tapPendingRemoval = tap
                             }
                         }
                 }
@@ -41,6 +40,27 @@ struct TapListView: View {
         }
         .sheet(isPresented: $showAddSheet) {
             AddTapSheet()
+        }
+        .confirmationDialog(
+            "Remove Tap?",
+            isPresented: Binding(
+                get: { tapPendingRemoval != nil },
+                set: { if !$0 { tapPendingRemoval = nil } }
+            ),
+            titleVisibility: .visible,
+            presenting: tapPendingRemoval
+        ) { tap in
+            Button("Remove Tap", role: .destructive) {
+                let name = tap.name
+                if selectedTap?.name == name { selectedTap = nil }
+                tapPendingRemoval = nil
+                Task { await brewService.removeTap(name: name) }
+            }
+            Button("Cancel", role: .cancel) {
+                tapPendingRemoval = nil
+            }
+        } message: { _ in
+            Text("This removes the tap repository from your Homebrew installation.")
         }
         .overlay {
             if brewService.isLoading, brewService.installedTaps.isEmpty {
@@ -211,6 +231,7 @@ struct TapDetailView: View {
     @Environment(BrewService.self)
     private var brewService
     let tap: BrewTap
+    @State private var showRemoveConfirmation = false
 
     private var installedFormulae: [BrewPackage] {
         let names = Set(tap.formulaNames)
@@ -224,6 +245,23 @@ struct TapDetailView: View {
 
     private var healthStatus: TapHealthStatus? {
         brewService.tapHealthStatuses[tap.name]
+    }
+
+    private var installedPackageCount: Int {
+        installedFormulae.count + installedCasks.count
+    }
+
+    private var removeConfirmationMessage: String {
+        if installedPackageCount > 0 {
+            let packageLabel = installedPackageCount == 1 ? "package" : "packages"
+            let verb = installedPackageCount == 1 ? "is" : "are"
+            let pronoun = installedPackageCount == 1 ? "that package" : "those packages"
+            return """
+            Homebrew will refuse to remove this tap while \(installedPackageCount) \(packageLabel) \
+            from it \(verb) installed. Uninstall \(pronoun) first.
+            """
+        }
+        return "This removes the tap repository from your Homebrew installation."
     }
 
     var body: some View {
@@ -269,12 +307,20 @@ struct TapDetailView: View {
 
             Section {
                 Button("Remove Tap", role: .destructive) {
-                    Task { await brewService.removeTap(name: tap.name) }
+                    showRemoveConfirmation = true
                 }
             }
         }
         .formStyle(.grouped)
         .navigationTitle(tap.name)
+        .confirmationDialog("Remove \(tap.name)?", isPresented: $showRemoveConfirmation, titleVisibility: .visible) {
+            Button("Remove Tap", role: .destructive) {
+                Task { await brewService.removeTap(name: tap.name) }
+            }
+            Button("Cancel", role: .cancel) {}
+        } message: {
+            Text(removeConfirmationMessage)
+        }
     }
 }
 
@@ -286,6 +332,7 @@ private struct TapHealthWarningSection: View {
     let tap: BrewTap
     let healthStatus: TapHealthStatus
     @State private var showMigrateConfirmation = false
+    @State private var showRemoveConfirmation = false
 
     private var movedToTapName: String? {
         guard let movedTo = healthStatus.movedTo else { return nil }
@@ -364,7 +411,15 @@ private struct TapHealthWarningSection: View {
             }
 
             Button("Remove Tap", role: .destructive) {
-                Task { await brewService.removeTap(name: tap.name) }
+                showRemoveConfirmation = true
+            }
+            .confirmationDialog("Remove \(tap.name)?", isPresented: $showRemoveConfirmation, titleVisibility: .visible) {
+                Button("Remove Tap", role: .destructive) {
+                    Task { await brewService.removeTap(name: tap.name) }
+                }
+                Button("Cancel", role: .cancel) {}
+            } message: {
+                Text("This removes the tap repository from your Homebrew installation.")
             }
         }
     }

--- a/BrewyTests/BrewServiceAsyncTests.swift
+++ b/BrewyTests/BrewServiceAsyncTests.swift
@@ -198,8 +198,8 @@ struct SearchTests {
     func searchReturnsBoth() async {
         let mock = MockCommandRunner()
         let (service, _) = makeService(mock: mock)
-        mock.setResult(for: ["search", "--formula", "fire"], output: "firewalld\nfirejail")
-        mock.setResult(for: ["search", "--cask", "fire"], output: "firefox\nfirealpaca")
+        mock.setResult(for: ["search", "--formula", "--", "fire"], output: "firewalld\nfirejail")
+        mock.setResult(for: ["search", "--cask", "--", "fire"], output: "firefox\nfirealpaca")
 
         await service.search(query: "fire")
 
@@ -215,8 +215,8 @@ struct SearchTests {
         let (service, _) = makeService(mock: mock)
         service.installedFormulae = [makePackage(name: "wget")]
 
-        mock.setResult(for: ["search", "--formula", "wget"], output: "wget\nwget2")
-        mock.setResult(for: ["search", "--cask", "wget"], output: "")
+        mock.setResult(for: ["search", "--formula", "--", "wget"], output: "wget\nwget2")
+        mock.setResult(for: ["search", "--cask", "--", "wget"], output: "")
 
         await service.search(query: "wget")
 
@@ -241,8 +241,8 @@ struct SearchTests {
     func searchHandlesFailure() async {
         let mock = MockCommandRunner()
         let (service, _) = makeService(mock: mock)
-        mock.setResult(for: ["search", "--formula", "test"], output: "Error", success: false)
-        mock.setResult(for: ["search", "--cask", "test"], output: "test-app")
+        mock.setResult(for: ["search", "--formula", "--", "test"], output: "Error", success: false)
+        mock.setResult(for: ["search", "--cask", "--", "test"], output: "test-app")
 
         await service.search(query: "test")
 
@@ -254,8 +254,8 @@ struct SearchTests {
     func searchFiltersHeaders() async {
         let mock = MockCommandRunner()
         let (service, _) = makeService(mock: mock)
-        mock.setResult(for: ["search", "--formula", "test"], output: "==> Formulae\ntest-formula")
-        mock.setResult(for: ["search", "--cask", "test"], output: "==> Casks\ntest-cask")
+        mock.setResult(for: ["search", "--formula", "--", "test"], output: "==> Formulae\ntest-formula")
+        mock.setResult(for: ["search", "--cask", "--", "test"], output: "==> Casks\ntest-cask")
 
         await service.search(query: "test")
 
@@ -272,8 +272,8 @@ struct SearchTests {
     func searchResultSourceTypes() async {
         let mock = MockCommandRunner()
         let (service, _) = makeService(mock: mock)
-        mock.setResult(for: ["search", "--formula", "test"], output: "test-formula")
-        mock.setResult(for: ["search", "--cask", "test"], output: "test-cask")
+        mock.setResult(for: ["search", "--formula", "--", "test"], output: "test-formula")
+        mock.setResult(for: ["search", "--cask", "--", "test"], output: "test-cask")
 
         await service.search(query: "test")
 

--- a/BrewyTests/ErrorPersistenceTests.swift
+++ b/BrewyTests/ErrorPersistenceTests.swift
@@ -20,6 +20,32 @@ struct ErrorPersistenceTests {
         #expect(service.lastError?.localizedDescription.contains("Refusing to untap") == true)
     }
 
+    @Test("performBrewAction preserves command failure after refresh")
+    func brewActionPreservesFailureAfterRefresh() async {
+        let mock = MockCommandRunner()
+        let (service, _) = makeService(mock: mock)
+        setupRefreshMock(mock)
+        mock.setResult(for: ["autoremove"], output: "autoremove failed", success: false)
+
+        await service.performBrewAction(["autoremove"], refreshAfter: true)
+
+        #expect(service.lastError != nil)
+        #expect(service.lastError?.localizedDescription.contains("autoremove failed") == true)
+    }
+
+    @Test("upgradeSelected preserves command failure after refresh")
+    func upgradeSelectedPreservesFailureAfterRefresh() async {
+        let mock = MockCommandRunner()
+        let (service, _) = makeService(mock: mock)
+        setupRefreshMock(mock)
+        mock.setResult(for: ["upgrade", "wget"], output: "upgrade failed", success: false)
+
+        await service.upgradeSelected(packages: [makePackage(name: "wget", isOutdated: true)])
+
+        #expect(service.lastError != nil)
+        #expect(service.lastError?.localizedDescription.contains("upgrade failed") == true)
+    }
+
     @Test("queued refresh preserves an error set while waiting")
     func queuedRefreshPreservesLateError() async {
         let mock = MockCommandRunner()

--- a/BrewyTests/SecurityHelpersTests.swift
+++ b/BrewyTests/SecurityHelpersTests.swift
@@ -61,3 +61,52 @@ struct ReleaseNotesHTMLTests {
         #expect(stripped.range(of: "src=", options: .caseInsensitive) == nil)
     }
 }
+
+@Suite("BrewService Safety Guardrails")
+@MainActor
+struct BrewServiceSafetyGuardrailTests {
+
+    @Test("search inserts option separator before query")
+    func searchUsesOptionSeparator() async {
+        let mock = MockCommandRunner()
+        let (service, _) = makeService(mock: mock)
+        mock.setResult(for: ["search", "--formula", "--", "--eval-all"], output: "safe-result")
+        mock.setResult(for: ["search", "--cask", "--", "--eval-all"], output: "")
+
+        await service.search(query: "--eval-all")
+
+        #expect(mock.executedCommands.contains(["search", "--formula", "--", "--eval-all"]))
+        #expect(mock.executedCommands.contains(["search", "--cask", "--", "--eval-all"]))
+    }
+
+    @Test("upgradeSelected excludes mas apps and reports App Store updates")
+    func upgradeSelectedReportsMasApps() async {
+        let mock = MockCommandRunner()
+        let (service, _) = makeService(mock: mock)
+        setupRefreshMock(mock)
+
+        let formula = makePackage(name: "wget", source: .formula)
+        let masApp = makePackage(name: "Xcode", source: .mas)
+        mock.setResult(for: ["upgrade", "wget"], output: "Upgraded wget")
+
+        await service.upgradeSelected(packages: [formula, masApp])
+
+        #expect(mock.executedCommands.contains(["upgrade", "wget"]))
+        #expect(!mock.executedCommands.contains { $0.contains("Xcode") })
+        #expect(service.lastError?.localizedDescription.contains("Mac App Store") == true)
+    }
+
+    @Test("upgradeAll reports outdated mas apps separately")
+    func upgradeAllReportsMasApps() async {
+        let mock = MockCommandRunner()
+        let (service, _) = makeService(mock: mock)
+        setupRefreshMock(mock)
+        service.outdatedPackages = [makePackage(name: "Xcode", source: .mas, isOutdated: true)]
+        mock.setResult(for: ["upgrade"], output: "All upgraded")
+
+        await service.upgradeAll()
+
+        #expect(mock.executedCommands.contains(["upgrade"]))
+        #expect(service.lastError?.localizedDescription.contains("Mac App Store") == true)
+    }
+}


### PR DESCRIPTION
Adds the missing rule 4 guardrails and two adjacent fixes:

- Tap removal, services cleanup, group deletion, and history clearing now require confirmation. The tap dialogs reflect that `brew untap` refuses to remove a tap while packages from it are installed.
- `brew search` queries are passed after a `--` separator so a leading-dash query cannot be parsed as a flag.
- Bulk upgrades keep Mac App Store apps out of `brew upgrade` and report how many need updating in the App Store; formula and cask upgrade errors accumulate instead of overwriting each other.

Stacked on #205; based on `brewy-tier1-correctness` until that merges, then this will be rebased onto `main`.