### PR TITLE
ci: tighten release and local checks

### DIFF
--- a/.githooks/commit-msg
+++ b/.githooks/commit-msg
@@ -6,6 +6,13 @@
 # (sets core.hooksPath to this directory).
 
 msg_file="$1"
+subject=$(sed -n '1p' "$msg_file")
+
+case "$subject" in
+    fixup!\ *|squash!\ *|Merge\ *)
+        exit 0
+        ;;
+esac
 
 if ! grep -qE '^Signed-off-by: .+ <.+@.+>' "$msg_file"; then
     echo "commit-msg hook: missing DCO sign-off." >&2

--- a/.githooks/pre-push
+++ b/.githooks/pre-push
@@ -1,3 +1,8 @@
 #!/bin/sh
 # Runs the same checks as CI before pushing.
+if ! command -v just >/dev/null 2>&1; then
+    echo "pre-push hook: 'just' is required. Install it with 'brew install just'." >&2
+    exit 127
+fi
+
 just check

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -55,9 +55,24 @@ jobs:
           # one on the same SHA, bypassing tests, lint, CodeQL and the rest.
           CHANGED=$(git diff --name-only "${BASE_SHA}...HEAD")
 
+          NEEDS_LINT=0
+          NEEDS_TESTS=0
+
           # Swift or CI workflow changes: lint + sanitizer tests
           if echo "${CHANGED}" | grep -qE '\.swift$|^Brewy\.xcodeproj/|^\.swiftlint\.yml$|^\.github/workflows/ci\.yml$'; then
+            NEEDS_LINT=1
+            NEEDS_TESTS=1
+          fi
+
+          # Docs, typo config, or release workflow changes: lint/typos + lockstep checks
+          if echo "${CHANGED}" | grep -qE '\.md$|^_typos\.toml$|^\.github/workflows/release\.yml$'; then
+            NEEDS_LINT=1
+          fi
+
+          if [[ "${NEEDS_LINT}" -eq 1 ]]; then
             MATRIX+=',{"name":"Lint","check":"lint","runner":"macos-26"}'
+          fi
+          if [[ "${NEEDS_TESTS}" -eq 1 ]]; then
             MATRIX+=',{"name":"Test (Thread Sanitizer)","check":"test-tsan","runner":"macos-26","xcodebuild_flags":"-enableCodeCoverage YES -enableThreadSanitizer YES","result_bundle":"TestResults-TSAN","environment":"codecov"}'
             # UI test runner is incompatible with ASan (crashes at launch); TSan covers the UI tests.
             MATRIX+=',{"name":"Test (Address Sanitizer)","check":"test-asan","runner":"macos-26","xcodebuild_flags":"-enableAddressSanitizer YES -skip-testing:BrewyUITests","result_bundle":"TestResults-ASAN"}'
@@ -170,6 +185,34 @@ jobs:
       - name: Typos
         if: matrix.check == 'lint'
         run: typos
+
+      - name: Sparkle version lockstep
+        if: matrix.check == 'lint'
+        run: |
+          PACKAGE_RESOLVED="Brewy.xcodeproj/project.xcworkspace/xcshareddata/swiftpm/Package.resolved"
+          RESOLVED_VERSION=$(
+            python3 -c '
+          import json
+          import sys
+
+          with open(sys.argv[1], encoding="utf-8") as package_resolved:
+              pins = json.load(package_resolved).get("pins", [])
+
+          for pin in pins:
+              if pin.get("identity") == "sparkle":
+                  print(pin.get("state", {}).get("version", ""))
+                  break
+          ' "${PACKAGE_RESOLVED}"
+          )
+          RELEASE_VERSION=$(awk -F'"' '/SPARKLE_VERSION:/ { print $2; exit }' .github/workflows/release.yml)
+          if [[ -z "${RESOLVED_VERSION}" || -z "${RELEASE_VERSION}" ]]; then
+            echo "::error::Could not read Sparkle versions from Package.resolved and release.yml."
+            exit 1
+          fi
+          if [[ "${RESOLVED_VERSION}" != "${RELEASE_VERSION}" ]]; then
+            echo "::error::Sparkle Package.resolved version (${RESOLVED_VERSION}) does not match release.yml (${RELEASE_VERSION})."
+            exit 1
+          fi
 
       # --- Periphery (dead-code scan) ---
 

--- a/.github/workflows/link-check.yml
+++ b/.github/workflows/link-check.yml
@@ -1,6 +1,11 @@
 name: Link Check
 
 on:
+  pull_request:
+    paths:
+      - "README.md"
+      - "CONTRIBUTING.md"
+      - "lychee.toml"
   schedule:
     - cron: "0 14 * * 1" # every Monday at 14:00 UTC
   workflow_dispatch:
@@ -8,7 +13,7 @@ on:
 permissions: {}
 
 concurrency:
-  group: link-check
+  group: link-check-${{ github.ref }}
   cancel-in-progress: true
 
 defaults:

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -72,6 +72,20 @@ jobs:
           echo "build_number=${BUILD_NUMBER}" >> "${GITHUB_OUTPUT}"
           echo "TAG=${TAG}" >> "${GITHUB_ENV}"
 
+      - name: Ensure release tag is available
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          REPOSITORY: ${{ github.repository }}
+        run: |
+          if gh release view "${TAG}" --repo "${REPOSITORY}" >/dev/null 2>&1; then
+            echo "::error::Release ${TAG} already exists."
+            exit 1
+          fi
+          if gh api "repos/${REPOSITORY}/git/ref/tags/${TAG}" >/dev/null 2>&1; then
+            echo "::error::Tag ${TAG} already exists."
+            exit 1
+          fi
+
       - name: Create and unlock temporary macOS keychain
         run: |
           # Keep xtrace disabled here: this password is generated at runtime and is not a registered secret.
@@ -192,6 +206,21 @@ jobs:
             "${RUNNER_TEMP}/staple/Brewy.app" \
             "${ARTIFACT_NAME}"
 
+      - name: Verify stapled app
+        env:
+          ARTIFACT_NAME: ${{ needs.build.outputs.artifact_name }}
+        run: |
+          ditto -xk "${ARTIFACT_NAME}" "${RUNNER_TEMP}/verify"
+          APP_PATH="${RUNNER_TEMP}/verify/Brewy.app"
+          codesign --verify --deep --strict --verbose=2 "${APP_PATH}"
+          xcrun stapler validate "${APP_PATH}"
+          spctl -a -t exec -vv "${APP_PATH}"
+          BUNDLE_VERSION=$(/usr/libexec/PlistBuddy -c 'Print :CFBundleShortVersionString' "${APP_PATH}/Contents/Info.plist")
+          if [[ "${BUNDLE_VERSION}" != "${TAG}" ]]; then
+            echo "::error::Built app version ${BUNDLE_VERSION} does not match release tag ${TAG}."
+            exit 1
+          fi
+
       - name: Generate build provenance for the published asset
         uses: actions/attest@a1948c3f048ba23858d222213b7c278aabede763 # v4.1.1
         with:
@@ -224,24 +253,16 @@ jobs:
           echo "SPARKLE_SIG=$(echo "${SIG_OUTPUT}" | grep -o 'sparkle:edSignature="[^"]*"' | cut -d'"' -f2)" >> "${GITHUB_ENV}"
           echo "SPARKLE_LENGTH=$(echo "${SIG_OUTPUT}" | grep -o 'length="[^"]*"' | cut -d'"' -f2)" >> "${GITHUB_ENV}"
 
-      - name: Create tag
-        env:
-          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
-          REPOSITORY: ${{ github.repository }}
-          COMMIT_SHA: ${{ github.sha }}
-        run: |
-          gh api "repos/${REPOSITORY}/git/refs" \
-            -f "ref=refs/tags/${TAG}" \
-            -f "sha=${COMMIT_SHA}"
-
       - name: Create release with generated notes
         env:
           GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
           ARTIFACT_NAME: ${{ needs.build.outputs.artifact_name }}
           REPOSITORY: ${{ github.repository }}
+          COMMIT_SHA: ${{ github.sha }}
         run: |
           gh release create "${TAG}" \
             --repo "${REPOSITORY}" \
+            --target "${COMMIT_SHA}" \
             --title "${TAG}" \
             --generate-notes \
             "${ARTIFACT_NAME}"
@@ -290,15 +311,15 @@ jobs:
         run: |
           git config user.name "github-actions[bot]"
           git config user.email "41898282+github-actions[bot]@users.noreply.github.com"
-          git remote set-url origin "https://x-access-token:${GH_TOKEN}@github.com/${REPOSITORY}.git"
+          AUTH_HEADER="$(printf 'x-access-token:%s' "${GH_TOKEN}" | base64 | tr -d '\n')"
           cp appcast.xml "${RUNNER_TEMP}/appcast.xml"
-          git fetch origin appcast
+          git -c "http.extraheader=AUTHORIZATION: Basic ${AUTH_HEADER}" fetch origin appcast
           git checkout appcast
           cp "${RUNNER_TEMP}/appcast.xml" appcast.xml
           git add appcast.xml
           git diff --cached --quiet && exit 0
           git commit -m "Update appcast for ${TAG}"
-          git push origin appcast
+          git -c "http.extraheader=AUTHORIZATION: Basic ${AUTH_HEADER}" push origin appcast
 
   bump-cask:
     name: Bump tap cask

--- a/justfile
+++ b/justfile
@@ -99,9 +99,15 @@ check:
     fi
     if command -v periphery &>/dev/null; then
         # Match CI: tolerate periphery:ignore comments CI sees as redundant (SwiftUI $-binding refs).
-        run periphery scan --strict --disable-update-check --no-superfluous-ignore-comments
+        run periphery scan --strict --disable-update-check --no-superfluous-ignore-comments \
+            -- CODE_SIGNING_REQUIRED=NO CODE_SIGNING_ALLOWED=NO EXCLUDED_ARCHS=x86_64
     else
         skip periphery periphery periphery
+    fi
+    if command -v lychee &>/dev/null; then
+        run lychee --config lychee.toml README.md CONTRIBUTING.md
+    else
+        skip lychee lychee lychee
     fi
     run xcodebuild test \
         -project Brewy.xcodeproj \


### PR DESCRIPTION
CI:

- The lint leg now also runs for docs, typos config, and release workflow changes, and verifies the Sparkle version in `Package.resolved` (looked up by pin identity) matches `release.yml`.
- lychee runs on pull requests touching README, CONTRIBUTING, or `lychee.toml`, with a per-ref concurrency group.

Release workflow:

- Fails early when the tag or release already exists, before any archive or notarization work.
- Creates the tag and release atomically with `gh release create --target`.
- Verifies the stapled app (`codesign --verify --deep --strict`, `stapler validate`, `spctl`, and bundle version matches the tag) before publishing.
- Scopes the appcast push credential to individual git invocations instead of persisting it in `.git/config`.

Local:

- `just check` runs lychee and matches CI's periphery build settings.
- The DCO hook lets `fixup!`, `squash!`, and merge commits through; pre-push explains how to install `just` when it is missing.