### PR TITLE
feat(discover): show newly added packages when search is empty

### DIFF
--- a/Brewy/Models/BrewService.swift
+++ b/Brewy/Models/BrewService.swift
@@ -103,6 +103,7 @@ final class BrewService {
 
     private(set) var allInstalled: [BrewPackage] = []
     private(set) var installedNames: Set<String> = []
+    private(set) var installedIDs: Set<String> = []
     private(set) var reverseDependencies: [String: [BrewPackage]] = [:]
     private(set) var leavesPackages: [BrewPackage] = []
     private(set) var pinnedPackages: [BrewPackage] = []
@@ -135,6 +136,7 @@ final class BrewService {
         let all = installedFormulae + installedCasks + installedMasApps
         allInstalled = all
         installedNames = Set(all.map(\.name))
+        installedIDs = Set(all.map(\.id))
 
         var reverse: [String: [BrewPackage]] = [:]
         reverse.reserveCapacity(all.count)

--- a/Brewy/Models/PackageModel.swift
+++ b/Brewy/Models/PackageModel.swift
@@ -414,23 +414,21 @@ struct BrewConfig {
 }
 
 // MARK: - Brew Update Result
-
 struct BrewUpdateItem: Identifiable, Hashable, Codable, Sendable {
     let name: String
     let description: String?
     let source: PackageSource
 
     var id: String { "\(source.rawValue)-\(name)" }
-
-    /// Builds a minimal BrewPackage suitable for handing to brew install actions.
-    func asPlaceholderPackage() -> BrewPackage {
+    /// Builds a minimal BrewPackage for newly discovered update items.
+    func asPlaceholderPackage(isInstalled: Bool = false) -> BrewPackage {
         BrewPackage(
             id: id,
             name: name,
             version: "",
             description: description ?? "",
             homepage: "",
-            isInstalled: false,
+            isInstalled: isInstalled,
             isOutdated: false,
             installedVersion: nil,
             latestVersion: nil,
@@ -449,6 +447,9 @@ struct BrewUpdateResult: Codable, Sendable {
 
     var isEmpty: Bool { newFormulae.isEmpty && newCasks.isEmpty }
     var totalCount: Int { newFormulae.count + newCasks.count }
+    func discoverPackages(installedPackageIDs: Set<String>) -> [BrewPackage] {
+        (newFormulae + newCasks).map { item in item.asPlaceholderPackage(isInstalled: installedPackageIDs.contains(item.id)) }
+    }
 }
 
 enum BrewUpdateParser {

--- a/Brewy/Views/DiscoverView.swift
+++ b/Brewy/Views/DiscoverView.swift
@@ -5,21 +5,35 @@ struct DiscoverView: View {
     private var brewService
     @Binding var selectedPackage: BrewPackage?
     @State private var searchText = ""
-    @State private var results: [BrewPackage] = []
+    @State private var searchResults: [BrewPackage] = []
     @State private var isSearching = false
     @State private var searchTask: Task<Void, Never>?
 
+    private var recentPackages: [BrewPackage] {
+        guard searchText.isEmpty,
+              let result = brewService.lastUpdateResult,
+              !result.isEmpty else { return [] }
+        return result.discoverPackages(installedPackageIDs: brewService.installedIDs)
+    }
+
+    private var displayedPackages: [BrewPackage] {
+        searchText.isEmpty ? recentPackages : searchResults
+    }
+
     var body: some View {
+        let packages = displayedPackages
         List(selection: $selectedPackage) {
-            if results.isEmpty {
+            if packages.isEmpty {
                 emptyContent
             } else {
-                ForEach(results) { package in
-                    DiscoverRow(
-                        package: package,
-                        onInstall: { pkg in await brewService.install(package: pkg) }
-                    )
-                    .tag(package)
+                if searchText.isEmpty, let result = brewService.lastUpdateResult {
+                    Section {
+                        packageRows(packages)
+                    } header: {
+                        Text("New since \(result.timestamp.formatted(.relative(presentation: .named)))")
+                    }
+                } else {
+                    packageRows(packages)
                 }
             }
         }
@@ -28,7 +42,7 @@ struct DiscoverView: View {
         .onChange(of: searchText) {
             searchTask?.cancel()
             guard !searchText.isEmpty else {
-                results = []
+                searchResults = []
                 isSearching = false
                 return
             }
@@ -38,21 +52,36 @@ struct DiscoverView: View {
                 isSearching = true
                 let fetched = await brewService.performSearch(query: searchText)
                 guard !Task.isCancelled else { return }
-                results = fetched
+                searchResults = fetched
                 isSearching = false
             }
         }
         .overlay {
-            if isSearching, !searchText.isEmpty, results.isEmpty {
+            if isSearching, !searchText.isEmpty, searchResults.isEmpty {
                 ProgressView("Searching...")
             }
         }
         .navigationTitle("Discover")
-        .navigationSubtitle(
-            searchText.isEmpty
-                ? "Search to find new packages"
-                : "\(results.count) results"
-        )
+        .navigationSubtitle(navigationSubtitle(for: packages.count))
+    }
+
+    @ViewBuilder
+    private func packageRows(_ packages: [BrewPackage]) -> some View {
+        ForEach(packages) { package in
+            DiscoverRow(
+                package: package,
+                onInstall: { pkg in await brewService.install(package: pkg) }
+            )
+            .tag(package)
+        }
+    }
+
+    private func navigationSubtitle(for count: Int) -> String {
+        if searchText.isEmpty {
+            guard count > 0 else { return "Search to find new packages" }
+            return count == 1 ? "1 new package" : "\(count) new packages"
+        }
+        return "\(count) results"
     }
 
     @ViewBuilder private var emptyContent: some View {

--- a/BrewyTests/BrewUpdateParserTests.swift
+++ b/BrewyTests/BrewUpdateParserTests.swift
@@ -170,6 +170,33 @@ struct BrewUpdateParserTests {
         let caskPkg = caskWithoutDesc.asPlaceholderPackage()
         #expect(caskPkg.source == .cask)
         #expect(caskPkg.description.isEmpty)
+
+        let installedPkg = formulaItem.asPlaceholderPackage(isInstalled: true)
+        #expect(installedPkg.isInstalled)
+    }
+
+    @Test("discoverPackages preserves order and uses source-qualified installed state")
+    func discoverPackagesMapsRecentItems() {
+        let result = BrewUpdateResult(
+            newFormulae: [
+                BrewUpdateItem(name: "foo", description: "Formula", source: .formula),
+                BrewUpdateItem(name: "shared", description: nil, source: .formula)
+            ],
+            newCasks: [
+                BrewUpdateItem(name: "bar", description: "Cask", source: .cask),
+                BrewUpdateItem(name: "shared", description: nil, source: .cask)
+            ],
+            timestamp: Date(timeIntervalSince1970: 1_700_000_000)
+        )
+
+        let packages = result.discoverPackages(installedPackageIDs: ["formula-foo", "formula-shared", "cask-bar"])
+
+        #expect(packages.map(\.id) == ["formula-foo", "formula-shared", "cask-bar", "cask-shared"])
+        #expect(packages.map(\.source) == [.formula, .formula, .cask, .cask])
+        #expect(packages.map(\.isInstalled) == [true, true, true, false])
+
+        let empty = BrewUpdateResult(newFormulae: [], newCasks: [], timestamp: Date())
+        #expect(empty.discoverPackages(installedPackageIDs: []).isEmpty)
     }
 
     @Test("Codable round-trip preserves all fields")


### PR DESCRIPTION
Discover now shows newly added Homebrew packages when the search field is empty. It lists the new formulae and casks from the most recent `brew update` under a "New since <time>" header, and switches to live Homebrew search results as soon as the user types.

Installed state for the recent list is resolved by source-qualified package id, so a formula and a cask that share a name no longer show a false Installed badge. The derivation is a pure `BrewUpdateResult.discoverPackages` function with unit tests covering ordering, installed-state mapping, and empty results.

Closes #231