### PR TITLE
fix(refresh): collapse installed fetches and route background failures non-modally

### DIFF
--- a/Brewy/Models/BrewService+Fetching.swift
+++ b/Brewy/Models/BrewService+Fetching.swift
@@ -15,7 +15,7 @@ extension BrewService {
         let result = await runBrewCommand(["info", "--installed", "--json=v2"])
         guard result.success, let data = result.output.data(using: .utf8) else {
             if !result.success {
-                lastError = .commandFailed(command: "info --installed", output: result.output)
+                reportFetchError(command: "info --installed", output: result.output)
             }
             return result.success ? ([], []) : nil
         }
@@ -33,7 +33,7 @@ extension BrewService {
             }
         }.value
         if packages == nil {
-            lastError = .commandFailed(command: "info --installed --json=v2", output: "Failed to parse Homebrew packages JSON.")
+            reportFetchError(command: "info --installed --json=v2", output: "Failed to parse Homebrew packages JSON.")
         }
         return packages
     }
@@ -42,7 +42,7 @@ extension BrewService {
         let result = await runBrewCommand(["outdated", "--json=v2"])
         guard result.success, let data = result.output.data(using: .utf8) else {
             if !result.success {
-                lastError = .commandFailed(command: "outdated", output: result.output)
+                reportFetchError(command: "outdated", output: result.output)
             }
             return result.success ? [] : nil
         }
@@ -59,7 +59,7 @@ extension BrewService {
             }
         }.value
         if packages == nil {
-            lastError = .commandFailed(command: "outdated --json=v2", output: "Failed to parse Homebrew outdated JSON.")
+            reportFetchError(command: "outdated --json=v2", output: "Failed to parse Homebrew outdated JSON.")
         }
         return packages
     }
@@ -68,7 +68,7 @@ extension BrewService {
         let result = await runBrewCommand(["tap-info", "--json=v1", "--installed"])
         guard result.success, let data = result.output.data(using: .utf8) else {
             if !result.success {
-                lastError = .commandFailed(command: "tap-info", output: result.output)
+                reportFetchError(command: "tap-info", output: result.output)
             }
             return result.success ? [] : nil
         }
@@ -83,7 +83,7 @@ extension BrewService {
             }
         }.value
         if taps == nil {
-            lastError = .commandFailed(command: "tap-info --json=v1 --installed", output: "Failed to parse Homebrew taps JSON.")
+            reportFetchError(command: "tap-info --json=v1 --installed", output: "Failed to parse Homebrew taps JSON.")
         }
         return taps
     }

--- a/Brewy/Models/BrewService+Fetching.swift
+++ b/Brewy/Models/BrewService+Fetching.swift
@@ -116,7 +116,9 @@ extension BrewService {
         let formulaeOutput = await formulaeResult
         let casksOutput = await casksResult
 
-        let knownNames = installedNames
+        // Match on source-qualified IDs, not bare names: a cask hit named like an
+        // installed formula (e.g. wireshark) must not show the installed badge.
+        let knownIDs = installedIDs
         var packages: [BrewPackage] = []
 
         for output in [(formulaeOutput, PackageSource.formula), (casksOutput, PackageSource.cask)] {
@@ -136,7 +138,7 @@ extension BrewService {
                         version: "",
                         description: "",
                         homepage: "",
-                        isInstalled: knownNames.contains(name),
+                        isInstalled: knownIDs.contains("\(prefix)-\(name)"),
                         isOutdated: false,
                         installedVersion: nil,
                         latestVersion: nil,

--- a/Brewy/Models/BrewService+Fetching.swift
+++ b/Brewy/Models/BrewService+Fetching.swift
@@ -7,52 +7,33 @@ extension BrewService {
 
     // MARK: - Fetch Installed Packages
 
-    /// Returns `nil` when the brew command fails so the caller can keep the previously loaded list
-    /// instead of clobbering it to empty; a successful-but-empty response still returns `[]`.
-    func fetchInstalledFormulae() async -> [BrewPackage]? {
+    /// Returns `nil` when the brew command fails so the caller can keep the previously loaded lists
+    /// instead of clobbering them to empty; a successful-but-empty response still returns `[]`s.
+    /// One `brew info --installed --json=v2` invocation carries both formulae and casks in the
+    /// JSON v2 envelope, so a refresh needs a single pass over the installed set, not two.
+    func fetchInstalledPackages() async -> (formulae: [BrewPackage], casks: [BrewPackage])? {
         let result = await runBrewCommand(["info", "--installed", "--json=v2"])
         guard result.success, let data = result.output.data(using: .utf8) else {
             if !result.success {
                 lastError = .commandFailed(command: "info --installed", output: result.output)
             }
-            return result.success ? [] : nil
+            return result.success ? ([], []) : nil
         }
 
-        let packages: [BrewPackage]? = await Task.detached(priority: .userInitiated) { () -> [BrewPackage]? in
+        let packages: (formulae: [BrewPackage], casks: [BrewPackage])? = await Task.detached(priority: .userInitiated) {
             do {
                 let response = try JSONDecoder().decode(BrewInfoResponse.self, from: data)
-                return (response.formulae ?? []).map { $0.toPackage() }
+                return (
+                    (response.formulae ?? []).map { $0.toPackage() },
+                    (response.casks ?? []).map { $0.toPackage() }
+                )
             } catch {
-                logger.error("Failed to parse formulae JSON: \(error.localizedDescription)")
+                logger.error("Failed to parse installed packages JSON: \(error.localizedDescription)")
                 return nil
             }
         }.value
         if packages == nil {
-            lastError = .commandFailed(command: "info --installed --json=v2", output: "Failed to parse Homebrew formulae JSON.")
-        }
-        return packages
-    }
-
-    func fetchInstalledCasks() async -> [BrewPackage]? {
-        let result = await runBrewCommand(["info", "--installed", "--cask", "--json=v2"])
-        guard result.success, let data = result.output.data(using: .utf8) else {
-            if !result.success {
-                lastError = .commandFailed(command: "info --installed --cask", output: result.output)
-            }
-            return result.success ? [] : nil
-        }
-
-        let packages: [BrewPackage]? = await Task.detached(priority: .userInitiated) { () -> [BrewPackage]? in
-            do {
-                let response = try JSONDecoder().decode(BrewInfoResponse.self, from: data)
-                return (response.casks ?? []).map { $0.toPackage() }
-            } catch {
-                logger.error("Failed to parse casks JSON: \(error.localizedDescription)")
-                return nil
-            }
-        }.value
-        if packages == nil {
-            lastError = .commandFailed(command: "info --installed --cask --json=v2", output: "Failed to parse Homebrew casks JSON.")
+            lastError = .commandFailed(command: "info --installed --json=v2", output: "Failed to parse Homebrew packages JSON.")
         }
         return packages
     }

--- a/Brewy/Models/BrewService.swift
+++ b/Brewy/Models/BrewService.swift
@@ -82,6 +82,9 @@ final class BrewService {
     var isPerformingAction = false
     var actionOutput: String = ""
     var lastError: BrewError?
+    /// Failure from a background auto-refresh, surfaced non-modally (sidebar footer)
+    /// instead of the error alert so a broken brew doesn't raise a modal every interval.
+    var backgroundRefreshError: BrewError?
     var lastUpdated: Date?
     var tapHealthStatuses: [String: TapHealthStatus] = [:]
     var packageGroups: [PackageGroup] = []
@@ -95,6 +98,9 @@ final class BrewService {
     var tapsLoaded = false
     private var isRefreshing = false
     private var needsRefresh = false
+    private var needsRefreshUserInitiated = false
+    @ObservationIgnored private var isBackgroundRefresh = false
+    @ObservationIgnored private var refreshReportedError = false
     @ObservationIgnored private var isBatchingUpdates = false
     @ObservationIgnored var infoCache: [String: String] = [:]
     @ObservationIgnored private var tapHealthTask: Task<Void, Never>?
@@ -153,8 +159,11 @@ final class BrewService {
     func dependents(of name: String) -> [BrewPackage] {
         reverseDependencies[name] ?? []
     }
+}
 
-    // MARK: - Cache
+// MARK: - Cache
+
+extension BrewService {
 
     nonisolated static let cacheDirectory: URL? = {
         guard let appSupport = FileManager.default.urls(for: .applicationSupportDirectory, in: .userDomainMask).first else {
@@ -240,25 +249,48 @@ final class BrewService {
         guard !Task.isCancelled else { return }
         tapHealthStatuses = updated
     }
+}
 
-    // MARK: - Homebrew CLI Interactions
+// MARK: - Homebrew CLI Interactions
 
-    func refresh() async {
+extension BrewService {
+
+    func refresh(isUserInitiated: Bool = true) async {
         guard !isRefreshing else {
             needsRefresh = true
+            // A queued follow-up runs as user-initiated if any queued request was.
+            needsRefreshUserInitiated = needsRefreshUserInitiated || isUserInitiated
             logger.info("Refresh already in progress, queuing follow-up")
             return
         }
         isRefreshing = true
         defer { isRefreshing = false }
+        var userInitiated = isUserInitiated
         repeat {
             needsRefresh = false
-            await performRefresh()
+            needsRefreshUserInitiated = false
+            await performRefresh(isUserInitiated: userInitiated)
+            userInitiated = needsRefreshUserInitiated
         } while needsRefresh
     }
 
-    private func performRefresh() async {
+    /// Routes fetch failures to the modal alert for user-initiated refreshes, or to the
+    /// non-modal `backgroundRefreshError` when a background auto-refresh fails.
+    func reportFetchError(command: String, output: String) {
+        refreshReportedError = true
+        let error = BrewError.commandFailed(command: command, output: output)
+        if isBackgroundRefresh {
+            backgroundRefreshError = error
+        } else {
+            lastError = error
+        }
+    }
+
+    private func performRefresh(isUserInitiated: Bool) async {
         logger.info("Starting full refresh")
+        isBackgroundRefresh = !isUserInitiated
+        refreshReportedError = false
+        defer { isBackgroundRefresh = false }
         let previousVersions = Dictionary(allInstalled.map { ($0.id, $0.version) }, uniquingKeysWith: { _, last in last })
         let hadCachedData = !installedFormulae.isEmpty || !installedCasks.isEmpty
         // Only show the spinner when there's no cached data yet; the counter keeps a concurrent
@@ -311,6 +343,10 @@ final class BrewService {
         installedTaps = fetchedTaps
         tapsLoaded = true
         updateBundleEntryStatuses()
+
+        if !refreshReportedError {
+            backgroundRefreshError = nil
+        }
 
         let masCount = fetchedMasApps.count
         let outdatedCount = allOutdated.count
@@ -382,6 +418,7 @@ final class BrewService {
         let brewPath = CommandRunner.resolvedBrewPath(preferred: customBrewPath)
         return await commandRunner.run(arguments, brewPath: brewPath)
     }
+
 }
 
 // MARK: - Package Category Queries

--- a/Brewy/Models/BrewService.swift
+++ b/Brewy/Models/BrewService.swift
@@ -269,8 +269,7 @@ final class BrewService {
             if showsSpinner { loadingCount -= 1 }
         }
 
-        async let formulae = fetchInstalledFormulae()
-        async let casks = fetchInstalledCasks()
+        async let installed = fetchInstalledPackages()
         async let outdated = fetchOutdatedPackages()
         async let masApps = fetchInstalledMasApps()
         async let masOutdated = fetchOutdatedMasApps()
@@ -278,8 +277,9 @@ final class BrewService {
 
         // Preserve the previously loaded list when a fetch fails (nil) rather than clobbering it
         // to empty — a transient `brew` failure shouldn't blank out (and then cache) good data.
-        let fetchedFormulae = await formulae ?? installedFormulae
-        let fetchedCasks = await casks ?? installedCasks
+        let fetchedInstalled = await installed
+        let fetchedFormulae = fetchedInstalled?.formulae ?? installedFormulae
+        let fetchedCasks = fetchedInstalled?.casks ?? installedCasks
         let fetchedOutdated = await outdated ?? outdatedPackages.filter { $0.source != .mas }
         let fetchedMasApps = await masApps ?? installedMasApps
         let fetchedMasOutdated = await masOutdated ?? outdatedPackages.filter(\.isMas)

--- a/Brewy/Models/BrewService.swift
+++ b/Brewy/Models/BrewService.swift
@@ -357,14 +357,14 @@ final class BrewService {
         var errorOutputs: [String] = []
 
         if !formulae.isEmpty {
-            let args = ["upgrade"] + formulae
+            let args = ["upgrade", "--"] + formulae
             let result = await runBrewCommand(args)
             actionOutput += result.output
             if !result.success { errorOutputs.append(result.output) }
             recordAction(arguments: args, packageName: nil, packageSource: .formula, success: result.success, output: result.output)
         }
         if !casks.isEmpty {
-            let args = ["upgrade", "--cask"] + casks
+            let args = ["upgrade", "--cask", "--"] + casks
             let result = await runBrewCommand(args)
             actionOutput += result.output
             if !result.success { errorOutputs.append(result.output) }

--- a/Brewy/Views/ContentView.swift
+++ b/Brewy/Views/ContentView.swift
@@ -115,7 +115,7 @@ struct ContentView: View {
             while !Task.isCancelled {
                 try? await Task.sleep(for: .seconds(autoRefreshInterval))
                 guard !Task.isCancelled else { break }
-                await brewService.refresh()
+                await brewService.refresh(isUserInitiated: false)
             }
         }
         .onChange(of: selectedCategory) {

--- a/Brewy/Views/SidebarView.swift
+++ b/Brewy/Views/SidebarView.swift
@@ -109,6 +109,14 @@ private struct SidebarFooter: View {
 
                 Spacer()
 
+                if let backgroundError = brewService.backgroundRefreshError {
+                    Image(systemName: "exclamationmark.triangle.fill")
+                        .font(.caption)
+                        .foregroundStyle(.yellow)
+                        .help("Background refresh failed: \(backgroundError.localizedDescription)")
+                        .accessibilityLabel("Background refresh failed")
+                }
+
                 if brewService.isLoading {
                     ProgressView()
                         .controlSize(.small)

--- a/BrewyTests/BrewServiceAsyncTests.swift
+++ b/BrewyTests/BrewServiceAsyncTests.swift
@@ -465,13 +465,13 @@ struct BulkUpgradeTests {
 
         let formula = makePackage(name: "wget", source: .formula)
         let cask = makePackage(name: "firefox", source: .cask)
-        mock.setResult(for: ["upgrade", "wget"], output: "Upgraded wget")
-        mock.setResult(for: ["upgrade", "--cask", "firefox"], output: "Upgraded firefox")
+        mock.setResult(for: ["upgrade", "--", "wget"], output: "Upgraded wget")
+        mock.setResult(for: ["upgrade", "--cask", "--", "firefox"], output: "Upgraded firefox")
 
         await service.upgradeSelected(packages: [formula, cask])
 
-        #expect(mock.executedCommands.contains(["upgrade", "wget"]))
-        #expect(mock.executedCommands.contains(["upgrade", "--cask", "firefox"]))
+        #expect(mock.executedCommands.contains(["upgrade", "--", "wget"]))
+        #expect(mock.executedCommands.contains(["upgrade", "--cask", "--", "firefox"]))
     }
 
     @Test("upgradeSelected with only formulae skips cask upgrade")
@@ -481,11 +481,11 @@ struct BulkUpgradeTests {
         setupRefreshMock(mock)
 
         let formula = makePackage(name: "wget", source: .formula)
-        mock.setResult(for: ["upgrade", "wget"], output: "Upgraded wget")
+        mock.setResult(for: ["upgrade", "--", "wget"], output: "Upgraded wget")
 
         await service.upgradeSelected(packages: [formula])
 
-        #expect(mock.executedCommands.contains(["upgrade", "wget"]))
+        #expect(mock.executedCommands.contains(["upgrade", "--", "wget"]))
         let hasCaskUpgrade = mock.executedCommands.contains { $0.first == "upgrade" && $0.contains("--cask") }
         #expect(!hasCaskUpgrade)
     }

--- a/BrewyTests/BrewServiceAsyncTests.swift
+++ b/BrewyTests/BrewServiceAsyncTests.swift
@@ -54,7 +54,6 @@ struct RefreshTests {
         let mock = MockCommandRunner()
         let (service, _) = makeService(mock: mock)
         mock.setResult(for: ["info", "--installed", "--json=v2"], output: TestJSON.emptyFormulae)
-        mock.setResult(for: ["info", "--installed", "--cask", "--json=v2"], output: TestJSON.emptyFormulae)
         mock.setResult(for: ["outdated", "--json=v2"], output: TestJSON.emptyOutdated)
         mock.setResult(for: ["tap-info", "--json=v1", "--installed"], output: TestJSON.emptyTaps)
 
@@ -71,14 +70,13 @@ struct RefreshTests {
         let mock = MockCommandRunner()
         let (service, _) = makeService(mock: mock)
         mock.setResult(for: ["info", "--installed", "--json=v2"], output: "Error", success: false)
-        mock.setResult(for: ["info", "--installed", "--cask", "--json=v2"], output: TestJSON.casks)
         mock.setResult(for: ["outdated", "--json=v2"], output: TestJSON.emptyOutdated)
         mock.setResult(for: ["tap-info", "--json=v1", "--installed"], output: TestJSON.emptyTaps)
 
         await service.refresh()
 
         #expect(service.installedFormulae.isEmpty)
-        #expect(service.installedCasks.count == 1)
+        #expect(service.installedCasks.isEmpty)
         #expect(service.lastError != nil)
     }
 
@@ -106,7 +104,6 @@ struct RefreshTests {
         await service.refresh()
 
         mock.setResult(for: ["info", "--installed", "--json=v2"], output: "not json")
-        mock.setResult(for: ["info", "--installed", "--cask", "--json=v2"], output: "not json")
         mock.setResult(for: ["outdated", "--json=v2"], output: "not json")
         mock.setResult(for: ["tap-info", "--json=v1", "--installed"], output: "not json")
 
@@ -185,102 +182,6 @@ struct RefreshTests {
         await service.refresh()
 
         #expect(service.tapHealthStatuses["homebrew/core"]?.status == .healthy)
-    }
-}
-
-// MARK: - Search Tests
-
-@Suite("BrewService.search()")
-@MainActor
-struct SearchTests {
-
-    @Test("search returns formula and cask results")
-    func searchReturnsBoth() async {
-        let mock = MockCommandRunner()
-        let (service, _) = makeService(mock: mock)
-        mock.setResult(for: ["search", "--formula", "--", "fire"], output: "firewalld\nfirejail")
-        mock.setResult(for: ["search", "--cask", "--", "fire"], output: "firefox\nfirealpaca")
-
-        await service.search(query: "fire")
-
-        #expect(service.searchResults.count == 4)
-        let names = Set(service.searchResults.map(\.name))
-        #expect(names.contains("firefox"))
-        #expect(names.contains("firewalld"))
-    }
-
-    @Test("search marks installed packages")
-    func searchMarksInstalled() async {
-        let mock = MockCommandRunner()
-        let (service, _) = makeService(mock: mock)
-        service.installedFormulae = [makePackage(name: "wget")]
-
-        mock.setResult(for: ["search", "--formula", "--", "wget"], output: "wget\nwget2")
-        mock.setResult(for: ["search", "--cask", "--", "wget"], output: "")
-
-        await service.search(query: "wget")
-
-        let wgetResult = service.searchResults.first { $0.name == "wget" }
-        let wget2Result = service.searchResults.first { $0.name == "wget2" }
-        #expect(wgetResult?.isInstalled == true)
-        #expect(wget2Result?.isInstalled == false)
-    }
-
-    @Test("search with empty query clears results")
-    func searchEmptyQueryClears() async {
-        let mock = MockCommandRunner()
-        let (service, _) = makeService(mock: mock)
-        service.searchResults = [makePackage(name: "old-result")]
-
-        await service.search(query: "")
-
-        #expect(service.searchResults.isEmpty)
-    }
-
-    @Test("search handles failure gracefully")
-    func searchHandlesFailure() async {
-        let mock = MockCommandRunner()
-        let (service, _) = makeService(mock: mock)
-        mock.setResult(for: ["search", "--formula", "--", "test"], output: "Error", success: false)
-        mock.setResult(for: ["search", "--cask", "--", "test"], output: "test-app")
-
-        await service.search(query: "test")
-
-        #expect(service.searchResults.count == 1)
-        #expect(service.searchResults[0].name == "test-app")
-    }
-
-    @Test("search filters out ==> header lines")
-    func searchFiltersHeaders() async {
-        let mock = MockCommandRunner()
-        let (service, _) = makeService(mock: mock)
-        mock.setResult(for: ["search", "--formula", "--", "test"], output: "==> Formulae\ntest-formula")
-        mock.setResult(for: ["search", "--cask", "--", "test"], output: "==> Casks\ntest-cask")
-
-        await service.search(query: "test")
-
-        let names = service.searchResults.map(\.name)
-        #expect(!names.contains("==>"))
-        // The header word itself must not survive tokenization as a phantom package.
-        #expect(!names.contains("Formulae"))
-        #expect(!names.contains("Casks"))
-        #expect(names.contains("test-formula"))
-        #expect(names.contains("test-cask"))
-    }
-
-    @Test("search results have correct source types")
-    func searchResultSourceTypes() async {
-        let mock = MockCommandRunner()
-        let (service, _) = makeService(mock: mock)
-        mock.setResult(for: ["search", "--formula", "--", "test"], output: "test-formula")
-        mock.setResult(for: ["search", "--cask", "--", "test"], output: "test-cask")
-
-        await service.search(query: "test")
-
-        let formula = service.searchResults.first { $0.name == "test-formula" }
-        let cask = service.searchResults.first { $0.name == "test-cask" }
-        #expect(formula?.source == .formula)
-        #expect(cask?.source == .cask)
     }
 }
 

--- a/BrewyTests/ErrorPersistenceTests.swift
+++ b/BrewyTests/ErrorPersistenceTests.swift
@@ -38,7 +38,7 @@ struct ErrorPersistenceTests {
         let mock = MockCommandRunner()
         let (service, _) = makeService(mock: mock)
         setupRefreshMock(mock)
-        mock.setResult(for: ["upgrade", "wget"], output: "upgrade failed", success: false)
+        mock.setResult(for: ["upgrade", "--", "wget"], output: "upgrade failed", success: false)
 
         await service.upgradeSelected(packages: [makePackage(name: "wget", isOutdated: true)])
 

--- a/BrewyTests/ErrorPersistenceTests.swift
+++ b/BrewyTests/ErrorPersistenceTests.swift
@@ -46,6 +46,67 @@ struct ErrorPersistenceTests {
         #expect(service.lastError?.localizedDescription.contains("upgrade failed") == true)
     }
 
+    @Test("background refresh failure stays out of the modal error")
+    func backgroundRefreshFailureIsNonModal() async {
+        let mock = MockCommandRunner()
+        let (service, _) = makeService(mock: mock)
+        setupRefreshMock(mock)
+        mock.setResult(for: ["info", "--installed", "--json=v2"], output: "brew broke", success: false)
+
+        await service.refresh(isUserInitiated: false)
+
+        #expect(service.lastError == nil)
+        #expect(service.backgroundRefreshError != nil)
+        #expect(service.backgroundRefreshError?.localizedDescription.contains("brew broke") == true)
+    }
+
+    @Test("user-initiated refresh failure raises the modal error")
+    func userRefreshFailureIsModal() async {
+        let mock = MockCommandRunner()
+        let (service, _) = makeService(mock: mock)
+        setupRefreshMock(mock)
+        mock.setResult(for: ["outdated", "--json=v2"], output: "brew broke", success: false)
+
+        await service.refresh()
+
+        #expect(service.lastError != nil)
+        #expect(service.backgroundRefreshError == nil)
+    }
+
+    @Test("clean refresh clears a stale background refresh error")
+    func cleanRefreshClearsBackgroundError() async {
+        let mock = MockCommandRunner()
+        let (service, _) = makeService(mock: mock)
+        setupRefreshMock(mock)
+        mock.setResult(for: ["tap-info", "--json=v1", "--installed"], output: "network down", success: false)
+
+        await service.refresh(isUserInitiated: false)
+        #expect(service.backgroundRefreshError != nil)
+
+        mock.setResult(for: ["tap-info", "--json=v1", "--installed"], output: TestJSON.taps)
+        await service.refresh(isUserInitiated: false)
+
+        #expect(service.backgroundRefreshError == nil)
+        #expect(service.lastError == nil)
+    }
+
+    @Test("failing background refresh keeps the prior package lists")
+    func backgroundFailureKeepsPriorLists() async {
+        let mock = MockCommandRunner()
+        let (service, _) = makeService(mock: mock)
+        setupRefreshMock(mock)
+
+        await service.refresh(isUserInitiated: false)
+        #expect(!service.installedFormulae.isEmpty)
+
+        mock.setResult(for: ["info", "--installed", "--json=v2"], output: "brew broke", success: false)
+        await service.refresh(isUserInitiated: false)
+
+        #expect(!service.installedFormulae.isEmpty)
+        #expect(service.lastError == nil)
+        #expect(service.backgroundRefreshError != nil)
+    }
+
     @Test("queued refresh preserves an error set while waiting")
     func queuedRefreshPreservesLateError() async {
         let mock = MockCommandRunner()

--- a/BrewyTests/SearchTests.swift
+++ b/BrewyTests/SearchTests.swift
@@ -1,0 +1,119 @@
+@testable import Brewy
+import Foundation
+import Testing
+
+// MARK: - Search Tests
+
+@Suite("BrewService.search()")
+@MainActor
+struct SearchTests {
+
+    @Test("search returns formula and cask results")
+    func searchReturnsBoth() async {
+        let mock = MockCommandRunner()
+        let (service, _) = makeService(mock: mock)
+        mock.setResult(for: ["search", "--formula", "--", "fire"], output: "firewalld\nfirejail")
+        mock.setResult(for: ["search", "--cask", "--", "fire"], output: "firefox\nfirealpaca")
+
+        await service.search(query: "fire")
+
+        #expect(service.searchResults.count == 4)
+        let names = Set(service.searchResults.map(\.name))
+        #expect(names.contains("firefox"))
+        #expect(names.contains("firewalld"))
+    }
+
+    @Test("search marks installed packages")
+    func searchMarksInstalled() async {
+        let mock = MockCommandRunner()
+        let (service, _) = makeService(mock: mock)
+        service.installedFormulae = [makePackage(name: "wget")]
+
+        mock.setResult(for: ["search", "--formula", "--", "wget"], output: "wget\nwget2")
+        mock.setResult(for: ["search", "--cask", "--", "wget"], output: "")
+
+        await service.search(query: "wget")
+
+        let wgetResult = service.searchResults.first { $0.name == "wget" }
+        let wget2Result = service.searchResults.first { $0.name == "wget2" }
+        #expect(wgetResult?.isInstalled == true)
+        #expect(wget2Result?.isInstalled == false)
+    }
+
+    @Test("search installed badge does not leak across sources")
+    func searchInstalledBadgeIsSourceQualified() async {
+        let mock = MockCommandRunner()
+        let (service, _) = makeService(mock: mock)
+        service.installedFormulae = [makePackage(name: "wireshark", source: .formula)]
+        service.installedMasApps = [makePackage(name: "amphetamine", source: .mas)]
+
+        mock.setResult(for: ["search", "--formula", "--", "shark"], output: "wireshark")
+        mock.setResult(for: ["search", "--cask", "--", "shark"], output: "wireshark\namphetamine")
+
+        await service.search(query: "shark")
+
+        let formulaHit = service.searchResults.first { $0.source == .formula && $0.name == "wireshark" }
+        let caskHit = service.searchResults.first { $0.source == .cask && $0.name == "wireshark" }
+        let masNamedCaskHit = service.searchResults.first { $0.source == .cask && $0.name == "amphetamine" }
+        #expect(formulaHit?.isInstalled == true)
+        #expect(caskHit?.isInstalled == false)
+        #expect(masNamedCaskHit?.isInstalled == false)
+    }
+
+    @Test("search with empty query clears results")
+    func searchEmptyQueryClears() async {
+        let mock = MockCommandRunner()
+        let (service, _) = makeService(mock: mock)
+        service.searchResults = [makePackage(name: "old-result")]
+
+        await service.search(query: "")
+
+        #expect(service.searchResults.isEmpty)
+    }
+
+    @Test("search handles failure gracefully")
+    func searchHandlesFailure() async {
+        let mock = MockCommandRunner()
+        let (service, _) = makeService(mock: mock)
+        mock.setResult(for: ["search", "--formula", "--", "test"], output: "Error", success: false)
+        mock.setResult(for: ["search", "--cask", "--", "test"], output: "test-app")
+
+        await service.search(query: "test")
+
+        #expect(service.searchResults.count == 1)
+        #expect(service.searchResults[0].name == "test-app")
+    }
+
+    @Test("search filters out ==> header lines")
+    func searchFiltersHeaders() async {
+        let mock = MockCommandRunner()
+        let (service, _) = makeService(mock: mock)
+        mock.setResult(for: ["search", "--formula", "--", "test"], output: "==> Formulae\ntest-formula")
+        mock.setResult(for: ["search", "--cask", "--", "test"], output: "==> Casks\ntest-cask")
+
+        await service.search(query: "test")
+
+        let names = service.searchResults.map(\.name)
+        #expect(!names.contains("==>"))
+        // The header word itself must not survive tokenization as a phantom package.
+        #expect(!names.contains("Formulae"))
+        #expect(!names.contains("Casks"))
+        #expect(names.contains("test-formula"))
+        #expect(names.contains("test-cask"))
+    }
+
+    @Test("search results have correct source types")
+    func searchResultSourceTypes() async {
+        let mock = MockCommandRunner()
+        let (service, _) = makeService(mock: mock)
+        mock.setResult(for: ["search", "--formula", "--", "test"], output: "test-formula")
+        mock.setResult(for: ["search", "--cask", "--", "test"], output: "test-cask")
+
+        await service.search(query: "test")
+
+        let formula = service.searchResults.first { $0.name == "test-formula" }
+        let cask = service.searchResults.first { $0.name == "test-cask" }
+        #expect(formula?.source == .formula)
+        #expect(cask?.source == .cask)
+    }
+}

--- a/BrewyTests/SecurityHelpersTests.swift
+++ b/BrewyTests/SecurityHelpersTests.swift
@@ -126,6 +126,25 @@ struct BrewServiceSafetyGuardrailTests {
         #expect(mock.executedCommands.contains(caskDetailCommand))
     }
 
+    @Test("upgradeSelected inserts option separator before package names")
+    func upgradeSelectedUsesOptionSeparator() async {
+        let mock = MockCommandRunner()
+        let (service, _) = makeService(mock: mock)
+        setupRefreshMock(mock)
+
+        let formula = makePackage(name: "--eval-all", source: .formula)
+        let cask = makePackage(name: "--zap", source: .cask)
+        let formulaCommand = ["upgrade", "--", "--eval-all"]
+        let caskCommand = ["upgrade", "--cask", "--", "--zap"]
+        mock.setResult(for: formulaCommand, output: "Upgraded formula")
+        mock.setResult(for: caskCommand, output: "Upgraded cask")
+
+        await service.upgradeSelected(packages: [formula, cask])
+
+        #expect(mock.executedCommands.contains(formulaCommand))
+        #expect(mock.executedCommands.contains(caskCommand))
+    }
+
     @Test("upgradeSelected excludes mas apps and reports App Store updates")
     func upgradeSelectedReportsMasApps() async {
         let mock = MockCommandRunner()
@@ -134,11 +153,11 @@ struct BrewServiceSafetyGuardrailTests {
 
         let formula = makePackage(name: "wget", source: .formula)
         let masApp = makePackage(name: "Xcode", source: .mas)
-        mock.setResult(for: ["upgrade", "wget"], output: "Upgraded wget")
+        mock.setResult(for: ["upgrade", "--", "wget"], output: "Upgraded wget")
 
         await service.upgradeSelected(packages: [formula, masApp])
 
-        #expect(mock.executedCommands.contains(["upgrade", "wget"]))
+        #expect(mock.executedCommands.contains(["upgrade", "--", "wget"]))
         #expect(!mock.executedCommands.contains { $0.contains("Xcode") })
         #expect(service.lastError?.localizedDescription.contains("Mac App Store") == true)
     }

--- a/BrewyTests/TestHelpers.swift
+++ b/BrewyTests/TestHelpers.swift
@@ -61,16 +61,14 @@ final class MockCommandRunner: CommandRunning, @unchecked Sendable {
 // MARK: - Test Data
 
 enum TestJSON {
-    static let formulae = """
+    /// Combined `brew info --installed --json=v2` envelope: formulae and casks arrive in one call.
+    static let installedPackages = """
     {"formulae":[{"name":"wget","desc":"Internet file retriever",\
     "homepage":"https://www.gnu.org/software/wget/",\
     "versions":{"stable":"1.24.5"},"pinned":false,\
     "installed":[{"version":"1.24.5","installed_on_request":true}],\
-    "dependencies":["openssl@3","libidn2"]}],"casks":[]}
-    """
-
-    static let casks = """
-    {"formulae":[],"casks":[{"token":"firefox","version":"122.0",\
+    "dependencies":["openssl@3","libidn2"]}],\
+    "casks":[{"token":"firefox","version":"122.0",\
     "desc":"Web browser","homepage":"https://www.mozilla.org/firefox/"}]}
     """
 
@@ -117,8 +115,7 @@ func makeService(mock: MockCommandRunner) -> (BrewService, MockCommandRunner) {
 }
 
 func setupRefreshMock(_ mock: MockCommandRunner) {
-    mock.setResult(for: ["info", "--installed", "--json=v2"], output: TestJSON.formulae)
-    mock.setResult(for: ["info", "--installed", "--cask", "--json=v2"], output: TestJSON.casks)
+    mock.setResult(for: ["info", "--installed", "--json=v2"], output: TestJSON.installedPackages)
     mock.setResult(for: ["outdated", "--json=v2"], output: TestJSON.outdated)
     mock.setResult(for: ["tap-info", "--json=v1", "--installed"], output: TestJSON.taps)
 }


### PR DESCRIPTION
Four fixes in the refresh and search path.

performRefresh ran `brew info --installed --json=v2` and then a second `info --installed --cask` call. The JSON v2 envelope already carries both arrays, and each call re-evaluates the whole installed set, so the second process was redundant work on every refresh. Both arrays now come from a single call, which also means a transient failure preserves both prior lists instead of clobbering one. Verified against Homebrew 6.0.12, where the scoped and unscoped envelopes return identical cask payloads.

Every fetch set lastError on failure, and ContentView presents lastError as a modal alert, so with an auto-refresh interval configured and brew or the network broken the user got a modal error on every interval. Background failures now route to a non-modal banner in the sidebar footer while user-initiated refreshes still raise the alert. A queued follow-up counts as user-initiated if any queued request was, so an explicit refresh is never demoted by a background one it waited on.

performSearch marked results installed by bare name against a set mixing formulae, casks, and Mac App Store apps, so a cask hit named like an installed formula showed the installed check wrongly. It now matches on source-qualified IDs, which also stops a Mac App Store app satisfying a same-named brew result. The search suite moves to its own file to stay under the file-length ceiling.

upgradeSelected built its argument arrays without the `--` separator that performAction and info use deliberately, so a package whose name began with a hyphen would be parsed as an option. The names come from brew itself, so the practical risk is low, but the guardrail should hold everywhere. The guardrail suite now covers the bulk path with adversarial names.
