### PR TITLE
feat(settings): add toggle to prevent Homebrew auto-update

### DIFF
--- a/Brewy/Models/CommandRunner.swift
+++ b/Brewy/Models/CommandRunner.swift
@@ -80,6 +80,7 @@ struct DefaultCommandRunner: CommandRunning {
 enum CommandRunner {
 
     static let defaultTimeout: Duration = .seconds(300)
+    static let preventHomebrewAutoUpdateKey = "preventHomebrewAutoUpdate"
     private static let standardBrewPaths = ["/opt/homebrew/bin/brew", "/usr/local/bin/brew"]
 
     /// Grace period between SIGTERM and SIGKILL when a process exceeds its timeout.
@@ -103,6 +104,10 @@ enum CommandRunner {
         return standardPaths.first { FileManager.default.isExecutableFile(atPath: $0) }
     }
 
+    static func preventsHomebrewAutoUpdate(userDefaults: UserDefaults = .standard) -> Bool {
+        userDefaults.bool(forKey: preventHomebrewAutoUpdateKey)
+    }
+
     static func run(
         _ arguments: [String],
         brewPath: String,
@@ -120,13 +125,15 @@ enum CommandRunner {
         let commandDescription = "\(execName) \(arguments.joined(separator: " "))"
         logger.info("Running: \(commandDescription)")
         let startTime = ContinuousClock.now
+        let preventHomebrewAutoUpdate = preventsHomebrewAutoUpdate()
 
         let result = await Task.detached(priority: .medium) {
             executeProcess(
                 arguments: arguments,
                 brewPath: executablePath,
                 timeout: timeout,
-                commandDescription: commandDescription
+                commandDescription: commandDescription,
+                preventHomebrewAutoUpdate: preventHomebrewAutoUpdate
             )
         }.value
 
@@ -148,10 +155,14 @@ enum CommandRunner {
         return paths[0]
     }
 
-    // MARK: - Private
+    // MARK: - Environment
 
-    private static func buildEnvironment(brewPath: String) -> [String: String] {
-        var env = ProcessInfo.processInfo.environment
+    static func buildEnvironment(
+        brewPath: String,
+        preventHomebrewAutoUpdate: Bool,
+        environment: [String: String] = ProcessInfo.processInfo.environment
+    ) -> [String: String] {
+        var env = environment
         let brewBin = URL(fileURLWithPath: brewPath).deletingLastPathComponent().path
         let brewPrefix = URL(fileURLWithPath: brewBin).deletingLastPathComponent().path
         let brewSbin = brewPrefix + "/sbin"
@@ -164,8 +175,13 @@ enum CommandRunner {
         }
 
         env["PATH"] = pathComponents.joined(separator: ":")
+        if preventHomebrewAutoUpdate {
+            env["HOMEBREW_NO_AUTO_UPDATE"] = "1"
+        }
         return env
     }
+
+    // MARK: - Private
 
     private static func standardBrewPath(matching path: String, standardPaths: [String]) -> String? {
         let resolvedPath = URL(fileURLWithPath: path).resolvingSymlinksInPath().path
@@ -187,7 +203,8 @@ enum CommandRunner {
         arguments: [String],
         brewPath: String,
         timeout: Duration,
-        commandDescription: String
+        commandDescription: String,
+        preventHomebrewAutoUpdate: Bool
     ) -> CommandResult {
         let process = Process()
         let stdoutPipe = Pipe()
@@ -195,7 +212,10 @@ enum CommandRunner {
 
         process.executableURL = URL(fileURLWithPath: brewPath)
         process.arguments = arguments
-        process.environment = buildEnvironment(brewPath: brewPath)
+        process.environment = buildEnvironment(
+            brewPath: brewPath,
+            preventHomebrewAutoUpdate: preventHomebrewAutoUpdate
+        )
         process.standardOutput = stdoutPipe
         process.standardError = stderrPipe
 

--- a/Brewy/Views/SettingsView.swift
+++ b/Brewy/Views/SettingsView.swift
@@ -23,6 +23,8 @@ struct SettingsView: View {
     private var brewfilePath = ""
     @AppStorage("autoRefreshInterval")
     private var autoRefreshInterval = 0
+    @AppStorage(CommandRunner.preventHomebrewAutoUpdateKey)
+    private var preventHomebrewAutoUpdate = false
     @AppStorage("showCasksByDefault")
     private var showCasksByDefault = false
     @AppStorage("appTheme")
@@ -56,6 +58,9 @@ struct SettingsView: View {
                 Text("Every 15 minutes").tag(900)
                 Text("Every hour").tag(3_600)
             }
+
+            Toggle("Prevent Homebrew auto-update", isOn: $preventHomebrewAutoUpdate)
+                .help("Stops Homebrew from updating itself before installs and upgrades.")
 
             Picker("Appearance:", selection: $appTheme) {
                 ForEach(AppTheme.allCases) { theme in
@@ -91,7 +96,7 @@ struct SettingsView: View {
         .onChange(of: appIcon, initial: true) {
             AppIconSelection.apply(rawValue: appIcon)
         }
-        .frame(width: 560, height: 380)
+        .frame(width: 560, height: 410)
     }
 
     private var brewfileOverrideSetting: some View {

--- a/BrewyTests/BrewServiceTests.swift
+++ b/BrewyTests/BrewServiceTests.swift
@@ -368,6 +368,37 @@ struct CommandRunnerTests {
 
         #expect(path == standardBrew.path)
     }
+
+    @Test("automatic Homebrew update prevention defaults off")
+    func automaticHomebrewUpdatePreventionDefaultsOff() throws {
+        let suiteName = "io.linnane.brewy.tests.\(UUID().uuidString)"
+        let defaults = try #require(UserDefaults(suiteName: suiteName))
+        defer { defaults.removePersistentDomain(forName: suiteName) }
+
+        #expect(!CommandRunner.preventsHomebrewAutoUpdate(userDefaults: defaults))
+    }
+
+    @Test("automatic Homebrew update prevention sets Homebrew environment")
+    func automaticHomebrewUpdatePreventionSetsEnvironment() {
+        let env = CommandRunner.buildEnvironment(
+            brewPath: "/opt/homebrew/bin/brew",
+            preventHomebrewAutoUpdate: true,
+            environment: [:]
+        )
+
+        #expect(env["HOMEBREW_NO_AUTO_UPDATE"] == "1")
+    }
+
+    @Test("automatic Homebrew update prevention leaves environment unchanged when disabled")
+    func automaticHomebrewUpdatePreventionLeavesEnvironmentUnchangedWhenDisabled() {
+        let env = CommandRunner.buildEnvironment(
+            brewPath: "/opt/homebrew/bin/brew",
+            preventHomebrewAutoUpdate: false,
+            environment: [:]
+        )
+
+        #expect(env["HOMEBREW_NO_AUTO_UPDATE"] == nil)
+    }
 }
 
 // MARK: - BrewService Batching Tests


### PR DESCRIPTION
Adds a "Prevent Homebrew auto-update" toggle in Settings, backed by `@AppStorage`. When enabled, Brewy sets `HOMEBREW_NO_AUTO_UPDATE=1` for the brew commands it launches, suppressing Homebrew's implicit auto-update before installs, upgrades, and refresh.

The manual "Update Homebrew" action runs an explicit `brew update` and is unaffected, so users who turn this on can still update on demand.

Closes #221.