### PR TITLE
test: raise SwiftUI coverage with fixture-backed UI tests

### DIFF
--- a/Brewy/BrewyApp.swift
+++ b/Brewy/BrewyApp.swift
@@ -4,7 +4,7 @@ import SwiftUI
 
 @main
 struct BrewyApp: App {
-    @State private var brewService = BrewService()
+    @State private var brewService = Self.makeBrewService()
     // HACK: there is a known color scheme bug in SwiftUI where passing `nil` to `.preferredColorScheme`
     // doesn't change the color of some elements:
     // https://stackoverflow.com/questions/76123702/preferredcolorschemenil-visual-bug-when-switching-to-system-light-dark-more
@@ -14,7 +14,11 @@ struct BrewyApp: App {
     private let updaterController: SPUStandardUpdaterController
 
     init() {
-        updaterController = SPUStandardUpdaterController(startingUpdater: true, updaterDelegate: nil, userDriverDelegate: nil)
+        updaterController = SPUStandardUpdaterController(
+            startingUpdater: !BrewyRuntime.isRunningTests,
+            updaterDelegate: nil,
+            userDriverDelegate: nil
+        )
     }
 
     @AppStorage("appTheme")
@@ -28,6 +32,15 @@ struct BrewyApp: App {
         case .darkAqua: .dark
         default: nil
         }
+    }
+
+    private static func makeBrewService() -> BrewService {
+#if DEBUG
+        if BrewyRuntime.isUITesting {
+            return BrewService(commandRunner: UITestCommandRunner())
+        }
+#endif
+        return BrewService()
     }
 
     private var preferredColorScheme: ColorScheme? {

--- a/Brewy/Models/BrewService+Groups.swift
+++ b/Brewy/Models/BrewService+Groups.swift
@@ -22,7 +22,7 @@ extension BrewService {
 
     private func saveGroups() {
         guard let url = Self.groupsURL,
-              ProcessInfo.processInfo.environment["XCTestBundlePath"] == nil else { return }
+              !BrewyRuntime.isRunningTests else { return }
         let groups = packageGroups
         Task.detached(priority: .utility) {
             do {

--- a/Brewy/Models/BrewService+History.swift
+++ b/Brewy/Models/BrewService+History.swift
@@ -26,7 +26,7 @@ extension BrewService {
 
     private func saveHistory() {
         guard let url = Self.historyURL,
-              ProcessInfo.processInfo.environment["XCTestBundlePath"] == nil else { return }
+              !BrewyRuntime.isRunningTests else { return }
         let history = actionHistory
         Task.detached(priority: .utility) {
             do {

--- a/Brewy/Models/BrewService+Updates.swift
+++ b/Brewy/Models/BrewService+Updates.swift
@@ -55,7 +55,7 @@ extension BrewService {
 
     private func saveLastUpdateResult() {
         guard let url = Self.lastUpdateResultURL,
-              ProcessInfo.processInfo.environment["XCTestBundlePath"] == nil,
+              !BrewyRuntime.isRunningTests,
               let result = lastUpdateResult else { return }
         Task.detached(priority: .utility) {
             do {

--- a/Brewy/Models/BrewService.swift
+++ b/Brewy/Models/BrewService.swift
@@ -207,7 +207,7 @@ final class BrewService {
 
     func saveToCache() {
         guard let cacheURL = Self.cacheURL,
-              ProcessInfo.processInfo.environment["XCTestBundlePath"] == nil else { return }
+              !BrewyRuntime.isRunningTests else { return }
         let cached = CachedData(
             schemaVersion: Self.cacheSchemaVersion,
             formulae: installedFormulae,
@@ -235,6 +235,7 @@ final class BrewService {
     }
 
     func checkTapHealth() async {
+        guard !BrewyRuntime.isRunningTests else { return }
         let updated = await TapHealthChecker.checkHealth(taps: installedTaps, existing: tapHealthStatuses)
         guard !Task.isCancelled else { return }
         tapHealthStatuses = updated

--- a/Brewy/Models/TapHealthChecker.swift
+++ b/Brewy/Models/TapHealthChecker.swift
@@ -49,7 +49,7 @@ enum TapHealthChecker {
 
     static func saveCache(_ statuses: [String: TapHealthStatus]) {
         guard let cacheURL,
-              ProcessInfo.processInfo.environment["XCTestBundlePath"] == nil else { return }
+              !BrewyRuntime.isRunningTests else { return }
         Task.detached(priority: .utility) {
             do {
                 let data = try JSONEncoder().encode(statuses)

--- a/Brewy/Models/UITestFixtures.swift
+++ b/Brewy/Models/UITestFixtures.swift
@@ -1,0 +1,293 @@
+import Foundation
+
+enum BrewyRuntime {
+    static var isUITesting: Bool {
+#if DEBUG
+        ProcessInfo.processInfo.environment["BREWY_UI_TESTING"] == "1"
+#else
+        false
+#endif
+    }
+
+    static var isUnitTesting: Bool {
+#if DEBUG
+        let environment = ProcessInfo.processInfo.environment
+        return environment["XCTestBundlePath"] != nil
+            || environment["XCTestConfigurationFilePath"] != nil
+            || NSClassFromString("XCTestCase") != nil
+#else
+        false
+#endif
+    }
+
+    static var isRunningTests: Bool {
+        isUITesting || isUnitTesting
+    }
+}
+
+#if DEBUG
+struct UITestCommandRunner: CommandRunning {
+    func run(_ arguments: [String], brewPath: String, timeout: Duration) async -> CommandResult {
+        if arguments == ["services", "info", "--all", "--json"] {
+            return CommandResult(output: Self.servicesJSON, success: true)
+        }
+        if arguments.first == "info" {
+            return CommandResult(
+                output: "From: https://github.com/Homebrew/homebrew-core\nLicense: Unlicense\n",
+                success: true
+            )
+        }
+        if arguments == ["--cache"] {
+            return CommandResult(output: "/private/tmp/brewy-ui-cache\n", success: true)
+        }
+        if arguments == ["config"] {
+            return CommandResult(output: Self.configOutput, success: true)
+        }
+        if arguments.starts(with: ["bundle", "list"]) {
+            return Self.bundleListResult(arguments)
+        }
+        if arguments.starts(with: ["bundle", "check"]) {
+            return CommandResult(output: "jq needs to be installed or updated.\n", success: false)
+        }
+        return CommandResult(output: "Fixture command completed.\n", success: true)
+    }
+
+    func runExecutable(
+        _ executablePath: String,
+        arguments: [String],
+        timeout: Duration
+    ) async -> CommandResult {
+        if executablePath == "/usr/bin/du" {
+            return CommandResult(output: "2048\t/private/tmp/brewy-ui-cache\n", success: true)
+        }
+        return CommandResult(output: "Fixture command completed.\n", success: true)
+    }
+
+    private static func bundleListResult(_ arguments: [String]) -> CommandResult {
+        let output: String
+        if arguments.contains("--formula") {
+            output = "ripgrep\njq\n"
+        } else if arguments.contains("--cask") {
+            output = "firefox\n"
+        } else if arguments.contains("--tap") {
+            output = "starhaven-io/tap\n"
+        } else if arguments.contains("--mas") {
+            output = "Xcode\n"
+        } else {
+            output = ""
+        }
+        return CommandResult(output: output, success: true)
+    }
+
+    private static let servicesJSON = """
+    [
+      {
+        "name": "postgresql@17",
+        "service_name": "homebrew.mxcl.postgresql@17",
+        "running": true,
+        "loaded": true,
+        "pid": 4242,
+        "exit_code": 0,
+        "user": "patrick",
+        "status": "started",
+        "file": "/opt/homebrew/opt/postgresql@17/homebrew.mxcl.postgresql@17.plist",
+        "log_path": "/opt/homebrew/var/log/postgresql@17.log",
+        "error_log_path": "/opt/homebrew/var/log/postgresql@17.error.log"
+      },
+      {
+        "name": "redis",
+        "service_name": "homebrew.mxcl.redis",
+        "running": false,
+        "loaded": false,
+        "pid": null,
+        "exit_code": null,
+        "user": null,
+        "status": "stopped",
+        "file": "/opt/homebrew/opt/redis/homebrew.mxcl.redis.plist",
+        "log_path": null,
+        "error_log_path": null
+      }
+    ]
+    """
+
+    private static let configOutput = """
+    HOMEBREW_VERSION: 4.6.0
+    Last commit: 2 days ago
+    Core tap last commit: 3 days ago
+    Core cask tap last commit: 4 days ago
+    """
+}
+
+extension BrewService {
+    func loadUITestFixtures() {
+        let fixtureTimestamp = Date().addingTimeInterval(-3_600)
+        let packages = loadUITestPackages()
+        loadUITestMetadata(
+            fixtureTimestamp: fixtureTimestamp,
+            ripgrep: packages.ripgrep,
+            pcre2: packages.pcre2,
+            firefox: packages.firefox
+        )
+        loadUITestBundle()
+    }
+
+    private func loadUITestPackages() -> (ripgrep: BrewPackage, pcre2: BrewPackage, firefox: BrewPackage) {
+        let ripgrep = makeRipgrepFixture()
+        let pcre2 = makePcre2Fixture()
+        let firefox = makeFirefoxFixture()
+        let xcode = makeXcodeFixture()
+
+        installedFormulae = [ripgrep, pcre2]
+        installedCasks = [firefox]
+        installedMasApps = [xcode]
+        isMasAvailable = true
+        outdatedPackages = [ripgrep, firefox]
+
+        return (ripgrep, pcre2, firefox)
+    }
+
+    private func makeRipgrepFixture() -> BrewPackage {
+        BrewPackage(
+            id: "formula-ripgrep",
+            name: "ripgrep",
+            version: "14.1.0",
+            description: "Search tool like grep and The Silver Searcher",
+            homepage: "https://github.com/BurntSushi/ripgrep",
+            isInstalled: true,
+            isOutdated: true,
+            installedVersion: "14.1.0",
+            latestVersion: "14.1.1",
+            source: .formula,
+            pinned: true,
+            installedOnRequest: true,
+            dependencies: ["pcre2"]
+        )
+    }
+
+    private func makePcre2Fixture() -> BrewPackage {
+        BrewPackage(
+            id: "formula-pcre2",
+            name: "pcre2",
+            version: "10.45",
+            description: "Perl compatible regular expressions library",
+            homepage: "https://www.pcre.org/",
+            isInstalled: true,
+            isOutdated: false,
+            installedVersion: "10.45",
+            latestVersion: nil,
+            source: .formula,
+            pinned: false,
+            installedOnRequest: false,
+            dependencies: []
+        )
+    }
+
+    private func makeFirefoxFixture() -> BrewPackage {
+        BrewPackage(
+            id: "cask-firefox",
+            name: "firefox",
+            version: "127.0",
+            description: "Web browser",
+            homepage: "https://www.mozilla.org/firefox/",
+            isInstalled: true,
+            isOutdated: true,
+            installedVersion: "127.0",
+            latestVersion: "128.0",
+            source: .cask,
+            pinned: false,
+            installedOnRequest: true,
+            dependencies: []
+        )
+    }
+
+    private func makeXcodeFixture() -> BrewPackage {
+        BrewPackage(
+            id: "mas-497799835",
+            name: "Xcode",
+            version: "26.0",
+            description: "Developer tools from Apple",
+            homepage: "https://apps.apple.com/app/xcode/id497799835",
+            isInstalled: true,
+            isOutdated: false,
+            installedVersion: "26.0",
+            latestVersion: nil,
+            source: .mas,
+            pinned: false,
+            installedOnRequest: true,
+            dependencies: []
+        )
+    }
+
+    private func loadUITestMetadata(
+        fixtureTimestamp: Date,
+        ripgrep: BrewPackage,
+        pcre2: BrewPackage,
+        firefox: BrewPackage
+    ) {
+        installedTaps = [
+            BrewTap(
+                name: "starhaven-io/tap",
+                remote: "https://github.com/starhaven-io/homebrew-tap",
+                isOfficial: false,
+                formulaNames: ["ripgrep"],
+                caskTokens: ["firefox"]
+            )
+        ]
+        tapHealthStatuses = [
+            "starhaven-io/tap": TapHealthStatus(
+                status: .archived,
+                movedTo: nil,
+                lastChecked: fixtureTimestamp
+            )
+        ]
+        packageGroups = [
+            PackageGroup(
+                id: UUID(uuidString: "11111111-1111-1111-1111-111111111111")!,
+                name: "Development",
+                systemImage: "hammer.fill",
+                packageIDs: [ripgrep.id, pcre2.id]
+            ),
+            PackageGroup(
+                id: UUID(uuidString: "22222222-2222-2222-2222-222222222222")!,
+                name: "Browsers",
+                systemImage: "globe",
+                packageIDs: [firefox.id]
+            )
+        ]
+        actionHistory = [
+            ActionHistoryEntry(
+                id: UUID(uuidString: "33333333-3333-3333-3333-333333333333")!,
+                command: "upgrade",
+                arguments: ["upgrade", "ripgrep"],
+                packageName: "ripgrep",
+                packageSource: .formula,
+                status: .failure,
+                output: "Error: fixture upgrade failed",
+                timestamp: fixtureTimestamp
+            )
+        ]
+        lastUpdateResult = BrewUpdateResult(
+            newFormulae: [
+                BrewUpdateItem(name: "atuin", description: "Shell history sync", source: .formula)
+            ],
+            newCasks: [
+                BrewUpdateItem(name: "zed", description: "High-performance editor", source: .cask)
+            ],
+            timestamp: fixtureTimestamp
+        )
+        lastUpdated = fixtureTimestamp
+    }
+
+    private func loadUITestBundle() {
+        brewfileURL = resolveBrewfile()
+        bundleEntries = [
+            BrewBundleEntry(type: .formula, name: "ripgrep", status: .installed),
+            BrewBundleEntry(type: .formula, name: "jq", status: .missing),
+            BrewBundleEntry(type: .cask, name: "firefox", status: .installed),
+            BrewBundleEntry(type: .tap, name: "starhaven-io/tap", status: .installed),
+            BrewBundleEntry(type: .mas, name: "Xcode", status: .installed)
+        ]
+        bundleCheckStatus = .unsatisfied(["jq"])
+    }
+}
+#endif

--- a/Brewy/Views/ContentView.swift
+++ b/Brewy/Views/ContentView.swift
@@ -85,6 +85,12 @@ struct ContentView: View {
         }
         .environment(\.selectPackage) { name in navigateToPackage(name) }
         .task {
+#if DEBUG
+            if BrewyRuntime.isUITesting {
+                brewService.loadUITestFixtures()
+                return
+            }
+#endif
             if showCasksByDefault {
                 selectedCategory = .casks
             }
@@ -93,11 +99,8 @@ struct ContentView: View {
             brewService.loadGroups()
             brewService.loadHistory()
             brewService.loadLastUpdateResult()
-            // Skip non-deterministic startup work under tests: real `brew` subprocesses
-            // hang the runner, and the WhatsNew sheet's modal AX hierarchy hides the sidebar.
-            // XCTestBundlePath is set by unit-test hosts; BREWY_UI_TESTING is set by UI-test setUp.
-            let env = ProcessInfo.processInfo.environment
-            guard env["XCTestBundlePath"] == nil, env["BREWY_UI_TESTING"] != "1" else { return }
+            // Skip non-deterministic startup work under unit tests.
+            guard !BrewyRuntime.isRunningTests else { return }
             let currentVersion = Bundle.main.object(forInfoDictionaryKey: "CFBundleShortVersionString") as? String ?? ""
             if !currentVersion.isEmpty, currentVersion != lastSeenVersion {
                 lastSeenVersion = currentVersion

--- a/Brewy/Views/GroupsView.swift
+++ b/Brewy/Views/GroupsView.swift
@@ -83,6 +83,7 @@ private struct GroupRow: View {
                 Text(group.name)
                     .font(.body)
                     .bold()
+                    .accessibilityIdentifier("group-row-\(group.name)")
             }
             Spacer()
             BrewyCountBadge(count: brewService.packages(in: group).count)

--- a/Brewy/Views/HistoryView.swift
+++ b/Brewy/Views/HistoryView.swift
@@ -58,7 +58,9 @@ private struct HistoryRow: View {
             VStack(alignment: .leading, spacing: 2) {
                 if let name = entry.packageName {
                     HStack(spacing: 6) {
-                        Text(name).fontWeight(.medium)
+                        Text(name)
+                            .fontWeight(.medium)
+                            .accessibilityIdentifier("history-row-\(name)")
                         Text(entry.command)
                             .font(.caption)
                             .foregroundStyle(.secondary)

--- a/Brewy/Views/MaintenanceView.swift
+++ b/Brewy/Views/MaintenanceView.swift
@@ -126,6 +126,7 @@ struct MaintenanceView: View {
                         .font(.callout)
                         .foregroundStyle(.secondary)
                         .monospacedDigit()
+                        .accessibilityIdentifier("maintenance-cache-size")
                 }
 
                 Button("Clear Cache") {

--- a/Brewy/Views/PackageListView.swift
+++ b/Brewy/Views/PackageListView.swift
@@ -256,6 +256,7 @@ private struct PackageRow: View {
                     Text(package.name)
                         .font(.body)
                         .fontWeight(.semibold)
+                        .accessibilityIdentifier("package-row-\(package.name)")
                     if showInstalledBadge, package.isInstalled {
                         Image(systemName: "checkmark.circle.fill")
                             .font(.caption2)

--- a/Brewy/Views/ServicesView.swift
+++ b/Brewy/Views/ServicesView.swift
@@ -126,6 +126,7 @@ private struct ServiceRow: View {
                 Text(service.name)
                     .font(.body)
                     .fontWeight(.medium)
+                    .accessibilityIdentifier("service-row-\(service.name)")
                 HStack(spacing: 6) {
                     Text(service.statusLabel)
                         .font(.caption)

--- a/Brewy/Views/TapListView.swift
+++ b/Brewy/Views/TapListView.swift
@@ -91,6 +91,7 @@ private struct TapRow: View {
                     Text(tap.name)
                         .font(.body)
                         .bold()
+                        .accessibilityIdentifier("tap-row-\(tap.name)")
                     if let healthStatus, healthStatus.status != .healthy, healthStatus.status != .unknown {
                         TapHealthBadge(status: healthStatus.status)
                     } else if isOfficialTap, healthStatus?.status == .healthy {

--- a/BrewyUITests/SidebarNavigationUITests.swift
+++ b/BrewyUITests/SidebarNavigationUITests.swift
@@ -1,3 +1,4 @@
+import CryptoKit
 import XCTest
 
 @MainActor
@@ -14,17 +15,43 @@ final class SidebarNavigationUITests: XCTestCase {
     private static let elementTimeout: TimeInterval = 10 * timeoutScale
 
     private var app: XCUIApplication!
+    private var fixtureDirectory: URL!
 
     override func setUp() async throws {
         continueAfterFailure = false
+        fixtureDirectory = FileManager.default.temporaryDirectory
+            .appendingPathComponent("brewy-ui-tests-\(ProcessInfo.processInfo.globallyUniqueString)")
+        let homebrewDirectory = fixtureDirectory.appendingPathComponent("homebrew")
+        try FileManager.default.createDirectory(at: homebrewDirectory, withIntermediateDirectories: true)
+        let brewfileURL = homebrewDirectory.appendingPathComponent("Brewfile")
+            .resolvingSymlinksInPath()
+        let brewfileData = Data("brew \"ripgrep\"\ncask \"firefox\"\n".utf8)
+        try brewfileData.write(to: brewfileURL)
+        let brewfileDigest = SHA256.hash(data: brewfileData)
+            .map { String(format: "%02x", $0) }
+            .joined()
+
         app = XCUIApplication()
-        app.launchArguments += ["-NSConstraintBasedLayoutVisualizeMutuallyExclusiveConstraints", "YES"]
+        app.terminate()
+        app.launchArguments += [
+            "-NSConstraintBasedLayoutVisualizeMutuallyExclusiveConstraints", "YES",
+            "-autoRefreshInterval", "0",
+            "-brewfilePath", "",
+            "-showCasksByDefault", "NO",
+            "-trustedBrewfilePath", brewfileURL.path,
+            "-trustedBrewfileDigest", brewfileDigest
+        ]
         app.launchEnvironment["BREWY_UI_TESTING"] = "1"
+        app.launchEnvironment["XDG_CONFIG_HOME"] = fixtureDirectory.path
         app.launch()
+        app.activate()
     }
 
     override func tearDown() async throws {
+        app?.terminate()
         app = nil
+        try? FileManager.default.removeItem(at: fixtureDirectory)
+        fixtureDirectory = nil
     }
 
     // MARK: - Sidebar Category Navigation
@@ -32,7 +59,7 @@ final class SidebarNavigationUITests: XCTestCase {
     func testAllSidebarCategoriesRender() throws {
         let categories = [
             "Installed", "Formulae", "Casks", "Mac App Store", "Outdated",
-            "Pinned", "Leaves", "Taps", "Services", "Groups",
+            "Pinned", "Leaves", "Taps", "Services", "Groups", "Bundle",
             "History", "Discover", "Maintenance"
         ]
 
@@ -53,7 +80,7 @@ final class SidebarNavigationUITests: XCTestCase {
 
         let expectedCategories = [
             "Installed", "Formulae", "Casks", "Mac App Store", "Outdated",
-            "Pinned", "Leaves", "Taps", "Services", "Groups",
+            "Pinned", "Leaves", "Taps", "Services", "Groups", "Bundle",
             "History", "Discover", "Maintenance"
         ]
 
@@ -98,6 +125,121 @@ final class SidebarNavigationUITests: XCTestCase {
             refreshButton,
             timeout: Self.launchTimeout,
             "Refresh button should exist in sidebar footer"
+        )
+    }
+
+    // MARK: - Fixture-backed flows
+
+    func testPackageDetailRendersFixtureData() throws {
+        let package = app.staticTexts["package-row-ripgrep"]
+        assertExists(package, timeout: Self.launchTimeout, "Fixture package should appear")
+        package.click()
+
+        assertExists(
+            app.staticTexts["Search tool like grep and The Silver Searcher"],
+            timeout: Self.elementTimeout,
+            "Package details should render"
+        )
+        assertExists(
+            app.buttons["Upgrade"],
+            timeout: Self.elementTimeout,
+            "Outdated package should offer Upgrade"
+        )
+        assertExists(
+            app.staticTexts["Version 14.1.0 → 14.1.1"],
+            timeout: Self.elementTimeout,
+            "Package version transition should render"
+        )
+    }
+
+    func testManagementViewsRenderFixtureDetails() throws {
+        let sidebar = app.outlines.firstMatch
+        assertExists(sidebar, timeout: Self.launchTimeout, "Sidebar should exist")
+
+        sidebar.staticTexts["Taps"].click()
+        let tap = app.staticTexts["tap-row-starhaven-io/tap"]
+        assertExists(tap, timeout: Self.elementTimeout, "Fixture tap should appear")
+        tap.click()
+        assertExists(
+            app.staticTexts["https://github.com/starhaven-io/homebrew-tap"].firstMatch,
+            timeout: Self.elementTimeout,
+            "Tap details should render"
+        )
+
+        sidebar.staticTexts["Services"].click()
+        let service = app.staticTexts["service-row-postgresql@17"]
+        assertExists(service, timeout: Self.elementTimeout, "Fixture service should appear")
+        service.click()
+        assertExists(
+            app.staticTexts["homebrew.mxcl.postgresql@17"],
+            timeout: Self.elementTimeout,
+            "Service details should render"
+        )
+
+        sidebar.staticTexts["Groups"].click()
+        let group = app.staticTexts["group-row-Development"]
+        assertExists(group, timeout: Self.elementTimeout, "Fixture group should appear")
+        group.click()
+        assertExists(
+            app.staticTexts["2 packages"],
+            timeout: Self.elementTimeout,
+            "Group package count should render"
+        )
+
+        sidebar.staticTexts["Bundle"].click()
+        assertExists(
+            app.staticTexts["Missing Dependencies"],
+            timeout: Self.elementTimeout,
+            "Bundle status should render"
+        )
+        assertExists(
+            app.staticTexts["jq"].firstMatch,
+            timeout: Self.elementTimeout,
+            "Missing bundle entry should render"
+        )
+    }
+
+    func testHistoryDiscoverAndMaintenanceRenderFixtureData() throws {
+        let sidebar = app.outlines.firstMatch
+        assertExists(sidebar, timeout: Self.launchTimeout, "Sidebar should exist")
+
+        sidebar.staticTexts["History"].click()
+        let historyEntry = app.staticTexts["history-row-ripgrep"]
+        assertExists(historyEntry, timeout: Self.elementTimeout, "Fixture history should appear")
+        historyEntry.click()
+        assertExists(
+            app.staticTexts["brew upgrade ripgrep"],
+            timeout: Self.elementTimeout,
+            "History command should render"
+        )
+        assertExists(
+            app.staticTexts["Error: fixture upgrade failed"],
+            timeout: Self.elementTimeout,
+            "History output should render"
+        )
+
+        sidebar.staticTexts["Discover"].click()
+        assertExists(
+            app.staticTexts["atuin"].firstMatch,
+            timeout: Self.elementTimeout,
+            "New formula should appear in Discover"
+        )
+        assertExists(
+            app.staticTexts["zed"].firstMatch,
+            timeout: Self.elementTimeout,
+            "New cask should appear in Discover"
+        )
+
+        sidebar.staticTexts["Maintenance"].click()
+        assertExists(
+            app.staticTexts["4.6.0"],
+            timeout: Self.elementTimeout,
+            "Fixture Homebrew version should render"
+        )
+        assertExists(
+            app.staticTexts["maintenance-cache-size"],
+            timeout: Self.elementTimeout,
+            "Fixture cache size should render"
         )
     }
 


### PR DESCRIPTION
Raises SwiftUI coverage with deterministic, fixture-backed UI tests.

A stub `CommandRunning` implementation is injected through `BrewService`, seeding packages, taps, services, groups, bundle state, history, Discover results, and maintenance data. UI automation targets stable accessibility identifiers. A `BrewyRuntime` helper detects unit and UI test execution and prevents tests from starting Sparkle, contacting GitHub, or writing real caches and history.

All synthetic fixtures, the stub runner, and `BREWY_UI_TESTING` behavior are confined to DEBUG builds, so Release contains no test-only code.
