### PR TITLE
docs(security): support only the latest released version

### DIFF
--- a/SECURITY.md
+++ b/SECURITY.md
@@ -27,5 +27,4 @@ you.
 
 ## Supported versions
 
-Security fixes are made against the current `main` branch and the latest released
-version of Brewy.
+Only the latest released version of Brewy is supported with security fixes.


### PR DESCRIPTION
main is for testing, not a support target. Only the latest released version of Brewy receives security fixes, matching the fleet-wide stance.