### PR TITLE
fix(security): separate package names from flags in brew commands

### DIFF
--- a/Brewy/Models/BrewService+Actions.swift
+++ b/Brewy/Models/BrewService+Actions.swift
@@ -78,6 +78,7 @@ extension BrewService {
 
         var args = [action]
         if package.isCask { args.append("--cask") }
+        args.append("--")
         args.append(package.name)
 
         let result = await runBrewCommand(args)
@@ -134,7 +135,7 @@ extension BrewService {
     func info(for package: BrewPackage) async -> String {
         guard !package.isMas else { return "" }
         if let cached = infoCache[package.id] { return cached }
-        let command = package.isCask ? ["info", "--cask", package.name] : ["info", package.name]
+        let command = package.isCask ? ["info", "--cask", "--", package.name] : ["info", "--", package.name]
         let result = await runBrewCommand(command)
         // Don't cache failures: a transient error would otherwise stick until the version changes.
         if result.success {

--- a/Brewy/Models/BrewService+PackageDetail.swift
+++ b/Brewy/Models/BrewService+PackageDetail.swift
@@ -9,8 +9,8 @@ extension BrewService {
 
     func fetchPackageDetail(for package: BrewPackage) async -> BrewPackage? {
         let command = package.isCask
-            ? ["info", "--cask", "--json=v2", package.name]
-            : ["info", "--json=v2", package.name]
+            ? ["info", "--cask", "--json=v2", "--", package.name]
+            : ["info", "--json=v2", "--", package.name]
         let result = await runBrewCommand(command)
         guard result.success, let data = result.output.data(using: .utf8) else { return nil }
 

--- a/BrewyTests/BrewServiceAsyncTests.swift
+++ b/BrewyTests/BrewServiceAsyncTests.swift
@@ -127,7 +127,7 @@ struct RefreshTests {
 
         await service.refresh()
 
-        mock.setResult(for: ["info", "wget"], output: "wget: stable 1.24.5")
+        mock.setResult(for: ["info", "--", "wget"], output: "wget: stable 1.24.5")
         let info = await service.info(for: service.installedFormulae[0])
         #expect(!info.isEmpty)
 
@@ -143,7 +143,7 @@ struct RefreshTests {
 
         await service.refresh()
 
-        mock.setResult(for: ["info", "wget"], output: "wget: stable 1.25.0")
+        mock.setResult(for: ["info", "--", "wget"], output: "wget: stable 1.25.0")
         let newInfo = await service.info(for: service.installedFormulae[0])
         #expect(newInfo == "wget: stable 1.25.0")
     }
@@ -296,11 +296,11 @@ struct PackageActionTests {
         let (service, _) = makeService(mock: mock)
         let pkg = makePackage(name: "wget")
         setupRefreshMock(mock)
-        mock.setResult(for: ["install", "wget"], output: "Installed wget")
+        mock.setResult(for: ["install", "--", "wget"], output: "Installed wget")
 
         await service.install(package: pkg)
 
-        #expect(mock.executedCommands.contains(["install", "wget"]))
+        #expect(mock.executedCommands.contains(["install", "--", "wget"]))
         #expect(service.actionOutput == "Installed wget")
     }
 
@@ -310,11 +310,11 @@ struct PackageActionTests {
         let (service, _) = makeService(mock: mock)
         let pkg = makePackage(name: "firefox", source: .cask)
         setupRefreshMock(mock)
-        mock.setResult(for: ["install", "--cask", "firefox"], output: "Installed firefox")
+        mock.setResult(for: ["install", "--cask", "--", "firefox"], output: "Installed firefox")
 
         await service.install(package: pkg)
 
-        #expect(mock.executedCommands.contains(["install", "--cask", "firefox"]))
+        #expect(mock.executedCommands.contains(["install", "--cask", "--", "firefox"]))
     }
 
     @Test("install skips mas packages")
@@ -335,11 +335,11 @@ struct PackageActionTests {
         let (service, _) = makeService(mock: mock)
         let pkg = makePackage(name: "wget")
         setupRefreshMock(mock)
-        mock.setResult(for: ["uninstall", "wget"], output: "Uninstalled wget")
+        mock.setResult(for: ["uninstall", "--", "wget"], output: "Uninstalled wget")
 
         await service.uninstall(package: pkg)
 
-        #expect(mock.executedCommands.contains(["uninstall", "wget"]))
+        #expect(mock.executedCommands.contains(["uninstall", "--", "wget"]))
     }
 
     @Test("upgrade calls brew upgrade")
@@ -348,11 +348,11 @@ struct PackageActionTests {
         let (service, _) = makeService(mock: mock)
         let pkg = makePackage(name: "wget")
         setupRefreshMock(mock)
-        mock.setResult(for: ["upgrade", "wget"], output: "Upgraded wget")
+        mock.setResult(for: ["upgrade", "--", "wget"], output: "Upgraded wget")
 
         await service.upgrade(package: pkg)
 
-        #expect(mock.executedCommands.contains(["upgrade", "wget"]))
+        #expect(mock.executedCommands.contains(["upgrade", "--", "wget"]))
     }
 
     @Test("pin calls brew pin")
@@ -361,11 +361,11 @@ struct PackageActionTests {
         let (service, _) = makeService(mock: mock)
         let pkg = makePackage(name: "wget")
         setupRefreshMock(mock)
-        mock.setResult(for: ["pin", "wget"], output: "Pinned wget")
+        mock.setResult(for: ["pin", "--", "wget"], output: "Pinned wget")
 
         await service.pin(package: pkg)
 
-        #expect(mock.executedCommands.contains(["pin", "wget"]))
+        #expect(mock.executedCommands.contains(["pin", "--", "wget"]))
     }
 
     @Test("unpin calls brew unpin")
@@ -374,11 +374,11 @@ struct PackageActionTests {
         let (service, _) = makeService(mock: mock)
         let pkg = makePackage(name: "wget")
         setupRefreshMock(mock)
-        mock.setResult(for: ["unpin", "wget"], output: "Unpinned wget")
+        mock.setResult(for: ["unpin", "--", "wget"], output: "Unpinned wget")
 
         await service.unpin(package: pkg)
 
-        #expect(mock.executedCommands.contains(["unpin", "wget"]))
+        #expect(mock.executedCommands.contains(["unpin", "--", "wget"]))
     }
 
     @Test("reinstall calls brew reinstall")
@@ -387,11 +387,11 @@ struct PackageActionTests {
         let (service, _) = makeService(mock: mock)
         let pkg = makePackage(name: "wget")
         setupRefreshMock(mock)
-        mock.setResult(for: ["reinstall", "wget"], output: "Reinstalled wget")
+        mock.setResult(for: ["reinstall", "--", "wget"], output: "Reinstalled wget")
 
         await service.reinstall(package: pkg)
 
-        #expect(mock.executedCommands.contains(["reinstall", "wget"]))
+        #expect(mock.executedCommands.contains(["reinstall", "--", "wget"]))
     }
 
     @Test("failed action records failure in history")
@@ -400,7 +400,7 @@ struct PackageActionTests {
         let (service, _) = makeService(mock: mock)
         let pkg = makePackage(name: "wget")
         setupRefreshMock(mock)
-        mock.setResult(for: ["install", "wget"], output: "Error: something failed", success: false)
+        mock.setResult(for: ["install", "--", "wget"], output: "Error: something failed", success: false)
 
         await service.install(package: pkg)
 
@@ -415,7 +415,7 @@ struct PackageActionTests {
         let (service, _) = makeService(mock: mock)
         let pkg = makePackage(name: "wget")
         setupRefreshMock(mock)
-        mock.setResult(for: ["install", "wget"], output: "Installed wget")
+        mock.setResult(for: ["install", "--", "wget"], output: "Installed wget")
 
         await service.install(package: pkg)
 
@@ -431,7 +431,7 @@ struct PackageActionTests {
         let (service, _) = makeService(mock: mock)
         let pkg = makePackage(name: "wget")
         setupRefreshMock(mock)
-        mock.setResult(for: ["install", "wget"], output: "Installed wget")
+        mock.setResult(for: ["install", "--", "wget"], output: "Installed wget")
 
         await service.install(package: pkg)
 

--- a/BrewyTests/BrewServiceDetailTests.swift
+++ b/BrewyTests/BrewServiceDetailTests.swift
@@ -147,7 +147,7 @@ struct InfoCachingTests {
         let mock = MockCommandRunner()
         let (service, _) = makeService(mock: mock)
         let pkg = makePackage(name: "wget")
-        mock.setResult(for: ["info", "wget"], output: "wget: stable 1.24.5")
+        mock.setResult(for: ["info", "--", "wget"], output: "wget: stable 1.24.5")
 
         let first = await service.info(for: pkg)
         let second = await service.info(for: pkg)
@@ -155,7 +155,7 @@ struct InfoCachingTests {
         #expect(first == "wget: stable 1.24.5")
         #expect(second == "wget: stable 1.24.5")
 
-        let infoCommands = mock.executedCommands.filter { $0 == ["info", "wget"] }
+        let infoCommands = mock.executedCommands.filter { $0 == ["info", "--", "wget"] }
         #expect(infoCommands.count == 1)
     }
 
@@ -164,12 +164,12 @@ struct InfoCachingTests {
         let mock = MockCommandRunner()
         let (service, _) = makeService(mock: mock)
         let pkg = makePackage(name: "firefox", source: .cask)
-        mock.setResult(for: ["info", "--cask", "firefox"], output: "firefox: 122.0")
+        mock.setResult(for: ["info", "--cask", "--", "firefox"], output: "firefox: 122.0")
 
         let result = await service.info(for: pkg)
 
         #expect(result == "firefox: 122.0")
-        #expect(mock.executedCommands.contains(["info", "--cask", "firefox"]))
+        #expect(mock.executedCommands.contains(["info", "--cask", "--", "firefox"]))
     }
 
     @Test("info returns empty string for mas packages")
@@ -196,7 +196,7 @@ struct PackageDetailTests {
         let mock = MockCommandRunner()
         let (service, _) = makeService(mock: mock)
         let pkg = makePackage(name: "wget")
-        mock.setResult(for: ["info", "--json=v2", "wget"], output: TestJSON.formulaDetail)
+        mock.setResult(for: ["info", "--json=v2", "--", "wget"], output: TestJSON.formulaDetail)
 
         let enriched = await service.fetchPackageDetail(for: pkg)
 
@@ -210,7 +210,7 @@ struct PackageDetailTests {
         let mock = MockCommandRunner()
         let (service, _) = makeService(mock: mock)
         let pkg = makePackage(name: "firefox", source: .cask)
-        mock.setResult(for: ["info", "--cask", "--json=v2", "firefox"], output: TestJSON.caskDetail)
+        mock.setResult(for: ["info", "--cask", "--json=v2", "--", "firefox"], output: TestJSON.caskDetail)
 
         let enriched = await service.fetchPackageDetail(for: pkg)
 
@@ -223,7 +223,7 @@ struct PackageDetailTests {
         let mock = MockCommandRunner()
         let (service, _) = makeService(mock: mock)
         let pkg = makePackage(name: "wget")
-        mock.setResult(for: ["info", "--json=v2", "wget"], output: "Error", success: false)
+        mock.setResult(for: ["info", "--json=v2", "--", "wget"], output: "Error", success: false)
 
         let enriched = await service.fetchPackageDetail(for: pkg)
 
@@ -235,7 +235,7 @@ struct PackageDetailTests {
         let mock = MockCommandRunner()
         let (service, _) = makeService(mock: mock)
         let pkg = makePackage(name: "wget")
-        mock.setResult(for: ["info", "--json=v2", "wget"], output: "not json at all")
+        mock.setResult(for: ["info", "--json=v2", "--", "wget"], output: "not json at all")
 
         let enriched = await service.fetchPackageDetail(for: pkg)
 
@@ -254,7 +254,7 @@ struct PackageDetailTests {
             source: .formula, pinned: true, installedOnRequest: true,
             dependencies: []
         )
-        mock.setResult(for: ["info", "--json=v2", "wget"], output: TestJSON.formulaDetail)
+        mock.setResult(for: ["info", "--json=v2", "--", "wget"], output: TestJSON.formulaDetail)
 
         let enriched = await service.fetchPackageDetail(for: pkg)
 
@@ -280,7 +280,7 @@ struct PackageDetailTests {
         {"formulae":[],"casks":[{"token":"firefox","version":"123.0",\
         "desc":"Fast web browser"}]}
         """
-        mock.setResult(for: ["info", "--cask", "--json=v2", "firefox"], output: detail)
+        mock.setResult(for: ["info", "--cask", "--json=v2", "--", "firefox"], output: detail)
 
         let enriched = await service.fetchPackageDetail(for: pkg)
 

--- a/BrewyTests/SecurityHelpersTests.swift
+++ b/BrewyTests/SecurityHelpersTests.swift
@@ -79,6 +79,53 @@ struct BrewServiceSafetyGuardrailTests {
         #expect(mock.executedCommands.contains(["search", "--cask", "--", "--eval-all"]))
     }
 
+    @Test("package actions insert option separator before package name")
+    func packageActionsUseOptionSeparator() async {
+        let mock = MockCommandRunner()
+        let (service, _) = makeService(mock: mock)
+        setupRefreshMock(mock)
+
+        let formula = makePackage(name: "--eval-all", source: .formula)
+        let cask = makePackage(name: "--zap", source: .cask)
+        let formulaCommand = ["install", "--", "--eval-all"]
+        let caskCommand = ["install", "--cask", "--", "--zap"]
+        mock.setResult(for: formulaCommand, output: "Installed formula")
+        mock.setResult(for: caskCommand, output: "Installed cask")
+
+        await service.install(package: formula)
+        await service.install(package: cask)
+
+        #expect(mock.executedCommands.contains(formulaCommand))
+        #expect(mock.executedCommands.contains(caskCommand))
+    }
+
+    @Test("read-only package info commands insert option separator before package name")
+    func packageInfoUsesOptionSeparator() async {
+        let mock = MockCommandRunner()
+        let (service, _) = makeService(mock: mock)
+
+        let formula = makePackage(name: "--eval-all", source: .formula)
+        let cask = makePackage(name: "--zap", source: .cask)
+        let formulaInfoCommand = ["info", "--", "--eval-all"]
+        let caskInfoCommand = ["info", "--cask", "--", "--zap"]
+        let formulaDetailCommand = ["info", "--json=v2", "--", "--eval-all"]
+        let caskDetailCommand = ["info", "--cask", "--json=v2", "--", "--zap"]
+        mock.setResult(for: formulaInfoCommand, output: "formula info")
+        mock.setResult(for: caskInfoCommand, output: "cask info")
+        mock.setResult(for: formulaDetailCommand, output: TestJSON.formulaDetail)
+        mock.setResult(for: caskDetailCommand, output: TestJSON.caskDetail)
+
+        _ = await service.info(for: formula)
+        _ = await service.info(for: cask)
+        _ = await service.fetchPackageDetail(for: formula)
+        _ = await service.fetchPackageDetail(for: cask)
+
+        #expect(mock.executedCommands.contains(formulaInfoCommand))
+        #expect(mock.executedCommands.contains(caskInfoCommand))
+        #expect(mock.executedCommands.contains(formulaDetailCommand))
+        #expect(mock.executedCommands.contains(caskDetailCommand))
+    }
+
     @Test("upgradeSelected excludes mas apps and reports App Store updates")
     func upgradeSelectedReportsMasApps() async {
         let mock = MockCommandRunner()


### PR DESCRIPTION
Package names reach brew argument arrays from untrusted metadata (search, update, and package detail). They were appended immediately after brew's flags, so a name beginning with a dash could be parsed by brew as an option rather than an operand.

Insert the `--` end-of-options terminator before the package name in every affected command: install, uninstall, upgrade, pin, unpin, reinstall, fetch, link, unlink, `info`, and the JSON detail fetch. This matches the terminator already used in `performSearch`. Execution already passed arguments as arrays through `CommandRunner`, so this is defense in depth against option injection rather than a shell-escaping fix.

Added guardrail tests using leading-dash formula and cask names that assert the exact captured argument arrays.