### PR TITLE
test(uitests): scale sidebar UI test timeouts under Thread Sanitizer

### DIFF
--- a/BrewyUITests/SidebarNavigationUITests.swift
+++ b/BrewyUITests/SidebarNavigationUITests.swift
@@ -3,8 +3,15 @@ import XCTest
 @MainActor
 final class SidebarNavigationUITests: XCTestCase {
 
-    private static let launchTimeout: TimeInterval = 30
-    private static let elementTimeout: TimeInterval = 10
+    // Thread Sanitizer instrumentation slows the app under test enough that the
+    // sidebar can take much longer than the unscaled timeouts to render, which
+    // flaked these waits in CI's TSan job. Scale every timeout and settle delay
+    // up when the sanitizer runtime is loaded: the UI-test bundle is built with
+    // the same scheme setting as the app, so its presence in this process is a
+    // reliable proxy for "the app under test is instrumented too".
+    private static let timeoutScale: TimeInterval = isThreadSanitizerActive ? 4 : 1
+    private static let launchTimeout: TimeInterval = 30 * timeoutScale
+    private static let elementTimeout: TimeInterval = 10 * timeoutScale
 
     private var app: XCUIApplication!
 
@@ -34,18 +41,15 @@ final class SidebarNavigationUITests: XCTestCase {
         for (index, category) in categories.enumerated() {
             let row = sidebar.staticTexts[category]
             let timeout = index == 0 ? Self.launchTimeout : Self.elementTimeout
-            XCTAssertTrue(
-                row.waitForExistence(timeout: timeout),
-                "Sidebar category '\(category)' should exist"
-            )
+            assertExists(row, timeout: timeout, "Sidebar category '\(category)' should exist")
             row.click()
-            RunLoop.current.run(until: Date(timeIntervalSinceNow: 0.5))
+            settle()
         }
     }
 
     func testSidebarContainsAllCategories() throws {
         let sidebar = app.outlines.firstMatch
-        XCTAssertTrue(sidebar.waitForExistence(timeout: Self.launchTimeout), "Sidebar should exist")
+        assertExists(sidebar, timeout: Self.launchTimeout, "Sidebar should exist")
 
         let expectedCategories = [
             "Installed", "Formulae", "Casks", "Mac App Store", "Outdated",
@@ -54,8 +58,9 @@ final class SidebarNavigationUITests: XCTestCase {
         ]
 
         for category in expectedCategories {
-            XCTAssertTrue(
-                sidebar.staticTexts[category].exists,
+            assertExists(
+                sidebar.staticTexts[category],
+                timeout: Self.elementTimeout,
                 "Sidebar should contain '\(category)' category"
             )
         }
@@ -67,25 +72,66 @@ final class SidebarNavigationUITests: XCTestCase {
         let sidebar = app.outlines.firstMatch
 
         let installed = sidebar.staticTexts["Installed"]
-        XCTAssertTrue(installed.waitForExistence(timeout: Self.launchTimeout))
+        assertExists(installed, timeout: Self.launchTimeout, "Sidebar category 'Installed' should exist")
         installed.click()
-        RunLoop.current.run(until: Date(timeIntervalSinceNow: 0.5))
+        settle()
 
         let maintenance = sidebar.staticTexts["Maintenance"]
+        assertExists(maintenance, timeout: Self.elementTimeout, "Sidebar category 'Maintenance' should exist")
         maintenance.click()
-        RunLoop.current.run(until: Date(timeIntervalSinceNow: 0.5))
+        settle()
 
+        assertExists(
+            installed,
+            timeout: Self.elementTimeout,
+            "Sidebar category 'Installed' should remain after returning from Maintenance"
+        )
         installed.click()
-        RunLoop.current.run(until: Date(timeIntervalSinceNow: 0.5))
+        settle()
     }
 
     // MARK: - Refresh Button
 
     func testRefreshButtonExists() throws {
         let refreshButton = app.buttons["Refresh"]
-        XCTAssertTrue(
-            refreshButton.waitForExistence(timeout: Self.launchTimeout),
+        assertExists(
+            refreshButton,
+            timeout: Self.launchTimeout,
             "Refresh button should exist in sidebar footer"
         )
+    }
+
+    // MARK: - Helpers
+
+    /// Waits for `element` to exist via an explicit `XCTWaiter` expectation and
+    /// asserts it appeared. Wrapping `waitForExistence` this way lets every wait
+    /// share the TSan-scaled timeouts and keeps the assertion message intact.
+    private func assertExists(
+        _ element: XCUIElement,
+        timeout: TimeInterval,
+        _ message: @autoclosure () -> String,
+        file: StaticString = #filePath,
+        line: UInt = #line
+    ) {
+        let expectation = XCTNSPredicateExpectation(
+            predicate: NSPredicate(format: "exists == true"),
+            object: element
+        )
+        let outcome = XCTWaiter().wait(for: [expectation], timeout: timeout)
+        XCTAssertEqual(outcome, .completed, message(), file: file, line: line)
+    }
+
+    /// Lets navigation animations and layout settle between interactions. The
+    /// delay is scaled so TSan builds get proportionally more time.
+    private func settle(_ seconds: TimeInterval = 0.5) {
+        RunLoop.current.run(until: Date(timeIntervalSinceNow: seconds * Self.timeoutScale))
+    }
+
+    /// True when the Thread Sanitizer runtime is loaded into this process.
+    private static var isThreadSanitizerActive: Bool {
+        (0..<_dyld_image_count()).contains { index in
+            guard let name = _dyld_get_image_name(index) else { return false }
+            return String(cString: name).contains("libclang_rt.tsan")
+        }
     }
 }


### PR DESCRIPTION
The Test (Thread Sanitizer) CI job intermittently failed `testAllSidebarCategoriesRender` and `testMaintenanceViewTransition` on the first wait for the "Installed" sidebar row. Thread Sanitizer instrumentation slows the app under test enough that the unscaled 30s launch / 10s element timeouts occasionally expired on loaded runners, then passed on rerun.

This detects the TSan runtime in-process (its dylib is loaded into the UI-test host whenever the scheme is built with `-enableThreadSanitizer YES`) and scales every wait and settle delay 4x when present. Existence checks now go through an explicit `XCTWaiter` helper so they share the scaled timeouts, and the transition test gains the previously missing existence wait before it clicks the Maintenance row. The assertions are unchanged in meaning.