### PR TITLE
docs(security): add email reporting channel

### DIFF
--- a/.github/ISSUE_TEMPLATE/config.yml
+++ b/.github/ISSUE_TEMPLATE/config.yml
@@ -2,4 +2,4 @@ blank_issues_enabled: true
 contact_links:
   - name: Report a security vulnerability
     url: https://github.com/starhaven-io/Brewy/security/advisories/new
-    about: Please report vulnerabilities privately instead of opening a public issue.
+    about: Report vulnerabilities privately through GitHub or security@starhaven.io.

--- a/README.md
+++ b/README.md
@@ -78,6 +78,8 @@ All CLI execution is centralized through `CommandRunner`, which invokes binaries
 
 Destructive maintenance operations show Homebrew dry-run previews before they can run. External links from package data, tap data, and release notes must pass through `ExternalURLPolicy`, which restricts URLs to `http` and `https` before opening them outside the app.
 
+Report suspected vulnerabilities privately by emailing [security@starhaven.io](mailto:security@starhaven.io) or using [GitHub's private vulnerability reporting](https://github.com/starhaven-io/Brewy/security/advisories/new). See the [security policy](SECURITY.md) for details.
+
 ## Contributing
 
 Contributions are welcome. See [CONTRIBUTING.md](CONTRIBUTING.md) for the development setup, local checks, and commit conventions.

--- a/SECURITY.md
+++ b/SECURITY.md
@@ -1,27 +1,19 @@
 # Security Policy
 
-## Supported Versions
+## Reporting a vulnerability
 
-Security fixes are made against the current `main` branch and the latest released
-version of Brewy.
+Please report suspected vulnerabilities privately by emailing
+[security@starhaven.io](mailto:security@starhaven.io) or using
+[GitHub's private vulnerability reporting](https://github.com/starhaven-io/Brewy/security/advisories/new).
+Do not open a public issue for an undisclosed vulnerability.
 
-## Reporting a Vulnerability
-
-Please do not report security vulnerabilities in a public issue.
-
-Use GitHub private vulnerability reporting for this repository:
-
-https://github.com/starhaven-io/Brewy/security/advisories/new
-
-If private vulnerability reporting is unavailable, open a public issue with no
-technical details and ask for a private contact path.
-
-Helpful reports include:
+Useful reports include:
 
 - Affected Brewy version or commit.
 - macOS version and processor architecture.
 - Homebrew path and relevant `brew` or `mas` version.
 - Steps to reproduce and the security impact.
+- Any suggested mitigation or fix.
 - Logs or command output with secrets, tokens, and local private paths removed.
 
 Brewy executes the user's local Homebrew installation and displays package, tap,
@@ -30,5 +22,10 @@ individual formulae, casks, taps, or upstream packages should usually be reporte
 to the upstream project or tap maintainer unless Brewy changes the security
 impact.
 
-We will acknowledge private reports as soon as practical, investigate the issue,
-and coordinate disclosure timing with the reporter when a fix is needed.
+We will acknowledge the report, investigate it, and coordinate disclosure with
+you.
+
+## Supported versions
+
+Security fixes are made against the current `main` branch and the latest released
+version of Brewy.


### PR DESCRIPTION
Add security@starhaven.io alongside GitHub private vulnerability reporting in the security policy, README, and issue-template contact link. Remove the public-issue fallback and align the reporting checklist and acknowledgment wording with the fleet.