### PR TITLE
fix(bundle): gate Brewfile evaluation behind explicit trust

### DIFF
--- a/Brewy/Models/BrewService+Bundle.swift
+++ b/Brewy/Models/BrewService+Bundle.swift
@@ -1,3 +1,4 @@
+import CryptoKit
 import Foundation
 import OSLog
 
@@ -58,6 +59,7 @@ struct BrewBundleEntry: Identifiable, Hashable {
 enum BrewBundleCheckStatus: Equatable {
     case unknown
     case noBrewfile
+    case untrusted
     case checking
     case satisfied
     case unsatisfied([String])
@@ -187,6 +189,9 @@ extension BrewService {
         if url == nil {
             bundleEntries = []
             bundleCheckStatus = .noBrewfile
+        } else if let url, !isTrustedBrewfile(url) {
+            bundleEntries = []
+            bundleCheckStatus = .untrusted
         }
         return url
     }
@@ -195,6 +200,7 @@ extension BrewService {
         guard !isBundleLoading, bundleCheckStatus != .checking else { return }
         lastError = nil
         guard let brewfileURL = resolveBrewfile() else { return }
+        guard canExecuteBrewfile(brewfileURL) else { return }
         guard await fetchBundleEntries(brewfileURL: brewfileURL) else { return }
         await checkBundle(brewfileURL: brewfileURL)
     }
@@ -214,6 +220,7 @@ extension BrewService {
 
     @discardableResult
     func fetchBundleEntries(brewfileURL: URL) async -> Bool {
+        guard canExecuteBrewfile(brewfileURL) else { return false }
         isBundleLoading = true
         defer { isBundleLoading = false }
 
@@ -246,6 +253,7 @@ extension BrewService {
     }
 
     func checkBundle(brewfileURL: URL) async {
+        guard canExecuteBrewfile(brewfileURL) else { return }
         bundleCheckStatus = .checking
         let arguments = ["bundle", "check", "--verbose", "--file", brewfileURL.path]
         let result = await runBrewCommand(arguments)
@@ -281,9 +289,33 @@ extension BrewService {
 
         if result.success {
             customBrewfilePath = url.path
+            trustBrewfile(at: url)
             await refreshBundle()
         }
         return result
+    }
+
+    @discardableResult
+    func trustBrewfile(at url: URL) -> Bool {
+        let resolvedURL = url.resolvingSymlinksInPath()
+        guard let digest = Self.brewfileDigest(at: resolvedURL) else {
+            let message = "Unable to read Brewfile at \(url.path)."
+            bundleCheckStatus = .failed(message)
+            lastError = .commandFailed(command: "bundle trust", output: message)
+            return false
+        }
+        trustedBrewfilePath = resolvedURL.path
+        trustedBrewfileDigest = digest
+        if brewfileURL?.path == resolvedURL.path, bundleCheckStatus == .untrusted {
+            bundleCheckStatus = .unknown
+        }
+        return true
+    }
+
+    func trustCurrentBrewfileAndRefresh() async {
+        guard let brewfileURL = resolveBrewfile() else { return }
+        guard trustBrewfile(at: brewfileURL) else { return }
+        await refreshBundle()
     }
 
     private func bundleStatus(for name: String, type: BrewBundleEntryType) -> BrewBundleEntryStatus {
@@ -306,5 +338,30 @@ extension BrewService {
                 ? BrewBundleEntryStatus.installed
                 : BrewBundleEntryStatus.missing
         }
+    }
+
+    private func canExecuteBrewfile(_ url: URL) -> Bool {
+        guard isTrustedBrewfile(url) else {
+            bundleEntries = []
+            bundleCheckStatus = .untrusted
+            return false
+        }
+        return true
+    }
+
+    private func isTrustedBrewfile(_ url: URL) -> Bool {
+        // Homebrew Bundle only accepts a path, so recheck trust immediately before launch.
+        guard trustedBrewfilePath == url.path,
+              let digest = Self.brewfileDigest(at: url) else {
+            return false
+        }
+        return trustedBrewfileDigest == digest
+    }
+
+    private static func brewfileDigest(at url: URL) -> String? {
+        guard let data = try? Data(contentsOf: url) else { return nil }
+        return SHA256.hash(data: data)
+            .map { String(format: "%02x", $0) }
+            .joined()
     }
 }

--- a/Brewy/Models/BrewService.swift
+++ b/Brewy/Models/BrewService.swift
@@ -45,6 +45,12 @@ final class BrewService {
     @AppStorage("brewfilePath")
     @ObservationIgnored var customBrewfilePath = ""
 
+    @AppStorage("trustedBrewfilePath")
+    @ObservationIgnored var trustedBrewfilePath = ""
+
+    @AppStorage("trustedBrewfileDigest")
+    @ObservationIgnored var trustedBrewfileDigest = ""
+
     init(commandRunner: CommandRunning = DefaultCommandRunner()) {
         self.commandRunner = commandRunner
     }

--- a/Brewy/Views/BundleView.swift
+++ b/Brewy/Views/BundleView.swift
@@ -24,10 +24,13 @@ struct BundleView: View {
                     brewfileURL: brewfileURL,
                     entryCount: brewService.bundleEntries.count,
                     status: brewService.bundleCheckStatus,
-                    isLoading: brewService.isBundleLoading
+                    isLoading: brewService.isBundleLoading,
+                    trustBrewfile: trustBrewfile
                 )
 
-                if brewService.bundleEntries.isEmpty, !brewService.isBundleLoading {
+                if brewService.bundleEntries.isEmpty,
+                   !brewService.isBundleLoading,
+                   brewService.bundleCheckStatus != .untrusted {
                     Section {
                         ContentUnavailableView(
                             "No Bundle Entries",
@@ -111,6 +114,11 @@ struct BundleView: View {
         guard panel.runModal() == .OK, let url = panel.url else { return }
         Task { await brewService.dumpBundle(to: url) }
     }
+
+    @MainActor
+    private func trustBrewfile() {
+        Task { await brewService.trustCurrentBrewfileAndRefresh() }
+    }
 }
 
 // MARK: - Bundle Status
@@ -120,6 +128,7 @@ private struct BundleStatusSection: View {
     let entryCount: Int
     let status: BrewBundleCheckStatus
     let isLoading: Bool
+    let trustBrewfile: () -> Void
 
     var body: some View {
         Section {
@@ -157,6 +166,17 @@ private struct BundleStatusSection: View {
                     }
                 }
             }
+
+            if status == .untrusted {
+                Text("Brewfiles can execute Ruby code. Trust this file before Brewy reads bundle entries.")
+                    .font(.caption)
+                    .foregroundStyle(.secondary)
+
+                Button("Trust and Refresh", systemImage: "checkmark.shield") {
+                    trustBrewfile()
+                }
+                .help("Run Homebrew Bundle for this Brewfile")
+            }
         } header: {
             Label("Check", systemImage: "checkmark.seal")
         }
@@ -166,6 +186,7 @@ private struct BundleStatusSection: View {
         switch status {
         case .unknown: return "Not Checked"
         case .noBrewfile: return "No Brewfile"
+        case .untrusted: return "Review Required"
         case .checking: return "Checking..."
         case .satisfied: return "Satisfied"
         case .unsatisfied: return "Missing Dependencies"
@@ -179,6 +200,8 @@ private struct BundleStatusSection: View {
             return "\(entryCount) entries loaded."
         case .noBrewfile:
             return "Choose or create a Brewfile."
+        case .untrusted:
+            return "Trust this Brewfile before running bundle checks."
         case .checking:
             return "Checking Brewfile dependencies."
         case .satisfied:
@@ -196,6 +219,7 @@ private struct BundleStatusSection: View {
         case .satisfied: return .green
         case .unsatisfied: return .red
         case .failed: return .orange
+        case .untrusted: return .orange
         case .checking: return .blue
         case .unknown, .noBrewfile: return .secondary
         }

--- a/BrewyTests/BrewBundleTests.swift
+++ b/BrewyTests/BrewBundleTests.swift
@@ -151,6 +151,7 @@ struct BrewServiceBundleTests {
         ]
         service.isMasAvailable = false
 
+        #expect(service.trustBrewfile(at: brewfile))
         Self.setBundleListResults(mock, path: brewfile.path)
 
         await service.fetchBundleEntries()
@@ -172,6 +173,7 @@ struct BrewServiceBundleTests {
         service.isMasAvailable = true
         service.installedMasApps = [makePackage(name: "Xcode", source: .mas)]
 
+        #expect(service.trustBrewfile(at: brewfile))
         Self.setBundleListResults(mock, path: brewfile.path)
 
         await service.fetchBundleEntries()
@@ -207,6 +209,7 @@ struct BrewServiceBundleTests {
         let mock = MockCommandRunner()
         let (service, _) = makeService(mock: mock)
         service.customBrewfilePath = brewfile.path
+        #expect(service.trustBrewfile(at: brewfile))
         mock.setResult(
             for: ["bundle", "check", "--verbose", "--file", brewfile.path],
             output: "The Brewfile's dependencies are satisfied.\n"
@@ -225,6 +228,7 @@ struct BrewServiceBundleTests {
         let mock = MockCommandRunner()
         let (service, _) = makeService(mock: mock)
         service.customBrewfilePath = brewfile.path
+        #expect(service.trustBrewfile(at: brewfile))
         mock.setResult(
             for: ["bundle", "check", "--verbose", "--file", brewfile.path],
             output: """
@@ -249,6 +253,7 @@ struct BrewServiceBundleTests {
         let mock = MockCommandRunner()
         let (service, _) = makeService(mock: mock)
         service.customBrewfilePath = brewfile.path
+        #expect(service.trustBrewfile(at: brewfile))
         mock.setResult(
             for: ["bundle", "check", "--verbose", "--file", brewfile.path],
             output: "Error: Permission denied @ rb_sysopen - \(brewfile.path)\n",
@@ -280,12 +285,80 @@ struct BrewServiceBundleTests {
         #expect(mock.executedCommands.isEmpty)
     }
 
+    @Test("refreshBundle requires trust before executing Brewfile commands")
+    func refreshBundleRequiresTrust() async throws {
+        let brewfile = try Self.makeBrewfile()
+        let mock = MockCommandRunner()
+        let (service, _) = makeService(mock: mock)
+        service.customBrewfilePath = brewfile.path
+        Self.setBundleListResults(mock, path: brewfile.path)
+        mock.setResult(
+            for: ["bundle", "check", "--verbose", "--file", brewfile.path],
+            output: "The Brewfile's dependencies are satisfied.\n"
+        )
+
+        await service.refreshBundle()
+
+        #expect(service.brewfileURL?.path == brewfile.path)
+        #expect(service.bundleEntries.isEmpty)
+        #expect(service.bundleCheckStatus == .untrusted)
+        #expect(mock.executedCommands.isEmpty)
+    }
+
+    @Test("changed or switched trusted Brewfile requires trust again")
+    func changedOrSwitchedTrustedBrewfileRequiresTrustAgain() async throws {
+        let brewfile = try Self.makeBrewfile(contents: "brew \"wget\"\n")
+        let otherBrewfile = try Self.makeBrewfile(contents: "brew \"curl\"\n")
+        let mock = MockCommandRunner()
+        let (service, _) = makeService(mock: mock)
+        service.customBrewfilePath = brewfile.path
+        #expect(service.trustBrewfile(at: brewfile))
+        try "brew \"curl\"\n".write(to: brewfile, atomically: true, encoding: .utf8)
+        Self.setBundleListResults(mock, path: brewfile.path)
+
+        await service.refreshBundle()
+
+        #expect(service.bundleEntries.isEmpty)
+        #expect(service.bundleCheckStatus == .untrusted)
+        #expect(mock.executedCommands.isEmpty)
+        service.customBrewfilePath = otherBrewfile.path
+
+        await service.fetchBundleEntries()
+        await service.checkBundle()
+        await service.refreshBundle()
+
+        #expect(service.brewfileURL?.path == otherBrewfile.path)
+        #expect(service.bundleCheckStatus == .untrusted)
+        #expect(mock.executedCommands.isEmpty)
+    }
+
+    @Test("trustCurrentBrewfileAndRefresh executes trusted Brewfile commands")
+    func trustCurrentBrewfileAndRefreshExecutesCommands() async throws {
+        let brewfile = try Self.makeBrewfile()
+        let mock = MockCommandRunner()
+        let (service, _) = makeService(mock: mock)
+        service.customBrewfilePath = brewfile.path
+        Self.setEmptyBundleListResults(mock, path: brewfile.path)
+        mock.setResult(
+            for: ["bundle", "check", "--verbose", "--file", brewfile.path],
+            output: "The Brewfile's dependencies are satisfied.\n"
+        )
+
+        await service.trustCurrentBrewfileAndRefresh()
+
+        #expect(service.trustedBrewfilePath == brewfile.path)
+        #expect(service.trustedBrewfileDigest.isEmpty == false)
+        #expect(service.bundleCheckStatus == .satisfied)
+        #expect(mock.executedCommands.count == 5)
+    }
+
     @Test("refreshBundle stops when listing fails")
     func refreshBundleStopsWhenListingFails() async throws {
         let brewfile = try Self.makeBrewfile()
         let mock = MockCommandRunner()
         let (service, _) = makeService(mock: mock)
         service.customBrewfilePath = brewfile.path
+        #expect(service.trustBrewfile(at: brewfile))
         mock.setResult(
             for: ["bundle", "list", "--formula", "--file", brewfile.path],
             output: "Error: Permission denied @ rb_sysopen - \(brewfile.path)\n",
@@ -312,6 +385,7 @@ struct BrewServiceBundleTests {
         let mock = MockCommandRunner()
         let (service, _) = makeService(mock: mock)
         service.customBrewfilePath = brewfile.path
+        #expect(service.trustBrewfile(at: brewfile))
         Self.setBundleListResults(mock, path: brewfile.path)
         mock.setResult(
             for: ["bundle", "check", "--verbose", "--file", brewfile.path],
@@ -375,6 +449,7 @@ struct BrewServiceBundleTests {
         let mock = MockCommandRunner()
         let (service, _) = makeService(mock: mock)
         service.customBrewfilePath = brewfile.path
+        #expect(service.trustBrewfile(at: brewfile))
         Self.setEmptyBundleListResults(mock, path: brewfile.path)
         mock.setResult(
             for: ["bundle", "check", "--verbose", "--file", brewfile.path],
@@ -403,12 +478,12 @@ struct BrewServiceBundleTests {
         mock.setResult(for: ["bundle", "list", "--mas", "--file", path], output: "")
     }
 
-    private static func makeBrewfile() throws -> URL {
+    private static func makeBrewfile(contents: String = "") throws -> URL {
         let directory = FileManager.default.temporaryDirectory
             .appendingPathComponent("BrewyBundleTests-\(UUID().uuidString)", isDirectory: true)
         try FileManager.default.createDirectory(at: directory, withIntermediateDirectories: true)
         let brewfile = directory.appendingPathComponent("Brewfile")
-        try Data().write(to: brewfile)
+        try contents.write(to: brewfile, atomically: true, encoding: .utf8)
         return brewfile
     }
 }


### PR DESCRIPTION
`brew bundle list` and `brew bundle check` evaluate the Brewfile as Ruby, so refreshing an auto-discovered or user-chosen Brewfile could execute its code before the user trusted the file.

This records an explicit trust as a (resolved path, SHA-256 digest) pair in app storage and gates every `bundle list`/`bundle check` invocation behind it. All entry points route through the check: startup refresh, the Bundle view task, manual refresh, `fetchBundleEntries`, `checkBundle`, and the post-dump refresh. `brew bundle dump` is unaffected since it writes from installed state rather than evaluating an existing file, and it trusts the file it just wrote.

Editing a trusted Brewfile or switching to a different one invalidates trust and requires re-confirmation. Until a file is trusted, the Bundle view shows a Review Required state with a Trust and Refresh action. Trust is rechecked immediately before each launch because Homebrew Bundle only accepts a path.

Regression tests assert zero command execution for untrusted files, for modified trusted content, and after switching to a different Brewfile path, covering the no-arg `fetchBundleEntries`/`checkBundle`/`refreshBundle` entry points directly.