### PR TITLE
docs: add repository hygiene templates

### DIFF
--- a/.github/ISSUE_TEMPLATE/bug_report.yml
+++ b/.github/ISSUE_TEMPLATE/bug_report.yml
@@ -1,0 +1,68 @@
+name: Bug report
+description: Report a reproducible problem in Brewy.
+title: "fix: "
+labels:
+  - bug
+body:
+  - type: markdown
+    attributes:
+      value: |
+        Thanks for helping improve Brewy. Please do not include secrets, tokens,
+        or private local paths in logs or screenshots.
+  - type: textarea
+    id: summary
+    attributes:
+      label: Summary
+      description: What happened?
+    validations:
+      required: true
+  - type: textarea
+    id: steps
+    attributes:
+      label: Steps to reproduce
+      description: List the smallest set of steps that triggers the issue.
+      placeholder: |
+        1. Open ...
+        2. Click ...
+        3. See ...
+    validations:
+      required: true
+  - type: textarea
+    id: expected
+    attributes:
+      label: Expected behavior
+      description: What did you expect Brewy to do?
+    validations:
+      required: true
+  - type: textarea
+    id: actual
+    attributes:
+      label: Actual behavior
+      description: What did Brewy do instead?
+    validations:
+      required: true
+  - type: input
+    id: brewy-version
+    attributes:
+      label: Brewy version
+      placeholder: "0.15.0"
+    validations:
+      required: true
+  - type: input
+    id: macos-version
+    attributes:
+      label: macOS version
+      placeholder: "15.5"
+    validations:
+      required: true
+  - type: input
+    id: brew-path
+    attributes:
+      label: Homebrew path
+      placeholder: "/opt/homebrew/bin/brew"
+  - type: textarea
+    id: logs
+    attributes:
+      label: Logs or screenshots
+      description: Add relevant output after removing secrets, tokens, and private paths.
+      render: text

--- a/.github/ISSUE_TEMPLATE/config.yml
+++ b/.github/ISSUE_TEMPLATE/config.yml
@@ -1,0 +1,5 @@
+blank_issues_enabled: true
+contact_links:
+  - name: Report a security vulnerability
+    url: https://github.com/starhaven-io/Brewy/security/advisories/new
+    about: Please report vulnerabilities privately instead of opening a public issue.

--- a/.github/ISSUE_TEMPLATE/feature_request.yml
+++ b/.github/ISSUE_TEMPLATE/feature_request.yml
@@ -1,0 +1,25 @@
+name: Feature request
+description: Suggest a focused improvement to Brewy.
+title: "feat: "
+labels:
+  - enhancement
+body:
+  - type: textarea
+    id: problem
+    attributes:
+      label: Problem
+      description: What workflow or limitation should this improve?
+    validations:
+      required: true
+  - type: textarea
+    id: proposal
+    attributes:
+      label: Proposal
+      description: What should Brewy do?
+    validations:
+      required: true
+  - type: textarea
+    id: alternatives
+    attributes:
+      label: Alternatives considered
+      description: Optional context or tradeoffs.

--- a/.github/PULL_REQUEST_TEMPLATE.md
+++ b/.github/PULL_REQUEST_TEMPLATE.md
@@ -1,0 +1,4 @@
+<!-- Keep the PR description to a concise summary. Do not add generated footers,
+test-plan sections, or tool-attribution sections. -->
+
+Summary:

--- a/SECURITY.md
+++ b/SECURITY.md
@@ -1,0 +1,34 @@
+# Security Policy
+
+## Supported Versions
+
+Security fixes are made against the current `main` branch and the latest released
+version of Brewy.
+
+## Reporting a Vulnerability
+
+Please do not report security vulnerabilities in a public issue.
+
+Use GitHub private vulnerability reporting for this repository:
+
+https://github.com/starhaven-io/Brewy/security/advisories/new
+
+If private vulnerability reporting is unavailable, open a public issue with no
+technical details and ask for a private contact path.
+
+Helpful reports include:
+
+- Affected Brewy version or commit.
+- macOS version and processor architecture.
+- Homebrew path and relevant `brew` or `mas` version.
+- Steps to reproduce and the security impact.
+- Logs or command output with secrets, tokens, and local private paths removed.
+
+Brewy executes the user's local Homebrew installation and displays package, tap,
+appcast, and release-note metadata from external sources. Vulnerabilities in
+individual formulae, casks, taps, or upstream packages should usually be reported
+to the upstream project or tap maintainer unless Brewy changes the security
+impact.
+
+We will acknowledge private reports as soon as practical, investigate the issue,
+and coordinate disclosure timing with the reporter when a fix is needed.


### PR DESCRIPTION
Adds a security policy, a pull request template, and structured issue forms.

- `SECURITY.md` directs vulnerability reports to GitHub private advisories and notes that formula, cask, and tap issues usually belong upstream unless Brewy changes the impact.
- The pull request template keeps descriptions to a concise summary.
- Bug and feature issue forms seed Conventional-Commit titles and use the built-in `bug`/`enhancement` labels; `config.yml` surfaces the private security-reporting link.