### PR TITLE
feat(bundle): add read-only Brewfile awareness

### DIFF
--- a/Brewy/Models/BrewService+Bundle.swift
+++ b/Brewy/Models/BrewService+Bundle.swift
@@ -1,0 +1,310 @@
+import Foundation
+import OSLog
+
+private let logger = Logger(subsystem: "io.linnane.brewy", category: "BrewService+Bundle")
+
+// MARK: - Brew Bundle Models
+
+enum BrewBundleEntryType: String, CaseIterable, Identifiable, Hashable {
+    case formula
+    case cask
+    case tap
+    case mas
+
+    var id: String { rawValue }
+
+    var listFlag: String {
+        switch self {
+        case .formula: "--formula"
+        case .cask: "--cask"
+        case .tap: "--tap"
+        case .mas: "--mas"
+        }
+    }
+
+    var title: String {
+        switch self {
+        case .formula: "Formulae"
+        case .cask: "Casks"
+        case .tap: "Taps"
+        case .mas: "Mac App Store"
+        }
+    }
+
+    var systemImage: String {
+        switch self {
+        case .formula: "terminal.fill"
+        case .cask: "macwindow"
+        case .tap: "spigot.fill"
+        case .mas: "app.badge.fill"
+        }
+    }
+}
+
+enum BrewBundleEntryStatus: Hashable {
+    case installed
+    case missing
+    case unknown
+}
+
+struct BrewBundleEntry: Identifiable, Hashable {
+    let type: BrewBundleEntryType
+    let name: String
+    let status: BrewBundleEntryStatus
+
+    var id: String { "\(type.rawValue)-\(name)" }
+}
+
+enum BrewBundleCheckStatus: Equatable {
+    case unknown
+    case noBrewfile
+    case checking
+    case satisfied
+    case unsatisfied([String])
+    case failed(String)
+}
+
+// MARK: - Brewfile Discovery
+
+enum BrewfileDiscovery {
+
+    static func resolve(
+        overridePath: String,
+        environment: [String: String] = ProcessInfo.processInfo.environment,
+        homeDirectory: URL = FileManager.default.homeDirectoryForCurrentUser,
+        fileExists: (String) -> Bool = { FileManager.default.fileExists(atPath: $0) }
+    ) -> URL? {
+        let trimmedOverride = overridePath.trimmingCharacters(in: .whitespacesAndNewlines)
+        if !trimmedOverride.isEmpty {
+            return existingURL(atPath: trimmedOverride, fileExists: fileExists)
+        }
+
+        var candidates: [String] = []
+        if let xdgConfigHome = environment["XDG_CONFIG_HOME"], !xdgConfigHome.isEmpty {
+            candidates.append(
+                URL(fileURLWithPath: expandedPath(xdgConfigHome))
+                    .appendingPathComponent("homebrew/Brewfile")
+                    .path
+            )
+        }
+        candidates.append(homeDirectory.appendingPathComponent(".homebrew/Brewfile").path)
+        candidates.append(homeDirectory.appendingPathComponent(".Brewfile").path)
+
+        for candidate in candidates {
+            if let url = existingURL(atPath: candidate, fileExists: fileExists) {
+                return url
+            }
+        }
+        return nil
+    }
+
+    private static func existingURL(atPath path: String, fileExists: (String) -> Bool) -> URL? {
+        let expanded = expandedPath(path)
+        guard fileExists(expanded) else { return nil }
+        return URL(fileURLWithPath: expanded).resolvingSymlinksInPath()
+    }
+
+    private static func expandedPath(_ path: String) -> String {
+        (path as NSString).expandingTildeInPath
+    }
+}
+
+// MARK: - Brew Bundle Parser
+
+enum BrewBundleParser {
+
+    static func parseList(_ output: String) -> [String] {
+        output
+            .split(separator: "\n")
+            .map { $0.trimmingCharacters(in: .whitespacesAndNewlines) }
+            .filter { !$0.isEmpty }
+    }
+
+    static func parseCheckResult(success: Bool, output: String) -> BrewBundleCheckStatus {
+        if success { return .satisfied }
+
+        let missing = parseMissingDependencies(output)
+        if !missing.isEmpty { return .unsatisfied(missing) }
+
+        let message = output.trimmingCharacters(in: .whitespacesAndNewlines)
+        return .failed(message.isEmpty ? "brew bundle check failed." : message)
+    }
+
+    private static func parseMissingDependencies(_ output: String) -> [String] {
+        var missing: [String] = []
+        for rawLine in output.split(separator: "\n", omittingEmptySubsequences: false) {
+            let line = rawLine.trimmingCharacters(in: .whitespacesAndNewlines)
+            guard !line.isEmpty else { continue }
+
+            if let dependency = dependencyNeedingInstall(from: line) {
+                missing.append(dependency)
+            }
+        }
+        return missing
+    }
+
+    private static func dependencyNeedingInstall(from line: String) -> String? {
+        let normalized = stripLeadingMarker(from: line)
+        let suffixes = [
+            " needs to be installed or updated.",
+            " needs to be installed or updated",
+            " need to be installed or updated.",
+            " need to be installed or updated",
+            " needs to be installed.",
+            " needs to be installed",
+            " need to be installed.",
+            " need to be installed"
+        ]
+        for suffix in suffixes where normalized.hasSuffix(suffix) {
+            return String(normalized.dropLast(suffix.count))
+                .trimmingCharacters(in: .whitespacesAndNewlines)
+        }
+        return nil
+    }
+
+    private static func stripLeadingMarker(from line: String) -> String {
+        let trimmed = line.trimmingCharacters(in: .whitespacesAndNewlines)
+        guard let first = trimmed.first, ["→", "•", "-", "*"].contains(first) else {
+            return trimmed
+        }
+        return String(trimmed.dropFirst()).trimmingCharacters(in: .whitespacesAndNewlines)
+    }
+}
+
+// MARK: - BrewService Bundle Integration
+
+extension BrewService {
+
+    var bundleEntryCount: Int? {
+        guard brewfileURL != nil else { return nil }
+        return bundleEntries.count
+    }
+
+    @discardableResult
+    func resolveBrewfile() -> URL? {
+        let url = BrewfileDiscovery.resolve(overridePath: customBrewfilePath)
+        brewfileURL = url
+        if url == nil {
+            bundleEntries = []
+            bundleCheckStatus = .noBrewfile
+        }
+        return url
+    }
+
+    func refreshBundle() async {
+        guard !isBundleLoading, bundleCheckStatus != .checking else { return }
+        lastError = nil
+        guard let brewfileURL = resolveBrewfile() else { return }
+        guard await fetchBundleEntries(brewfileURL: brewfileURL) else { return }
+        await checkBundle(brewfileURL: brewfileURL)
+    }
+
+    func updateBundleEntryStatuses() {
+        guard !bundleEntries.isEmpty else { return }
+        bundleEntries = bundleEntries.map {
+            BrewBundleEntry(type: $0.type, name: $0.name, status: bundleStatus(for: $0.name, type: $0.type))
+        }
+    }
+
+    @discardableResult
+    func fetchBundleEntries() async -> Bool {
+        guard let brewfileURL = resolveBrewfile() else { return false }
+        return await fetchBundleEntries(brewfileURL: brewfileURL)
+    }
+
+    @discardableResult
+    func fetchBundleEntries(brewfileURL: URL) async -> Bool {
+        isBundleLoading = true
+        defer { isBundleLoading = false }
+
+        var fetchedEntries: [BrewBundleEntry] = []
+        for type in BrewBundleEntryType.allCases {
+            let arguments = ["bundle", "list", type.listFlag, "--file", brewfileURL.path]
+            let result = await runBrewCommand(arguments)
+            guard result.success else {
+                logger.warning("Failed to list \(type.rawValue) bundle entries: \(result.output.prefix(200))")
+                let message = BrewError.commandFailed(
+                    command: arguments.joined(separator: " "),
+                    output: result.output
+                )
+                lastError = message
+                bundleCheckStatus = .failed(message.localizedDescription)
+                bundleEntries = []
+                return false
+            }
+            fetchedEntries += BrewBundleParser.parseList(result.output).map {
+                BrewBundleEntry(type: type, name: $0, status: bundleStatus(for: $0, type: type))
+            }
+        }
+        bundleEntries = fetchedEntries
+        return true
+    }
+
+    func checkBundle() async {
+        guard let brewfileURL = resolveBrewfile() else { return }
+        await checkBundle(brewfileURL: brewfileURL)
+    }
+
+    func checkBundle(brewfileURL: URL) async {
+        bundleCheckStatus = .checking
+        let arguments = ["bundle", "check", "--verbose", "--file", brewfileURL.path]
+        let result = await runBrewCommand(arguments)
+        let status = BrewBundleParser.parseCheckResult(success: result.success, output: result.output)
+        bundleCheckStatus = status
+
+        if case .failed = status {
+            logger.warning("Bundle check failed: \(result.output.prefix(200))")
+            lastError = .commandFailed(command: arguments.joined(separator: " "), output: result.output)
+        }
+    }
+
+    @discardableResult
+    func dumpBundle(to url: URL) async -> CommandResult {
+        guard !isPerformingAction else {
+            logger.info("bundle dump skipped, action already in progress")
+            return CommandResult(output: "Another action is already running.", success: false)
+        }
+
+        isPerformingAction = true
+        actionOutput = ""
+        lastError = nil
+
+        let arguments = ["bundle", "dump", "--file", url.path]
+        let result = await runBrewCommand(arguments)
+        actionOutput = result.output
+        if !result.success {
+            logger.warning("Bundle dump failed: \(result.output.prefix(200))")
+            lastError = .commandFailed(command: arguments.joined(separator: " "), output: result.output)
+        }
+        recordAction(arguments: arguments, packageName: nil, packageSource: nil, success: result.success, output: result.output)
+        isPerformingAction = false
+
+        if result.success {
+            customBrewfilePath = url.path
+            await refreshBundle()
+        }
+        return result
+    }
+
+    private func bundleStatus(for name: String, type: BrewBundleEntryType) -> BrewBundleEntryStatus {
+        switch type {
+        case .formula:
+            return installedFormulae.contains { $0.name == name }
+                ? BrewBundleEntryStatus.installed
+                : BrewBundleEntryStatus.missing
+        case .cask:
+            return installedCasks.contains { $0.name == name }
+                ? BrewBundleEntryStatus.installed
+                : BrewBundleEntryStatus.missing
+        case .tap:
+            return installedTaps.contains { $0.name == name }
+                ? BrewBundleEntryStatus.installed
+                : BrewBundleEntryStatus.missing
+        case .mas:
+            guard isMasAvailable else { return .unknown }
+            return installedMasApps.contains { $0.name == name }
+                ? BrewBundleEntryStatus.installed
+                : BrewBundleEntryStatus.missing
+        }
+    }
+}

--- a/Brewy/Models/BrewService.swift
+++ b/Brewy/Models/BrewService.swift
@@ -42,6 +42,9 @@ final class BrewService {
     @AppStorage("brewPath")
     @ObservationIgnored var customBrewPath = "/opt/homebrew/bin/brew"
 
+    @AppStorage("brewfilePath")
+    @ObservationIgnored var customBrewfilePath = ""
+
     init(commandRunner: CommandRunning = DefaultCommandRunner()) {
         self.commandRunner = commandRunner
     }
@@ -78,6 +81,10 @@ final class BrewService {
     var packageGroups: [PackageGroup] = []
     var actionHistory: [ActionHistoryEntry] = []
     var lastUpdateResult: BrewUpdateResult?
+    var brewfileURL: URL?
+    var bundleEntries: [BrewBundleEntry] = []
+    var bundleCheckStatus: BrewBundleCheckStatus = .unknown
+    var isBundleLoading = false
 
     var tapsLoaded = false
     private var isRefreshing = false
@@ -137,28 +144,6 @@ final class BrewService {
 
     func dependents(of name: String) -> [BrewPackage] {
         reverseDependencies[name] ?? []
-    }
-
-    func packages(for category: SidebarCategory) -> [BrewPackage] {
-        switch category {
-        case .installed: allInstalled
-        case .formulae: installedFormulae
-        case .casks: installedCasks
-        case .masApps: installedMasApps
-        case .outdated: outdatedPackages
-        case .pinned: pinnedPackages
-        case .leaves: leavesPackages
-        case .taps: []
-        case .services: []
-        case .groups: []
-        case .history: []
-        case .discover: searchResults
-        case .maintenance: []
-        }
-    }
-
-    var homebrewOutdatedPackages: [BrewPackage] {
-        outdatedPackages.filter { !$0.isMas }
     }
 
     // MARK: - Cache
@@ -316,6 +301,7 @@ final class BrewService {
 
         installedTaps = fetchedTaps
         tapsLoaded = true
+        updateBundleEntryStatuses()
 
         let masCount = fetchedMasApps.count
         let outdatedCount = allOutdated.count
@@ -386,5 +372,33 @@ final class BrewService {
     func runBrewCommand(_ arguments: [String]) async -> CommandResult {
         let brewPath = CommandRunner.resolvedBrewPath(preferred: customBrewPath)
         return await commandRunner.run(arguments, brewPath: brewPath)
+    }
+}
+
+// MARK: - Package Category Queries
+
+extension BrewService {
+
+    func packages(for category: SidebarCategory) -> [BrewPackage] {
+        switch category {
+        case .installed: allInstalled
+        case .formulae: installedFormulae
+        case .casks: installedCasks
+        case .masApps: installedMasApps
+        case .outdated: outdatedPackages
+        case .pinned: pinnedPackages
+        case .leaves: leavesPackages
+        case .taps: []
+        case .services: []
+        case .groups: []
+        case .bundle: []
+        case .history: []
+        case .discover: searchResults
+        case .maintenance: []
+        }
+    }
+
+    var homebrewOutdatedPackages: [BrewPackage] {
+        outdatedPackages.filter { !$0.isMas }
     }
 }

--- a/Brewy/Models/PackageModel.swift
+++ b/Brewy/Models/PackageModel.swift
@@ -124,6 +124,7 @@ enum SidebarCategory: String, CaseIterable, Identifiable {
     case taps = "Taps"
     case services = "Services"
     case groups = "Groups"
+    case bundle = "Bundle"
     case history = "History"
     case discover = "Discover"
     case maintenance = "Maintenance"
@@ -142,6 +143,7 @@ enum SidebarCategory: String, CaseIterable, Identifiable {
         case .taps: "spigot.fill"
         case .services: "gearshape.2"
         case .groups: "folder.fill"
+        case .bundle: "doc.text.fill"
         case .history: "clock.arrow.circlepath"
         case .discover: "magnifyingglass"
         case .maintenance: "wrench.and.screwdriver.fill"
@@ -151,7 +153,7 @@ enum SidebarCategory: String, CaseIterable, Identifiable {
     static let packageCategories: [Self] = [
         .installed, .formulae, .casks, .masApps, .outdated, .pinned, .leaves
     ]
-    static let managementCategories: [Self] = [.taps, .services, .groups]
+    static let managementCategories: [Self] = [.taps, .services, .groups, .bundle]
     static let toolCategories: [Self] = [.history, .discover, .maintenance]
 }
 

--- a/Brewy/Views/BrewfilePicker.swift
+++ b/Brewy/Views/BrewfilePicker.swift
@@ -1,0 +1,18 @@
+import AppKit
+
+enum BrewfilePicker {
+
+    @MainActor
+    static func choosePath() -> String? {
+        let panel = NSOpenPanel()
+        panel.title = "Choose Brewfile"
+        panel.prompt = "Choose"
+        panel.canChooseFiles = true
+        panel.canChooseDirectories = false
+        panel.allowsMultipleSelection = false
+        panel.isExtensionHidden = false
+
+        guard panel.runModal() == .OK, let url = panel.url else { return nil }
+        return url.path
+    }
+}

--- a/Brewy/Views/BundleView.swift
+++ b/Brewy/Views/BundleView.swift
@@ -1,0 +1,296 @@
+import AppKit
+import SwiftUI
+
+struct BundleView: View {
+    @Environment(BrewService.self)
+    private var brewService
+    @AppStorage("brewfilePath")
+    private var brewfilePath = ""
+
+    private var groupedEntries: [BrewBundleEntryType: [BrewBundleEntry]] {
+        Dictionary(grouping: brewService.bundleEntries, by: \.type)
+    }
+
+    private var navigationSubtitle: String {
+        guard brewService.brewfileURL != nil else { return "No Brewfile" }
+        let count = brewService.bundleEntries.count
+        return count == 1 ? "1 entry" : "\(count) entries"
+    }
+
+    var body: some View {
+        List {
+            if let brewfileURL = brewService.brewfileURL {
+                BundleStatusSection(
+                    brewfileURL: brewfileURL,
+                    entryCount: brewService.bundleEntries.count,
+                    status: brewService.bundleCheckStatus,
+                    isLoading: brewService.isBundleLoading
+                )
+
+                if brewService.bundleEntries.isEmpty, !brewService.isBundleLoading {
+                    Section {
+                        ContentUnavailableView(
+                            "No Bundle Entries",
+                            systemImage: "doc.text",
+                            description: Text("No formulae, casks, taps, or Mac App Store apps were found in this Brewfile.")
+                        )
+                    }
+                } else {
+                    ForEach(BrewBundleEntryType.allCases) { type in
+                        if let entries = groupedEntries[type], !entries.isEmpty {
+                            Section {
+                                ForEach(entries) { entry in
+                                    BundleEntryRow(entry: entry)
+                                }
+                            } header: {
+                                Label(type.title, systemImage: type.systemImage)
+                            }
+                        }
+                    }
+                }
+            } else {
+                Section {
+                    BundleEmptyState(
+                        chooseBrewfile: chooseBrewfile,
+                        createBrewfile: createBrewfileFromInstalled
+                    )
+                }
+            }
+        }
+        .listStyle(.inset(alternatesRowBackgrounds: true))
+        .navigationTitle("Bundle")
+        .navigationSubtitle(navigationSubtitle)
+        .toolbar {
+            ToolbarItemGroup(placement: .primaryAction) {
+                Button("Choose Brewfile", systemImage: "folder") {
+                    chooseBrewfile()
+                }
+                .help("Choose a Brewfile")
+
+                Button("Create from Installed Packages", systemImage: "square.and.arrow.down") {
+                    createBrewfileFromInstalled()
+                }
+                .help("Create a Brewfile from installed packages")
+                .disabled(brewService.isPerformingAction)
+
+                Button("Refresh", systemImage: "arrow.clockwise") {
+                    Task { await brewService.refreshBundle() }
+                }
+                .help("Refresh bundle status")
+                .disabled(brewService.isBundleLoading)
+            }
+        }
+        .overlay {
+            if brewService.isBundleLoading, brewService.bundleEntries.isEmpty, brewService.brewfileURL != nil {
+                ProgressView("Loading bundle...")
+            }
+        }
+        .task(id: brewfilePath) {
+            await brewService.refreshBundle()
+        }
+        .refreshable {
+            await brewService.refreshBundle()
+        }
+    }
+
+    @MainActor
+    private func chooseBrewfile() {
+        guard let path = BrewfilePicker.choosePath() else { return }
+        brewfilePath = path
+    }
+
+    @MainActor
+    private func createBrewfileFromInstalled() {
+        let panel = NSSavePanel()
+        panel.title = "Create Brewfile"
+        panel.prompt = "Create"
+        panel.nameFieldStringValue = "Brewfile"
+        panel.canCreateDirectories = true
+        panel.isExtensionHidden = false
+
+        guard panel.runModal() == .OK, let url = panel.url else { return }
+        Task { await brewService.dumpBundle(to: url) }
+    }
+}
+
+// MARK: - Bundle Status
+
+private struct BundleStatusSection: View {
+    let brewfileURL: URL
+    let entryCount: Int
+    let status: BrewBundleCheckStatus
+    let isLoading: Bool
+
+    var body: some View {
+        Section {
+            HStack(spacing: 10) {
+                BrewyStatusDot(color: statusColor, label: statusTitle)
+                VStack(alignment: .leading, spacing: 2) {
+                    Text(statusTitle)
+                        .font(.headline)
+                    Text(statusSubtitle)
+                        .font(.caption)
+                        .foregroundStyle(.secondary)
+                }
+                Spacer()
+                if isLoading || status == .checking {
+                    ProgressView()
+                        .controlSize(.small)
+                }
+            }
+
+            LabeledContent("Brewfile") {
+                Text(brewfileURL.path)
+                    .font(.system(.caption, design: .monospaced))
+                    .foregroundStyle(.secondary)
+                    .lineLimit(2)
+                    .textSelection(.enabled)
+            }
+
+            if case .unsatisfied(let missing) = status, !missing.isEmpty {
+                ForEach(missing, id: \.self) { dependency in
+                    LabeledContent("Missing") {
+                        Text(dependency)
+                            .font(.system(.caption, design: .monospaced))
+                            .foregroundStyle(.secondary)
+                            .textSelection(.enabled)
+                    }
+                }
+            }
+        } header: {
+            Label("Check", systemImage: "checkmark.seal")
+        }
+    }
+
+    private var statusTitle: String {
+        switch status {
+        case .unknown: return "Not Checked"
+        case .noBrewfile: return "No Brewfile"
+        case .checking: return "Checking..."
+        case .satisfied: return "Satisfied"
+        case .unsatisfied: return "Missing Dependencies"
+        case .failed: return "Check Failed"
+        }
+    }
+
+    private var statusSubtitle: String {
+        switch status {
+        case .unknown:
+            return "\(entryCount) entries loaded."
+        case .noBrewfile:
+            return "Choose or create a Brewfile."
+        case .checking:
+            return "Checking Brewfile dependencies."
+        case .satisfied:
+            return "All Brewfile dependencies are installed."
+        case .unsatisfied(let missing):
+            let count = missing.count
+            return count == 1 ? "1 dependency is missing." : "\(count) dependencies are missing."
+        case .failed(let message):
+            return message
+        }
+    }
+
+    private var statusColor: Color {
+        switch status {
+        case .satisfied: return .green
+        case .unsatisfied: return .red
+        case .failed: return .orange
+        case .checking: return .blue
+        case .unknown, .noBrewfile: return .secondary
+        }
+    }
+}
+
+// MARK: - Bundle Empty State
+
+private struct BundleEmptyState: View {
+    let chooseBrewfile: () -> Void
+    let createBrewfile: () -> Void
+
+    var body: some View {
+        ContentUnavailableView {
+            Label("No Brewfile", systemImage: "doc.text")
+        } description: {
+            Text("Brewy looks for Homebrew Bundle's global Brewfile locations, or you can choose one.")
+        } actions: {
+            HStack(spacing: 10) {
+                Button("Choose Brewfile", systemImage: "folder") {
+                    chooseBrewfile()
+                }
+                Button("Create from Installed Packages", systemImage: "square.and.arrow.down") {
+                    createBrewfile()
+                }
+            }
+        }
+    }
+}
+
+// MARK: - Bundle Entry Row
+
+private struct BundleEntryRow: View {
+    let entry: BrewBundleEntry
+
+    var body: some View {
+        HStack(spacing: 10) {
+            Image(systemName: entry.type.systemImage)
+                .font(.title3)
+                .foregroundStyle(entry.type.tint)
+                .frame(width: 24)
+            VStack(alignment: .leading, spacing: 2) {
+                Text(entry.name)
+                    .font(.body)
+                    .fontWeight(.medium)
+                Text(entry.type.title)
+                    .font(.caption)
+                    .foregroundStyle(.secondary)
+            }
+            Spacer()
+            BundleEntryStatusBadge(status: entry.status)
+        }
+        .padding(.vertical, 2)
+    }
+}
+
+private struct BundleEntryStatusBadge: View {
+    let status: BrewBundleEntryStatus
+
+    var body: some View {
+        BrewyStatusBadge(title, systemImage: systemImage, color: color)
+    }
+
+    private var title: String {
+        switch status {
+        case .installed: "installed"
+        case .missing: "missing"
+        case .unknown: "unknown"
+        }
+    }
+
+    private var systemImage: String {
+        switch status {
+        case .installed: "checkmark.circle.fill"
+        case .missing: "exclamationmark.circle.fill"
+        case .unknown: "questionmark.circle.fill"
+        }
+    }
+
+    private var color: Color {
+        switch status {
+        case .installed: .green
+        case .missing: .red
+        case .unknown: .secondary
+        }
+    }
+}
+
+extension BrewBundleEntryType {
+    fileprivate var tint: Color {
+        switch self {
+        case .formula: .green
+        case .cask: .indigo
+        case .tap: .teal
+        case .mas: .pink
+        }
+    }
+}

--- a/Brewy/Views/ContentView.swift
+++ b/Brewy/Views/ContentView.swift
@@ -60,6 +60,9 @@ struct ContentView: View {
             } else if selectedCategory == .groups {
                 GroupsView(selectedGroup: $selectedGroupItem)
                     .navigationSplitViewColumnWidth(min: 300, ideal: 350, max: 500)
+            } else if selectedCategory == .bundle {
+                BundleView()
+                    .navigationSplitViewColumnWidth(min: 400, ideal: 600, max: .infinity)
             } else if selectedCategory == .history {
                 HistoryView(selectedEntry: $selectedHistoryEntry)
                     .navigationSplitViewColumnWidth(min: 300, ideal: 350, max: 500)
@@ -100,7 +103,9 @@ struct ContentView: View {
                 lastSeenVersion = currentVersion
                 showWhatsNew = true
             }
+            async let bundleRefresh: Void = brewService.refreshBundle()
             await brewService.refresh()
+            await bundleRefresh
         }
         .task(id: autoRefreshInterval) {
             guard autoRefreshInterval > 0 else { return }
@@ -146,7 +151,8 @@ struct ContentView: View {
     }
 
     @ViewBuilder private var detailView: some View {
-        if selectedCategory == .maintenance || (selectedCategory == .masApps && !brewService.isMasAvailable) {
+        if selectedCategory == .maintenance || selectedCategory == .bundle
+            || (selectedCategory == .masApps && !brewService.isMasAvailable) {
             Color.clear
                 .navigationSplitViewColumnWidth(0)
         } else if selectedCategory == .services, let service = selectedServiceItem {

--- a/Brewy/Views/SettingsView.swift
+++ b/Brewy/Views/SettingsView.swift
@@ -19,6 +19,8 @@ enum AppTheme: String, CaseIterable, Identifiable {
 struct SettingsView: View {
     @AppStorage("brewPath")
     private var brewPath = "/opt/homebrew/bin/brew"
+    @AppStorage("brewfilePath")
+    private var brewfilePath = ""
     @AppStorage("autoRefreshInterval")
     private var autoRefreshInterval = 0
     @AppStorage("showCasksByDefault")
@@ -32,6 +34,10 @@ struct SettingsView: View {
         FileManager.default.isExecutableFile(atPath: brewPath)
     }
 
+    private var isBrewfilePathValid: Bool {
+        brewfilePath.isEmpty || BrewfileDiscovery.resolve(overridePath: brewfilePath) != nil
+    }
+
     var body: some View {
         Form {
             TextField("Homebrew Path:", text: $brewPath)
@@ -41,6 +47,8 @@ struct SettingsView: View {
                     .font(.caption)
                     .foregroundStyle(.red)
             }
+
+            brewfileOverrideSetting
 
             Picker("Auto-refresh:", selection: $autoRefreshInterval) {
                 Text("Off").tag(0)
@@ -83,7 +91,38 @@ struct SettingsView: View {
         .onChange(of: appIcon, initial: true) {
             AppIconSelection.apply(rawValue: appIcon)
         }
-        .frame(width: 500, height: 330)
+        .frame(width: 560, height: 380)
+    }
+
+    private var brewfileOverrideSetting: some View {
+        Group {
+            LabeledContent("Brewfile:") {
+                HStack(spacing: 8) {
+                    TextField("Auto-detect", text: $brewfilePath)
+                        .textFieldStyle(.roundedBorder)
+                    Button("Choose", systemImage: "folder") {
+                        chooseBrewfile()
+                    }
+                    .help("Choose a Brewfile")
+                    Button("Clear", systemImage: "xmark.circle") {
+                        brewfilePath = ""
+                    }
+                    .help("Use auto-discovery")
+                    .disabled(brewfilePath.isEmpty)
+                }
+            }
+            if !isBrewfilePathValid {
+                Text("No Brewfile found at this path.")
+                    .font(.caption)
+                    .foregroundStyle(.red)
+            }
+        }
+    }
+
+    @MainActor
+    private func chooseBrewfile() {
+        guard let path = BrewfilePicker.choosePath() else { return }
+        brewfilePath = path
     }
 }
 

--- a/Brewy/Views/SidebarView.swift
+++ b/Brewy/Views/SidebarView.swift
@@ -60,6 +60,7 @@ private struct SidebarRow: View {
         case .taps: brewService.installedTaps.count
         case .services: nil
         case .groups: brewService.packageGroups.isEmpty ? nil : brewService.packageGroups.count
+        case .bundle: brewService.bundleEntryCount
         case .history: brewService.actionHistory.isEmpty ? nil : brewService.actionHistory.count
         case .discover: nil
         case .maintenance: nil
@@ -79,6 +80,7 @@ private struct SidebarRow: View {
         case .taps: .teal
         case .services: .gray
         case .groups: .brown
+        case .bundle: .brewyAccent
         case .history: .secondary
         case .discover: .cyan
         case .maintenance: .purple

--- a/BrewyTests/BrewBundleTests.swift
+++ b/BrewyTests/BrewBundleTests.swift
@@ -1,0 +1,414 @@
+@testable import Brewy
+import Foundation
+import Testing
+
+// MARK: - Brew Bundle Parsing
+
+@Suite("Brew Bundle Parsing")
+struct BrewBundleParsingTests {
+
+    @Test("parseList trims lines for every bundle type")
+    func parseListForEveryType() {
+        for type in BrewBundleEntryType.allCases {
+            let output = "  \(type.rawValue)-one  \n\n\(type.rawValue)-two\n"
+            #expect(BrewBundleParser.parseList(output) == ["\(type.rawValue)-one", "\(type.rawValue)-two"])
+        }
+    }
+
+    @Test("parseList handles empty output")
+    func parseListEmpty() {
+        #expect(BrewBundleParser.parseList("").isEmpty)
+        #expect(BrewBundleParser.parseList("\n \n").isEmpty)
+    }
+
+    @Test("parseCheckResult treats exit zero as satisfied")
+    func parseCheckSatisfied() {
+        let status = BrewBundleParser.parseCheckResult(
+            success: true,
+            output: "The Brewfile's dependencies are satisfied.\n"
+        )
+        #expect(status == .satisfied)
+    }
+
+    @Test("parseCheckResult extracts verbose missing dependencies")
+    func parseCheckUnsatisfied() {
+        let output = """
+        brew bundle can't satisfy your Brewfile's dependencies.
+        → Cask firefox needs to be installed or updated.
+        → Formula wget needs to be installed or updated.
+        Satisfy missing dependencies with `brew bundle install`.
+        """
+
+        let status = BrewBundleParser.parseCheckResult(success: false, output: output)
+
+        #expect(status == .unsatisfied([
+            "Cask firefox",
+            "Formula wget"
+        ]))
+    }
+
+    @Test("parseCheckResult tolerates older installed-only suffixes")
+    func parseCheckOlderInstalledSuffix() {
+        let output = """
+        * Formula jq needs to be installed.
+        - Tap homebrew/cask needs to be installed.
+        """
+
+        let status = BrewBundleParser.parseCheckResult(success: false, output: output)
+
+        #expect(status == .unsatisfied([
+            "Formula jq",
+            "Tap homebrew/cask"
+        ]))
+    }
+
+    @Test("parseCheckResult treats non-missing failures as genuine failures")
+    func parseCheckFailure() {
+        let status = BrewBundleParser.parseCheckResult(
+            success: false,
+            output: "Error: No Brewfile found at /tmp/missing/Brewfile\n"
+        )
+        #expect(status == .failed("Error: No Brewfile found at /tmp/missing/Brewfile"))
+    }
+}
+
+// MARK: - Brewfile Discovery
+
+@Suite("Brewfile Discovery")
+struct BrewfileDiscoveryTests {
+
+    @Test("Settings override beats global candidates")
+    func overrideBeatsGlobalCandidates() {
+        let override = "/tmp/override/Brewfile"
+        let xdg = "/tmp/xdg/homebrew/Brewfile"
+        let homebrew = "/tmp/home/.homebrew/Brewfile"
+        let home = URL(fileURLWithPath: "/tmp/home")
+        let existing = Set([override, xdg, homebrew])
+
+        let resolved = BrewfileDiscovery.resolve(
+            overridePath: override,
+            environment: ["XDG_CONFIG_HOME": "/tmp/xdg"],
+            homeDirectory: home,
+            fileExists: { existing.contains($0) }
+        )
+
+        #expect(resolved?.path == override)
+    }
+
+    @Test("Global discovery follows Homebrew candidate order")
+    func globalCandidateOrder() {
+        let xdg = "/tmp/xdg/homebrew/Brewfile"
+        let dotHomebrew = "/tmp/home/.homebrew/Brewfile"
+        let dotBrewfile = "/tmp/home/.Brewfile"
+        let home = URL(fileURLWithPath: "/tmp/home")
+        let existing = Set([dotHomebrew, dotBrewfile])
+
+        let resolvedWithoutXDG = BrewfileDiscovery.resolve(
+            overridePath: "",
+            environment: [:],
+            homeDirectory: home,
+            fileExists: { existing.contains($0) }
+        )
+        #expect(resolvedWithoutXDG?.path == dotHomebrew)
+
+        let resolvedWithXDG = BrewfileDiscovery.resolve(
+            overridePath: "",
+            environment: ["XDG_CONFIG_HOME": "/tmp/xdg"],
+            homeDirectory: home,
+            fileExists: { existing.union([xdg]).contains($0) }
+        )
+        #expect(resolvedWithXDG?.path == xdg)
+    }
+
+    @Test("No Brewfile found resolves nil")
+    func noBrewfileFound() {
+        let resolved = BrewfileDiscovery.resolve(
+            overridePath: "",
+            environment: [:],
+            homeDirectory: URL(fileURLWithPath: "/tmp/home"),
+            fileExists: { _ in false }
+        )
+        #expect(resolved == nil)
+    }
+}
+
+// MARK: - BrewService Bundle
+
+@Suite("BrewService Bundle")
+@MainActor
+struct BrewServiceBundleTests {
+
+    @Test("fetchBundleEntries lists typed entries and marks installed status")
+    func fetchBundleEntries() async throws {
+        let brewfile = try Self.makeBrewfile()
+        let mock = MockCommandRunner()
+        let (service, _) = makeService(mock: mock)
+        service.customBrewfilePath = brewfile.path
+        service.installedFormulae = [makePackage(name: "wget")]
+        service.installedCasks = [makePackage(name: "firefox", source: .cask)]
+        service.installedTaps = [
+            BrewTap(name: "homebrew/core", remote: "", isOfficial: true, formulaNames: [], caskTokens: [])
+        ]
+        service.isMasAvailable = false
+
+        Self.setBundleListResults(mock, path: brewfile.path)
+
+        await service.fetchBundleEntries()
+
+        #expect(service.bundleEntries.count == 6)
+        #expect(service.bundleEntries.first { $0.name == "wget" }?.status == .installed)
+        #expect(service.bundleEntries.first { $0.name == "curl" }?.status == .missing)
+        #expect(service.bundleEntries.first { $0.name == "firefox" }?.status == .installed)
+        #expect(service.bundleEntries.first { $0.name == "homebrew/core" }?.status == .installed)
+        #expect(service.bundleEntries.first { $0.type == .mas }?.status == .unknown)
+    }
+
+    @Test("fetchBundleEntries marks mas entries installed by name")
+    func fetchBundleEntriesMatchesMasByName() async throws {
+        let brewfile = try Self.makeBrewfile()
+        let mock = MockCommandRunner()
+        let (service, _) = makeService(mock: mock)
+        service.customBrewfilePath = brewfile.path
+        service.isMasAvailable = true
+        service.installedMasApps = [makePackage(name: "Xcode", source: .mas)]
+
+        Self.setBundleListResults(mock, path: brewfile.path)
+
+        await service.fetchBundleEntries()
+
+        #expect(service.bundleEntries.first { $0.type == .mas && $0.name == "Xcode" }?.status == .installed)
+    }
+
+    @Test("updateBundleEntryStatuses recomputes entries after installed packages load")
+    func updateBundleEntryStatusesRecomputesAfterInstalledPackagesLoad() {
+        let (service, _) = makeService(mock: MockCommandRunner())
+        service.bundleEntries = [
+            BrewBundleEntry(type: .formula, name: "wget", status: .missing),
+            BrewBundleEntry(type: .cask, name: "firefox", status: .missing),
+            BrewBundleEntry(type: .tap, name: "homebrew/core", status: .missing),
+            BrewBundleEntry(type: .mas, name: "Xcode", status: .unknown)
+        ]
+        service.installedFormulae = [makePackage(name: "wget")]
+        service.installedCasks = [makePackage(name: "firefox", source: .cask)]
+        service.installedTaps = [
+            BrewTap(name: "homebrew/core", remote: "", isOfficial: true, formulaNames: [], caskTokens: [])
+        ]
+        service.isMasAvailable = true
+        service.installedMasApps = [makePackage(name: "Xcode", source: .mas)]
+
+        service.updateBundleEntryStatuses()
+
+        #expect(service.bundleEntries.allSatisfy { $0.status == .installed })
+    }
+
+    @Test("checkBundle reports satisfied without history")
+    func checkBundleSatisfied() async throws {
+        let brewfile = try Self.makeBrewfile()
+        let mock = MockCommandRunner()
+        let (service, _) = makeService(mock: mock)
+        service.customBrewfilePath = brewfile.path
+        mock.setResult(
+            for: ["bundle", "check", "--verbose", "--file", brewfile.path],
+            output: "The Brewfile's dependencies are satisfied.\n"
+        )
+
+        await service.checkBundle()
+
+        #expect(service.bundleCheckStatus == .satisfied)
+        #expect(service.lastError == nil)
+        #expect(service.actionHistory.isEmpty)
+    }
+
+    @Test("checkBundle treats unsatisfied dependencies as state")
+    func checkBundleUnsatisfied() async throws {
+        let brewfile = try Self.makeBrewfile()
+        let mock = MockCommandRunner()
+        let (service, _) = makeService(mock: mock)
+        service.customBrewfilePath = brewfile.path
+        mock.setResult(
+            for: ["bundle", "check", "--verbose", "--file", brewfile.path],
+            output: """
+            brew bundle can't satisfy your Brewfile's dependencies.
+            → Cask firefox needs to be installed or updated.
+            → Formula wget needs to be installed or updated.
+            Satisfy missing dependencies with `brew bundle install`.
+            """,
+            success: false
+        )
+
+        await service.checkBundle()
+
+        #expect(service.bundleCheckStatus == .unsatisfied(["Cask firefox", "Formula wget"]))
+        #expect(service.lastError == nil)
+        #expect(service.actionHistory.isEmpty)
+    }
+
+    @Test("checkBundle surfaces genuine failures")
+    func checkBundleFailure() async throws {
+        let brewfile = try Self.makeBrewfile()
+        let mock = MockCommandRunner()
+        let (service, _) = makeService(mock: mock)
+        service.customBrewfilePath = brewfile.path
+        mock.setResult(
+            for: ["bundle", "check", "--verbose", "--file", brewfile.path],
+            output: "Error: Permission denied @ rb_sysopen - \(brewfile.path)\n",
+            success: false
+        )
+
+        await service.checkBundle()
+
+        if case .failed(let message) = service.bundleCheckStatus {
+            #expect(message.contains("Permission denied"))
+        } else {
+            Issue.record("Expected bundle check failure")
+        }
+        #expect(service.lastError != nil)
+    }
+
+    @Test("no Brewfile yields empty state without error")
+    func noBrewfileFound() async {
+        let mock = MockCommandRunner()
+        let (service, _) = makeService(mock: mock)
+        service.customBrewfilePath = "/tmp/brewy-missing-\(UUID().uuidString)/Brewfile"
+
+        await service.fetchBundleEntries()
+
+        #expect(service.brewfileURL == nil)
+        #expect(service.bundleEntries.isEmpty)
+        #expect(service.bundleCheckStatus == .noBrewfile)
+        #expect(service.lastError == nil)
+        #expect(mock.executedCommands.isEmpty)
+    }
+
+    @Test("refreshBundle stops when listing fails")
+    func refreshBundleStopsWhenListingFails() async throws {
+        let brewfile = try Self.makeBrewfile()
+        let mock = MockCommandRunner()
+        let (service, _) = makeService(mock: mock)
+        service.customBrewfilePath = brewfile.path
+        mock.setResult(
+            for: ["bundle", "list", "--formula", "--file", brewfile.path],
+            output: "Error: Permission denied @ rb_sysopen - \(brewfile.path)\n",
+            success: false
+        )
+        mock.setResult(
+            for: ["bundle", "check", "--verbose", "--file", brewfile.path],
+            output: "The Brewfile's dependencies are satisfied.\n"
+        )
+
+        await service.refreshBundle()
+
+        #expect(mock.executedCommands == [["bundle", "list", "--formula", "--file", brewfile.path]])
+        if case .failed(let message) = service.bundleCheckStatus {
+            #expect(message.contains("Permission denied"))
+        } else {
+            Issue.record("Expected bundle list failure")
+        }
+    }
+
+    @Test("refreshBundle commands always include explicit file")
+    func commandsIncludeExplicitFile() async throws {
+        let brewfile = try Self.makeBrewfile()
+        let mock = MockCommandRunner()
+        let (service, _) = makeService(mock: mock)
+        service.customBrewfilePath = brewfile.path
+        Self.setBundleListResults(mock, path: brewfile.path)
+        mock.setResult(
+            for: ["bundle", "check", "--verbose", "--file", brewfile.path],
+            output: "The Brewfile's dependencies are satisfied.\n"
+        )
+
+        await service.refreshBundle()
+
+        #expect(mock.executedCommands.count == 5)
+        for command in mock.executedCommands {
+            #expect(command.contains("--file"))
+            #expect(command.last == brewfile.path)
+        }
+    }
+
+    @Test("dumpBundle never passes force and surfaces existing-file failure")
+    func dumpBundleExistingFileFailure() async throws {
+        let brewfile = try Self.makeBrewfile()
+        let mock = MockCommandRunner()
+        let (service, _) = makeService(mock: mock)
+        mock.setResult(
+            for: ["bundle", "dump", "--file", brewfile.path],
+            output: "Error: Brewfile already exists at \(brewfile.path)\n",
+            success: false
+        )
+
+        let result = await service.dumpBundle(to: brewfile)
+
+        #expect(result.success == false)
+        #expect(mock.executedCommands == [["bundle", "dump", "--file", brewfile.path]])
+        #expect(mock.executedCommands[0].contains("--force") == false)
+        #expect(service.lastError != nil)
+        #expect(service.actionHistory.count == 1)
+        #expect(service.actionHistory[0].status == .failure)
+    }
+
+    @Test("dumpBundle success adopts the path and refreshes")
+    func dumpBundleSuccessAdoptsPathAndRefreshes() async throws {
+        let brewfile = try Self.makeBrewfile()
+        let mock = MockCommandRunner()
+        let (service, _) = makeService(mock: mock)
+        mock.setResult(for: ["bundle", "dump", "--file", brewfile.path], output: "Using Brewfile\n")
+        Self.setEmptyBundleListResults(mock, path: brewfile.path)
+        mock.setResult(
+            for: ["bundle", "check", "--verbose", "--file", brewfile.path],
+            output: "The Brewfile's dependencies are satisfied.\n"
+        )
+
+        let result = await service.dumpBundle(to: brewfile)
+
+        #expect(result.success)
+        #expect(service.customBrewfilePath == brewfile.path)
+        #expect(service.bundleCheckStatus == .satisfied)
+        #expect(service.actionHistory.first?.status == .success)
+        #expect(mock.executedCommands.last == ["bundle", "check", "--verbose", "--file", brewfile.path])
+    }
+
+    @Test("existing empty Brewfile refreshes to satisfied empty state")
+    func existingEmptyBrewfile() async throws {
+        let brewfile = try Self.makeBrewfile()
+        let mock = MockCommandRunner()
+        let (service, _) = makeService(mock: mock)
+        service.customBrewfilePath = brewfile.path
+        Self.setEmptyBundleListResults(mock, path: brewfile.path)
+        mock.setResult(
+            for: ["bundle", "check", "--verbose", "--file", brewfile.path],
+            output: "The Brewfile's dependencies are satisfied.\n"
+        )
+
+        await service.refreshBundle()
+
+        #expect(service.brewfileURL?.path == brewfile.path)
+        #expect(service.bundleEntries.isEmpty)
+        #expect(service.bundleEntryCount == 0)
+        #expect(service.bundleCheckStatus == .satisfied)
+    }
+
+    private static func setBundleListResults(_ mock: MockCommandRunner, path: String) {
+        mock.setResult(for: ["bundle", "list", "--formula", "--file", path], output: "wget\ncurl\n")
+        mock.setResult(for: ["bundle", "list", "--cask", "--file", path], output: "firefox\n")
+        mock.setResult(for: ["bundle", "list", "--tap", "--file", path], output: "homebrew/core\nhomebrew/cask\n")
+        mock.setResult(for: ["bundle", "list", "--mas", "--file", path], output: "Xcode\n")
+    }
+
+    private static func setEmptyBundleListResults(_ mock: MockCommandRunner, path: String) {
+        mock.setResult(for: ["bundle", "list", "--formula", "--file", path], output: "")
+        mock.setResult(for: ["bundle", "list", "--cask", "--file", path], output: "")
+        mock.setResult(for: ["bundle", "list", "--tap", "--file", path], output: "")
+        mock.setResult(for: ["bundle", "list", "--mas", "--file", path], output: "")
+    }
+
+    private static func makeBrewfile() throws -> URL {
+        let directory = FileManager.default.temporaryDirectory
+            .appendingPathComponent("BrewyBundleTests-\(UUID().uuidString)", isDirectory: true)
+        try FileManager.default.createDirectory(at: directory, withIntermediateDirectories: true)
+        let brewfile = directory.appendingPathComponent("Brewfile")
+        try Data().write(to: brewfile)
+        return brewfile
+    }
+}


### PR DESCRIPTION
Adds Homebrew Bundle (Brewfile) awareness as the first part of #54.

- Discovers the active Brewfile from a Settings override or Homebrew's global
  locations, with a Choose or Create empty state when none is found.
- Lists formulae, casks, taps, and Mac App Store entries grouped by type, each
  marked installed or missing.
- Runs brew bundle check and shows satisfied, missing-dependency, or failure
  state, without raising an error for a normal unsatisfied Brewfile.
- Can create a Brewfile from installed packages via brew bundle dump, never
  with --force.

Out of scope here: bundle install, cleanup, editing, and add or remove
integration from the package panes.

All bundle commands run through CommandRunner with an explicit --file.
