### PR TITLE
test: cover small service and summary gaps

### DIFF
--- a/BrewyTests/BrewServiceTests.swift
+++ b/BrewyTests/BrewServiceTests.swift
@@ -293,6 +293,30 @@ struct BrewErrorTests {
         let error = BrewError.commandFailed(command: "install wget", output: "Error: wget already installed")
         #expect(error.errorDescription == "Error: wget already installed")
     }
+
+    @Test("commandFailed reports command when output is empty")
+    func commandFailedEmptyOutput() {
+        let error = BrewError.commandFailed(command: "install wget", output: " \n ")
+
+        #expect(error.errorDescription == "brew install wget failed.")
+    }
+
+    @Test("commandFailed summarizes the last six output lines")
+    func commandFailedUsesOutputTail() {
+        let output = (1...8).map { "line \($0)" }.joined(separator: "\n")
+        let error = BrewError.commandFailed(command: "install wget", output: output)
+
+        #expect(error.errorDescription == "line 3\nline 4\nline 5\nline 6\nline 7\nline 8")
+    }
+
+    @Test("commandFailed truncates long output tails")
+    func commandFailedTruncatesLongOutput() {
+        let longLine = String(repeating: "x", count: 900)
+        let error = BrewError.commandFailed(command: "install wget", output: longLine)
+
+        #expect(error.errorDescription?.first == "…")
+        #expect(error.errorDescription?.count == 801)
+    }
 }
 
 // MARK: - CommandRunner Tests

--- a/BrewyTests/DryRunTests.swift
+++ b/BrewyTests/DryRunTests.swift
@@ -54,4 +54,44 @@ struct DryRunTests {
         #expect(!result.success)
         #expect(result.output == "Permission denied")
     }
+
+    @Test("cacheSize trims brew cache path and converts KiB to bytes")
+    func cacheSizeConvertsKilobytes() async {
+        let mock = MockCommandRunner()
+        let (service, _) = makeService(mock: mock)
+        mock.setResult(for: ["--cache"], output: " /Users/test/Library/Caches/Homebrew \n")
+        mock.setResult(for: ["-sk", "/Users/test/Library/Caches/Homebrew"], output: "42\t/Users/test/Library/Caches/Homebrew")
+
+        let size = await service.cacheSize()
+
+        #expect(mock.executedCommands.contains(["--cache"]))
+        #expect(mock.executedExecutables.contains { entry in
+            entry.path == "/usr/bin/du" && entry.arguments == ["-sk", "/Users/test/Library/Caches/Homebrew"]
+        })
+        #expect(size == 42 * 1_024)
+    }
+
+    @Test("cacheSize returns zero when brew cache path is empty")
+    func cacheSizeEmptyPath() async {
+        let mock = MockCommandRunner()
+        let (service, _) = makeService(mock: mock)
+        mock.setResult(for: ["--cache"], output: "\n")
+
+        let size = await service.cacheSize()
+
+        #expect(size == 0)
+        #expect(!mock.executedExecutables.contains { $0.path == "/usr/bin/du" })
+    }
+
+    @Test("cacheSize returns zero when du fails or returns malformed output")
+    func cacheSizeInvalidDuOutput() async {
+        let mock = MockCommandRunner()
+        let (service, _) = makeService(mock: mock)
+        mock.setResult(for: ["--cache"], output: "/tmp/homebrew-cache")
+        mock.setResult(for: ["-sk", "/tmp/homebrew-cache"], output: "not-a-number\t/tmp/homebrew-cache")
+
+        let size = await service.cacheSize()
+
+        #expect(size == 0)
+    }
 }

--- a/BrewyTests/GroupsAndMasTests.swift
+++ b/BrewyTests/GroupsAndMasTests.swift
@@ -239,6 +239,17 @@ struct MasOutputParsingTests {
         #expect(packages.isEmpty)
     }
 
+    @Test("parseMasOutdated uses the same version when no arrow is present")
+    func parseMasOutdatedWithoutArrow() {
+        let output = "497799835 Xcode (16.0)\n"
+        let packages = MasParser.parseOutdated(output)
+
+        #expect(packages.count == 1)
+        #expect(packages[0].installedVersion == "16.0")
+        #expect(packages[0].latestVersion == "16.0")
+        #expect(packages[0].version == "16.0")
+    }
+
     @Test("parseMasList generates App Store homepage URLs")
     func parseMasListHomepage() {
         let output = "497799835 Xcode (15.4)\n"

--- a/BrewyTests/JSONAndServicesTests.swift
+++ b/BrewyTests/JSONAndServicesTests.swift
@@ -163,4 +163,43 @@ struct ServicesIntegrationTests {
         #expect(services.count == 1)
         #expect(services[0].name == "redis")
     }
+
+    @Test("fetchServices returns empty when both service commands fail")
+    func fetchServicesDoubleFailure() async {
+        let mock = MockCommandRunner()
+        let service = BrewService(commandRunner: mock)
+        mock.setResult(for: ["services", "info", "--all", "--json"], output: "info failed", success: false)
+        mock.setResult(for: ["services", "list", "--json"], output: "list failed", success: false)
+
+        let services = await service.fetchServices()
+
+        #expect(services.isEmpty)
+        #expect(mock.executedCommands.contains(["services", "info", "--all", "--json"]))
+        #expect(mock.executedCommands.contains(["services", "list", "--json"]))
+    }
+
+    @Test("cleanupServices runs brew services cleanup")
+    func cleanupServicesRunsCommand() async {
+        let mock = MockCommandRunner()
+        let service = BrewService(commandRunner: mock)
+        mock.setResult(for: ["services", "cleanup"], output: "Cleaned")
+
+        let result = await service.cleanupServices()
+
+        #expect(result.success)
+        #expect(result.output == "Cleaned")
+        #expect(mock.executedCommands.contains(["services", "cleanup"]))
+    }
+
+    @Test("cleanupServices preserves failure result")
+    func cleanupServicesPreservesFailure() async {
+        let mock = MockCommandRunner()
+        let service = BrewService(commandRunner: mock)
+        mock.setResult(for: ["services", "cleanup"], output: "cleanup failed", success: false)
+
+        let result = await service.cleanupServices()
+
+        #expect(!result.success)
+        #expect(result.output == "cleanup failed")
+    }
 }


### PR DESCRIPTION
Adds unit coverage for previously untested pure helpers. No production changes.

- `BrewError.summarize`: empty output, six-line tail, and 800-character truncation.
- `cacheSize`: path trimming, `du -sk` invocation, KiB-to-bytes math, and both zero paths.
- `MasParser.parseOutdated`: the branch where mas reports a single version with no arrow.
- `ServicesService`: `fetchServices` double-failure and `cleanupServices` success/failure.