### PR TITLE
ci: cache Homebrew downloads for lint tools

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -171,6 +171,15 @@ jobs:
 
       # --- Lint ---
 
+      - name: Cache Homebrew downloads
+        if: matrix.check == 'lint' || matrix.check == 'periphery'
+        uses: actions/cache@0400d5f644dc74513175e3cd8d07132dd4860809 # v4.2.4
+        with:
+          path: ~/Library/Caches/Homebrew
+          key: homebrew-${{ runner.os }}-${{ hashFiles('.github/workflows/ci.yml') }}
+          restore-keys: |
+            homebrew-${{ runner.os }}-
+
       - name: Install lint tools
         if: matrix.check == 'lint'
         env:


### PR DESCRIPTION
Caches the Homebrew download directory on the lint and periphery legs to cut repeated `brew install` time. Keyed on the workflow-file hash with a `homebrew-${{ runner.os }}-` restore-key fallback, so it refreshes when CI changes and otherwise reuses. Tool versions continue to track Homebrew's current formulae, as on the other legs.