### PR TITLE
chore(ci): drop the unused Homebrew/actions zizmor exception

### DIFF
--- a/.fleet.yml
+++ b/.fleet.yml
@@ -1,7 +1,6 @@
 schema: 1
 license: "agpl"
 params:
-  zizmor-config: true
   dependabot:
     - package-ecosystem: "github-actions"
       group: "github-actions"

--- a/.github/zizmor.yml
+++ b/.github/zizmor.yml
@@ -1,7 +1,0 @@
-rules:
-  unpinned-uses:
-    config:
-      policies:
-        # Homebrew/actions does not publish versioned refs; keep this exception
-        # scoped to upstream Homebrew actions.
-        Homebrew/actions/*: ref-pin


### PR DESCRIPTION
Homebrew/actions publishes CalVer release tags, so the fleet-wide zizmor ref-pin exception for `Homebrew/actions` is being retired.

Brewy runs no `Homebrew/actions` workflows, so its `zizmor-config` opt-in only rendered an unused `.github/zizmor.yml`. Removing it lets zizmor's default full-SHA policy apply.
