### PR TITLE
ci: add a Release build leg and a weekly Homebrew JSON drift probe

### DIFF
--- a/.github/workflows/brew-json-probe.yml
+++ b/.github/workflows/brew-json-probe.yml
@@ -1,0 +1,55 @@
+name: Brew JSON Drift Probe
+
+# Brewy's core contract is Homebrew's JSON output, which changes upstream on its
+# own schedule. Decode the runner's real brew with the repo's own Codable types
+# weekly so schema drift fails here first, not on users' machines.
+on:
+  schedule:
+    - cron: "23 8 * * 2" # Tuesday 08:23 UTC
+  workflow_dispatch:
+
+defaults:
+  run:
+    shell: bash -xeuo pipefail {0}
+
+permissions: {}
+
+concurrency:
+  group: "brew-json-probe-${{ github.ref }}"
+  cancel-in-progress: true
+
+jobs:
+  probe:
+    name: Decode live brew JSON with BrewJSONTypes
+    runs-on: macos-26
+    timeout-minutes: 45
+    permissions:
+      contents: read
+    steps:
+      - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
+        with:
+          persist-credentials: false
+
+      - name: Update Homebrew
+        env:
+          HOMEBREW_NO_ENV_HINTS: 1
+        run: brew update
+
+      - name: Install probe packages
+        env:
+          HOMEBREW_NO_AUTO_UPDATE: 1
+          HOMEBREW_NO_ENV_HINTS: 1
+        run: |
+          brew install wget
+          brew install --cask font-fira-code
+
+      - name: Build probe
+        run: |
+          xcrun swiftc -o /tmp/brew-json-probe \
+            Brewy/Models/BrewJSONTypes.swift \
+            Brewy/Models/PackageModel.swift \
+            Brewy/Models/ExternalURLPolicy.swift \
+            scripts/brew-json-probe/main.swift
+
+      - name: Run probe against real brew
+        run: /tmp/brew-json-probe

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -97,6 +97,10 @@ jobs:
             add_check '{"name":"Test (Thread Sanitizer)","check":"test-tsan","runner":"macos-26","xcodebuild_flags":"-enableCodeCoverage YES -enableThreadSanitizer YES","result_bundle":"TestResults-TSAN","environment":"codecov"}'
             # UI test runner is incompatible with ASan (crashes at launch); TSan covers the UI tests.
             add_check '{"name":"Test (Address Sanitizer)","check":"test-asan","runner":"macos-26","xcodebuild_flags":"-enableAddressSanitizer YES -skip-testing:BrewyUITests","result_bundle":"TestResults-ASAN"}'
+            # Everything else builds Debug; without this leg the release workflow is the
+            # first place Release-only breakage (optimization warnings, stray references
+            # to DEBUG-gated test fixtures) can surface.
+            add_check '{"name":"Build (Release)","check":"build-release","runner":"macos-26"}'
           fi
 
           # Source or periphery-config changes: dead-code scan
@@ -214,6 +218,21 @@ jobs:
           periphery scan --strict --disable-update-check --no-superfluous-ignore-comments \
             -- CODE_SIGNING_REQUIRED=NO CODE_SIGNING_ALLOWED=NO EXCLUDED_ARCHS=x86_64
 
+
+      - name: Build (Release)
+        if: matrix.check == 'build-release'
+        run: |
+          xcodebuild build \
+            -project Brewy.xcodeproj \
+            -scheme Brewy \
+            -destination 'generic/platform=macOS' \
+            -configuration Release \
+            -derivedDataPath ./DerivedData \
+            CODE_SIGN_IDENTITY="" \
+            CODE_SIGNING_REQUIRED=NO \
+            CODE_SIGNING_ALLOWED=NO \
+            SWIFT_TREAT_WARNINGS_AS_ERRORS=YES \
+            EXCLUDED_ARCHS=x86_64
 
       - name: Test
         if: startsWith(matrix.check, 'test-')

--- a/justfile
+++ b/justfile
@@ -1,3 +1,8 @@
+derived_data_path := env(
+    "BREWY_DERIVED_DATA_PATH",
+    "/private/tmp/brewy-deriveddata-" + sha256(justfile_directory())
+)
+
 # Build
 
 # Build the app with xcodebuild
@@ -7,6 +12,7 @@ build:
         -scheme Brewy \
         -destination 'generic/platform=macOS' \
         -configuration Debug \
+        -derivedDataPath {{ quote(derived_data_path) }} \
         CODE_SIGN_IDENTITY="" \
         CODE_SIGNING_REQUIRED=NO \
         CODE_SIGNING_ALLOWED=NO \
@@ -18,7 +24,8 @@ build:
 clean:
     xcodebuild clean \
         -project Brewy.xcodeproj \
-        -scheme Brewy
+        -scheme Brewy \
+        -derivedDataPath {{ quote(derived_data_path) }}
 
 # Setup
 
@@ -38,6 +45,7 @@ test:
         -destination 'platform=macOS' \
         -only-testing:BrewyTests \
         -enableCodeCoverage YES \
+        -derivedDataPath {{ quote(derived_data_path) }} \
         CODE_SIGN_IDENTITY="" \
         CODE_SIGNING_REQUIRED=NO \
         CODE_SIGNING_ALLOWED=NO \
@@ -61,7 +69,7 @@ typos:
 
 # Scan for unused code (uses .periphery.yml)
 periphery:
-    periphery scan
+    periphery scan --clean-build
 
 # Check README and CONTRIBUTING links
 lychee:
@@ -102,7 +110,7 @@ check:
     fi
     if command -v periphery &>/dev/null; then
         # Match CI: tolerate periphery:ignore comments CI sees as redundant (SwiftUI $-binding refs).
-        run periphery scan --strict --disable-update-check --no-superfluous-ignore-comments \
+        run periphery scan --strict --disable-update-check --no-superfluous-ignore-comments --clean-build \
             -- CODE_SIGNING_REQUIRED=NO CODE_SIGNING_ALLOWED=NO EXCLUDED_ARCHS=x86_64
     else
         skip periphery periphery periphery
@@ -118,6 +126,7 @@ check:
         -destination 'platform=macOS' \
         -only-testing:BrewyTests \
         -enableCodeCoverage YES \
+        -derivedDataPath {{ quote(derived_data_path) }} \
         CODE_SIGN_IDENTITY="" \
         CODE_SIGNING_REQUIRED=NO \
         CODE_SIGNING_ALLOWED=NO \

--- a/scripts/brew-json-probe/main.swift
+++ b/scripts/brew-json-probe/main.swift
@@ -1,0 +1,69 @@
+// Compiled standalone in CI (with BrewJSONTypes.swift, PackageModel.swift, and
+// ExternalURLPolicy.swift) and run against the runner's real Homebrew to catch
+// upstream JSON schema drift before users hit it. See .github/workflows/brew-json-probe.yml.
+import Foundation
+
+struct ProbeFailure: Error, CustomStringConvertible {
+    let description: String
+}
+
+func runBrew(_ arguments: [String]) throws -> Data {
+    let standardBrewPaths = ["/opt/homebrew/bin/brew", "/usr/local/bin/brew"]
+    guard let brewPath = standardBrewPaths.first(where: { FileManager.default.isExecutableFile(atPath: $0) }) else {
+        throw ProbeFailure(description: "brew not found at \(standardBrewPaths.joined(separator: " or "))")
+    }
+    let process = Process()
+    process.executableURL = URL(fileURLWithPath: brewPath)
+    process.arguments = arguments
+    let stdout = Pipe()
+    process.standardOutput = stdout
+    try process.run()
+    // Drain to EOF before waiting so a full pipe can't deadlock the child.
+    let output = stdout.fileHandleForReading.readDataToEndOfFile()
+    process.waitUntilExit()
+    guard process.terminationStatus == 0 else {
+        throw ProbeFailure(description: "brew \(arguments.joined(separator: " ")) exited \(process.terminationStatus)")
+    }
+    return output
+}
+
+func probe() throws {
+    // The app's refresh contract: one `info --installed` call carries both arrays.
+    let installedData = try runBrew(["info", "--installed", "--json=v2"])
+    let installed = try JSONDecoder().decode(BrewInfoResponse.self, from: installedData)
+    let formulae = (installed.formulae ?? []).map { $0.toPackage() }
+    let casks = (installed.casks ?? []).map { $0.toPackage() }
+    print("installed envelope: \(formulae.count) formulae, \(casks.count) casks decoded")
+    guard !formulae.isEmpty else {
+        throw ProbeFailure(description: "no installed formulae decoded; the workflow installs one before probing")
+    }
+    guard !casks.isEmpty else {
+        throw ProbeFailure(description: "no installed casks decoded; the workflow installs one before probing")
+    }
+
+    // Decode additional live cask metadata without installing large applications.
+    let caskData = try runBrew(["info", "--json=v2", "--cask", "--", "firefox", "iterm2"])
+    let caskInfo = try JSONDecoder().decode(BrewInfoResponse.self, from: caskData)
+    let probedCasks = (caskInfo.casks ?? []).map { $0.toPackage() }
+    print("cask metadata: \(probedCasks.count) casks decoded")
+    guard probedCasks.count == 2 else {
+        throw ProbeFailure(description: "expected 2 casks decoded, got \(probedCasks.count)")
+    }
+
+    let outdatedData = try runBrew(["outdated", "--json=v2"])
+    let outdated = try JSONDecoder().decode(BrewOutdatedResponse.self, from: outdatedData)
+    let outdatedCount = (outdated.formulae?.count ?? 0) + (outdated.casks?.count ?? 0)
+    print("outdated envelope decoded (\(outdatedCount) entries)")
+
+    let tapData = try runBrew(["tap-info", "--json=v1", "--installed"])
+    let taps = try JSONDecoder().decode([TapJSON].self, from: tapData).map { $0.toTap() }
+    print("tap-info envelope decoded (\(taps.count) taps)")
+}
+
+do {
+    try probe()
+    print("brew JSON drift probe passed")
+} catch {
+    print("brew JSON drift probe FAILED: \(error)")
+    exit(1)
+}


### PR DESCRIPTION
Three build and CI changes.

Every existing CI leg builds Debug, so the release workflow was the first place Release-only breakage could surface: optimization warnings, or stray references to the DEBUG-gated UI test fixtures. The PR matrix now runs an unsigned Release build with warnings treated as errors whenever source changes.

Brewy's core contract is Homebrew's JSON output, which changes upstream on its own schedule. A new weekly workflow decodes the runner's real brew with the repo's own Codable types, so drift fails in CI rather than on users' machines. It installs both a formula and a cask, and the probe asserts both arrays decode non-empty, because the single `brew info --installed --json=v2` call that feeds every refresh carries formulae and casks in one envelope.

The justfile recipes left derived data in the repository root while AGENTS.md tells automation to use /private/tmp. A single shared path is also wrong once a second clone or worktree exists: concurrent runs race on one build database, and `just clean` in one checkout wipes another's artifacts. The path is now derived from the checkout directory and overridable with BREWY_DERIVED_DATA_PATH. Periphery gets --clean-build for the same reason, so its index cannot be inherited from another checkout or another branch.

The new workflow has never executed on a hosted runner, so the first scheduled run or a manual dispatch is the real signal.
