### PR TITLE
fix(history): cap persisted action output at 64 KB of UTF-8

### DIFF
--- a/Brewy/Models/ActionHistoryEntry+Commands.swift
+++ b/Brewy/Models/ActionHistoryEntry+Commands.swift
@@ -9,4 +9,23 @@ extension ActionHistoryEntry {
         "pin", "unpin", "link", "unlink", "autoremove", "cleanup", "update",
         "tap", "untap"
     ]
+
+    static let recordedOutputByteLimit = 65_536
+
+    static func truncatedOutput(_ output: String) -> String {
+        let totalBytes = output.utf8.count
+        guard totalBytes > recordedOutputByteLimit else { return output }
+
+        var omittedBytes = totalBytes - recordedOutputByteLimit
+        var result = ""
+        for _ in 0..<3 {
+            let marker = "\n… [\(omittedBytes) bytes omitted] …\n"
+            let contentBudget = max(0, recordedOutputByteLimit - marker.utf8.count)
+            let head = UTF8ByteTruncation.prefix(output, maxBytes: contentBudget / 2)
+            let tail = UTF8ByteTruncation.suffix(output, maxBytes: contentBudget - head.utf8.count)
+            result = head + marker + tail
+            omittedBytes = totalBytes - head.utf8.count - tail.utf8.count
+        }
+        return result
+    }
 }

--- a/Brewy/Models/BrewService+History.swift
+++ b/Brewy/Models/BrewService+History.swift
@@ -55,7 +55,7 @@ extension BrewService {
             packageName: packageName,
             packageSource: packageSource,
             status: success ? .success : .failure,
-            output: output,
+            output: ActionHistoryEntry.truncatedOutput(output),
             timestamp: Date()
         )
         actionHistory.insert(entry, at: 0)

--- a/Brewy/Models/UTF8ByteTruncation.swift
+++ b/Brewy/Models/UTF8ByteTruncation.swift
@@ -1,0 +1,34 @@
+import Foundation
+
+enum UTF8ByteTruncation {
+    static func prefix(_ value: String, maxBytes: Int) -> String {
+        guard maxBytes > 0 else { return "" }
+        let scalars = value.unicodeScalars
+        var index = scalars.startIndex
+        var byteCount = 0
+
+        while index < scalars.endIndex {
+            let width = scalars[index].utf8.count
+            guard byteCount + width <= maxBytes else { break }
+            byteCount += width
+            index = scalars.index(after: index)
+        }
+        return String(scalars[..<index])
+    }
+
+    static func suffix(_ value: String, maxBytes: Int) -> String {
+        guard maxBytes > 0 else { return "" }
+        let scalars = value.unicodeScalars
+        var index = scalars.endIndex
+        var byteCount = 0
+
+        while index > scalars.startIndex {
+            let previous = scalars.index(before: index)
+            let width = scalars[previous].utf8.count
+            guard byteCount + width <= maxBytes else { break }
+            byteCount += width
+            index = previous
+        }
+        return String(scalars[index...])
+    }
+}

--- a/BrewyTests/HistoryTests.swift
+++ b/BrewyTests/HistoryTests.swift
@@ -150,6 +150,42 @@ struct ActionHistoryEntryTests {
     }
 }
 
+// MARK: - Output Truncation Tests
+
+@Suite("ActionHistoryEntry Output Truncation")
+struct ActionHistoryOutputTruncationTests {
+
+    @Test("Output at the cap is stored unchanged")
+    func shortOutputUnchanged() {
+        let output = String(repeating: "a", count: ActionHistoryEntry.recordedOutputByteLimit)
+        #expect(ActionHistoryEntry.truncatedOutput(output) == output)
+    }
+
+    @Test("Oversized output keeps head and tail with an omission marker")
+    func oversizedOutputTruncated() {
+        let output = "START"
+            + String(repeating: "x", count: ActionHistoryEntry.recordedOutputByteLimit + 1_000)
+            + "END"
+        let truncated = ActionHistoryEntry.truncatedOutput(output)
+
+        #expect(truncated.count < output.count)
+        #expect(truncated.utf8.count <= ActionHistoryEntry.recordedOutputByteLimit)
+        #expect(truncated.hasPrefix("START"))
+        #expect(truncated.hasSuffix("END"))
+        #expect(truncated.contains("bytes omitted"))
+    }
+
+    @Test("Multi-byte output stays within the byte cap")
+    func multiByteOutputStaysWithinCap() {
+        let output = String(repeating: "🍺", count: ActionHistoryEntry.recordedOutputByteLimit)
+        let truncated = ActionHistoryEntry.truncatedOutput(output)
+
+        #expect(truncated.utf8.count <= ActionHistoryEntry.recordedOutputByteLimit)
+        #expect(truncated.contains("bytes omitted"))
+        #expect(truncated.canBeConverted(to: .utf8))
+    }
+}
+
 // MARK: - BrewService History Tests
 
 @Suite("BrewService Action History")
@@ -197,6 +233,21 @@ struct BrewServiceHistoryTests {
             )
         }
         #expect(service.actionHistory.count == BrewService.maxHistoryEntries)
+    }
+
+    @Test("recordAction truncates oversized output")
+    func recordActionTruncatesOutput() {
+        let service = BrewService()
+        let hugeOutput = String(
+            repeating: "z",
+            count: ActionHistoryEntry.recordedOutputByteLimit + 1_000
+        )
+        service.recordAction(
+            arguments: ["upgrade"], packageName: nil,
+            packageSource: nil, success: true, output: hugeOutput
+        )
+        #expect(service.actionHistory[0].output.utf8.count <= ActionHistoryEntry.recordedOutputByteLimit)
+        #expect(service.actionHistory[0].output.contains("bytes omitted"))
     }
 
     @Test("clearHistory removes all entries")


### PR DESCRIPTION
recordAction stored the full output of every command. A verbose upgrade can emit megabytes, and the whole history is re-encoded to disk after every action and decoded on the main actor at launch.

Entries now keep a head and a tail around an omission marker, measured in UTF-8 bytes rather than Characters. brew's own output carries emoji and box drawing, so a Character-based cap would have let a 64 K-Character entry persist several hundred KB, or 1.6 MB for grapheme clusters like a family emoji.

Truncation doubles as data minimisation, since brew occasionally echoes paths and tokens.
