### PR TITLE
test: cover execution safety mapping

### DIFF
--- a/Brewy/Models/CommandRunner.swift
+++ b/Brewy/Models/CommandRunner.swift
@@ -93,11 +93,14 @@ enum CommandRunner {
         return preferred
     }
 
-    static func resolvedPrivilegedBrewPath(preferred: String) -> String? {
+    static func resolvedPrivilegedBrewPath(
+        preferred: String,
+        standardPaths: [String] = standardBrewPaths
+    ) -> String? {
         if FileManager.default.isExecutableFile(atPath: preferred) {
-            return standardBrewPath(matching: preferred)
+            return standardBrewPath(matching: preferred, standardPaths: standardPaths)
         }
-        return standardBrewPaths.first { FileManager.default.isExecutableFile(atPath: $0) }
+        return standardPaths.first { FileManager.default.isExecutableFile(atPath: $0) }
     }
 
     static func run(
@@ -164,9 +167,9 @@ enum CommandRunner {
         return env
     }
 
-    private static func standardBrewPath(matching path: String) -> String? {
+    private static func standardBrewPath(matching path: String, standardPaths: [String]) -> String? {
         let resolvedPath = URL(fileURLWithPath: path).resolvingSymlinksInPath().path
-        return standardBrewPaths.first { standardPath in
+        return standardPaths.first { standardPath in
             FileManager.default.isExecutableFile(atPath: standardPath)
                 && URL(fileURLWithPath: standardPath).resolvingSymlinksInPath().path == resolvedPath
         }

--- a/Brewy/Models/TapHealthChecker.swift
+++ b/Brewy/Models/TapHealthChecker.swift
@@ -151,7 +151,7 @@ enum TapHealthChecker {
         }
     }
 
-    private static func mapResponse(
+    static func mapResponse(
         statusCode: Int,
         data: Data,
         response: HTTPURLResponse,

--- a/BrewyTests/BrewServiceTests.swift
+++ b/BrewyTests/BrewServiceTests.swift
@@ -323,6 +323,27 @@ struct CommandRunnerTests {
         let path = CommandRunner.resolvedPrivilegedBrewPath(preferred: "/bin/sh")
         #expect(path == nil)
     }
+
+    @Test("resolvedPrivilegedBrewPath accepts symlink to standard executable")
+    func privilegedPathAcceptsSymlinkToStandardExecutable() throws {
+        let directory = FileManager.default.temporaryDirectory
+            .appendingPathComponent("brewy-command-runner-\(UUID().uuidString)", isDirectory: true)
+        try FileManager.default.createDirectory(at: directory, withIntermediateDirectories: true)
+        defer { try? FileManager.default.removeItem(at: directory) }
+
+        let standardBrew = directory.appendingPathComponent("brew")
+        let alias = directory.appendingPathComponent("custom-brew")
+        try Data("#!/bin/sh\nexit 0\n".utf8).write(to: standardBrew)
+        try FileManager.default.setAttributes([.posixPermissions: 0o755], ofItemAtPath: standardBrew.path)
+        try FileManager.default.createSymbolicLink(at: alias, withDestinationURL: standardBrew)
+
+        let path = CommandRunner.resolvedPrivilegedBrewPath(
+            preferred: alias.path,
+            standardPaths: [standardBrew.path]
+        )
+
+        #expect(path == standardBrew.path)
+    }
 }
 
 // MARK: - BrewService Batching Tests

--- a/BrewyTests/TapAndConfigTests.swift
+++ b/BrewyTests/TapAndConfigTests.swift
@@ -53,6 +53,93 @@ struct TapHealthStatusTests {
     }
 }
 
+// MARK: - TapHealthChecker Tests
+
+@Suite("TapHealthChecker")
+struct TapHealthCheckerTests {
+
+    @Test("mapResponse maps archived repository response")
+    func mapArchivedResponse() async throws {
+        let status = await TapHealthChecker.mapResponse(
+            statusCode: 200,
+            data: Data(#"{"archived":true}"#.utf8),
+            response: try response(statusCode: 200),
+            owner: "owner",
+            repo: "repo"
+        )
+
+        #expect(status.status == .archived)
+        #expect(status.movedTo == nil)
+    }
+
+    @Test("mapResponse maps moved repository response")
+    func mapMovedResponse() async throws {
+        let movedTo = "https://github.com/new-owner/homebrew-new"
+        let status = await TapHealthChecker.mapResponse(
+            statusCode: 301,
+            data: Data(),
+            response: try response(statusCode: 301, headers: ["Location": movedTo]),
+            owner: "owner",
+            repo: "repo"
+        )
+
+        #expect(status.status == .moved)
+        #expect(status.movedTo == movedTo)
+    }
+
+    @Test("mapResponse maps missing repository response")
+    func mapMissingResponse() async throws {
+        let status = await TapHealthChecker.mapResponse(
+            statusCode: 404,
+            data: Data(),
+            response: try response(statusCode: 404),
+            owner: "owner",
+            repo: "repo"
+        )
+
+        #expect(status.status == .notFound)
+        #expect(status.movedTo == nil)
+    }
+
+    @Test("mapResponse maps rate limit response to unknown")
+    func mapRateLimitResponse() async throws {
+        let status = await TapHealthChecker.mapResponse(
+            statusCode: 403,
+            data: Data(),
+            response: try response(statusCode: 403),
+            owner: "owner",
+            repo: "repo"
+        )
+
+        #expect(status.status == .unknown)
+        #expect(status.movedTo == nil)
+    }
+
+    @Test("checkHealth prunes statuses for removed taps")
+    func checkHealthPrunesRemovedTaps() async {
+        let existing = [
+            "old/tap": TapHealthStatus(status: .healthy, movedTo: nil, lastChecked: Date())
+        ]
+
+        let statuses = await TapHealthChecker.checkHealth(taps: [], existing: existing)
+
+        #expect(statuses.isEmpty)
+    }
+
+    private func response(
+        statusCode: Int,
+        headers: [String: String]? = nil
+    ) throws -> HTTPURLResponse {
+        let url = try #require(URL(string: "https://api.github.com/repos/owner/repo"))
+        return try #require(HTTPURLResponse(
+            url: url,
+            statusCode: statusCode,
+            httpVersion: nil,
+            headerFields: headers
+        ))
+    }
+}
+
 // MARK: - parseGitHubRepo Tests
 
 @Suite("parseGitHubRepo")


### PR DESCRIPTION
Makes two helpers testable and adds coverage for their previously untested paths. Runtime behavior is unchanged.

- `resolvedPrivilegedBrewPath` and its helper take an injectable standard-paths list defaulting to the real one, so a symlink to a standard executable can be asserted to resolve. This is the check that gates which binary can run as root via osascript.
- `TapHealthChecker.mapResponse` becomes internal so the archived (200 + `archived:true`), moved (301), missing (404), and rate-limited (403 to `.unknown`) mappings are table tested, and `checkHealth` is shown to prune statuses for removed taps.