### PR TITLE
feat(actions): live streaming output and safe cancellation for long-running commands

### DIFF
--- a/Brewy/BrewyApp.swift
+++ b/Brewy/BrewyApp.swift
@@ -76,11 +76,7 @@ struct BrewyApp: App {
 
                 Divider()
 
-                Button("Upgrade All") {
-                    Task { await brewService.upgradeAll() }
-                }
-                .keyboardShortcut("u", modifiers: .command)
-                .disabled(brewService.homebrewOutdatedPackages.isEmpty)
+                UpgradeAllCommandButton(brewService: brewService)
 
                 Button("Cleanup...") {
                     NotificationCenter.default.post(name: .showCleanupPreview, object: nil)
@@ -107,6 +103,21 @@ struct BrewyApp: App {
                 systemImage: count > 0 ? "shippingbox.fill" : "shippingbox"
             )
         }
+    }
+}
+
+private struct UpgradeAllCommandButton: View {
+    @Environment(\.openWindow)
+    private var openWindow
+    let brewService: BrewService
+
+    var body: some View {
+        Button("Upgrade All") {
+            openWindow(id: "main")
+            Task { await brewService.upgradeAll() }
+        }
+        .keyboardShortcut("u", modifiers: .command)
+        .disabled(brewService.homebrewOutdatedPackages.isEmpty)
     }
 }
 
@@ -159,6 +170,7 @@ private struct MenuBarView: View {
             if homebrewOutdatedCount > 0 {
                 Divider()
                 Button("Upgrade Homebrew Packages") {
+                    openWindow(id: "main")
                     Task { await brewService.upgradeAll() }
                 }
             }

--- a/Brewy/Models/ActionHistoryEntry+Commands.swift
+++ b/Brewy/Models/ActionHistoryEntry+Commands.swift
@@ -1,7 +1,21 @@
+import Foundation
+
 extension ActionHistoryEntry {
     var isMutatingCommand: Bool {
+        if isBundleDump { return true }
         guard let command = arguments.first else { return false }
         return Self.mutatingCommands.contains(command)
+    }
+
+    var isBundleDump: Bool {
+        arguments.starts(with: ["bundle", "dump"])
+    }
+
+    var bundleDumpURL: URL? {
+        guard isBundleDump,
+              let fileIndex = arguments.firstIndex(of: "--file"),
+              arguments.indices.contains(fileIndex + 1) else { return nil }
+        return URL(fileURLWithPath: arguments[fileIndex + 1])
     }
 
     private static let mutatingCommands: Set<String> = [

--- a/Brewy/Models/BrewService+Actions.swift
+++ b/Brewy/Models/BrewService+Actions.swift
@@ -21,8 +21,8 @@ extension BrewService {
 
     func upgradeAll() async {
         let masOutdatedCount = outdatedPackages.filter(\.isMas).count
-        await performBrewAction(["upgrade"], refreshAfter: true)
-        if masOutdatedCount > 0, lastError == nil {
+        guard let result = await performBrewAction(["upgrade"], refreshAfter: true) else { return }
+        if masOutdatedCount > 0, lastError == nil, !result.cancelled {
             lastError = .commandFailed(command: "upgrade", output: Self.masUpgradeMessage(count: masOutdatedCount))
         }
     }
@@ -36,25 +36,26 @@ extension BrewService {
 
     // MARK: - Action Helpers
 
-    func performBrewAction(_ arguments: [String], refreshAfter: Bool = false) async {
+    @discardableResult
+    func performBrewAction(_ arguments: [String], refreshAfter: Bool = false) async -> CommandResult? {
         guard !isPerformingAction else {
             logger.info("\(arguments.first ?? "action") skipped, action already in progress")
-            return
+            return nil
         }
         isPerformingAction = true
         actionOutput = ""
         lastError = nil
         defer { isPerformingAction = false }
 
-        let result = await runBrewCommand(arguments)
-        actionOutput = result.output
-        if !result.success {
+        let result = await runBrewCommandStreaming(arguments)
+        if !result.success, !result.cancelled {
             lastError = .commandFailed(command: arguments.joined(separator: " "), output: result.output)
         }
         recordAction(arguments: arguments, packageName: nil, packageSource: nil, success: result.success, output: result.output)
         if refreshAfter {
             await refresh()
         }
+        return result
     }
 
     func performAction(_ action: String, package: BrewPackage) async {
@@ -81,9 +82,8 @@ extension BrewService {
         args.append("--")
         args.append(package.name)
 
-        let result = await runBrewCommand(args)
-        actionOutput = result.output
-        if !result.success {
+        let result = await runBrewCommandStreaming(args)
+        if !result.success, !result.cancelled {
             logger.warning("\(action) failed for \(package.name): \(result.output.prefix(200))")
             lastError = .commandFailed(command: action, output: result.output)
         }

--- a/Brewy/Models/BrewService+Bundle.swift
+++ b/Brewy/Models/BrewService+Bundle.swift
@@ -279,7 +279,7 @@ extension BrewService {
         actionOutput = ""
         lastError = nil
 
-        let arguments = ["bundle", "dump", "--file", url.path]
+        let arguments = ["bundle", "dump", "--force", "--file", url.path]
         let result = await runBrewCommandStreaming(arguments)
         if !result.success, !result.cancelled {
             logger.warning("Bundle dump failed: \(result.output.prefix(200))")

--- a/Brewy/Models/BrewService+Bundle.swift
+++ b/Brewy/Models/BrewService+Bundle.swift
@@ -266,6 +266,8 @@ extension BrewService {
         }
     }
 
+    /// Overwrites any existing file at `url`; callers must obtain user consent first
+    /// (BundleView's NSSavePanel shows the system Replace prompt before calling this).
     @discardableResult
     func dumpBundle(to url: URL) async -> CommandResult {
         guard !isPerformingAction else {
@@ -278,9 +280,8 @@ extension BrewService {
         lastError = nil
 
         let arguments = ["bundle", "dump", "--file", url.path]
-        let result = await runBrewCommand(arguments)
-        actionOutput = result.output
-        if !result.success {
+        let result = await runBrewCommandStreaming(arguments)
+        if !result.success, !result.cancelled {
             logger.warning("Bundle dump failed: \(result.output.prefix(200))")
             lastError = .commandFailed(command: arguments.joined(separator: " "), output: result.output)
         }

--- a/Brewy/Models/BrewService+History.swift
+++ b/Brewy/Models/BrewService+History.swift
@@ -78,9 +78,8 @@ extension BrewService {
         lastError = nil
         defer { isPerformingAction = false }
 
-        let result = await runBrewCommand(entry.arguments)
-        actionOutput = result.output
-        if !result.success {
+        let result = await runBrewCommandStreaming(entry.arguments)
+        if !result.success, !result.cancelled {
             lastError = .commandFailed(command: entry.arguments.joined(separator: " "), output: result.output)
         }
         recordAction(

--- a/Brewy/Models/BrewService+History.swift
+++ b/Brewy/Models/BrewService+History.swift
@@ -90,7 +90,11 @@ extension BrewService {
             output: result.output
         )
 
-        if entry.isMutatingCommand {
+        if result.success, entry.isBundleDump, let url = entry.bundleDumpURL {
+            customBrewfilePath = url.path
+            trustBrewfile(at: url)
+            await refreshBundle()
+        } else if entry.isMutatingCommand {
             await refresh()
         }
     }

--- a/Brewy/Models/BrewService+Streaming.swift
+++ b/Brewy/Models/BrewService+Streaming.swift
@@ -1,0 +1,51 @@
+extension BrewService {
+    nonisolated static let actionOutputByteLimit = 262_144
+
+    /// Streams command output into a bounded display buffer. The returned result retains the
+    /// full output for error handling and byte-bounded history persistence.
+    func runBrewCommandStreaming(_ arguments: [String]) async -> CommandResult {
+        let brewPath = CommandRunner.resolvedBrewPath(preferred: customBrewPath)
+        let timeout = CommandRunner.timeout(forBrewArguments: arguments)
+        let baseline = actionOutput
+        let (stream, continuation) = AsyncStream.makeStream(of: String.self)
+        // A single consumer applies chunks in arrival order; Task-per-chunk would not
+        // guarantee ordering.
+        let appender = Task { @MainActor [weak self] in
+            for await chunk in stream {
+                self?.appendActionOutput(chunk)
+            }
+        }
+        let commandTask = Task { [commandRunner] in
+            await commandRunner.runStreaming(arguments, brewPath: brewPath, timeout: timeout) { chunk in
+                continuation.yield(chunk)
+            }
+        }
+        actionCommandTask = commandTask
+        canCancelCurrentAction = true
+        let result = await commandTask.value
+        canCancelCurrentAction = false
+        actionCommandTask = nil
+        continuation.finish()
+        await appender.value
+        actionOutput = Self.boundedActionOutput(baseline + result.output)
+        return result
+    }
+
+    func cancelCurrentAction() {
+        guard canCancelCurrentAction else { return }
+        canCancelCurrentAction = false
+        actionCommandTask?.cancel()
+    }
+
+    nonisolated static func boundedActionOutput(_ output: String) -> String {
+        guard output.utf8.count > actionOutputByteLimit else { return output }
+        return "…\n" + UTF8ByteTruncation.suffix(output, maxBytes: actionOutputByteLimit - 4)
+    }
+
+    private func appendActionOutput(_ chunk: String) {
+        actionOutput += chunk
+        if actionOutput.utf8.count > Self.actionOutputByteLimit {
+            actionOutput = Self.boundedActionOutput(actionOutput)
+        }
+    }
+}

--- a/Brewy/Models/BrewService+Taps.swift
+++ b/Brewy/Models/BrewService+Taps.swift
@@ -67,10 +67,10 @@ extension BrewService {
 
     @discardableResult
     private func runTapCommand(_ arguments: [String]) async -> CommandResult {
-        let result = await runBrewCommand(arguments)
-        actionOutput += actionOutput.isEmpty ? result.output : "\n" + result.output
-        if !result.success {
-            lastError = .commandFailed(command: arguments.first ?? "", output: result.output)
+        if !actionOutput.isEmpty { actionOutput += "\n" }
+        let result = await runBrewCommandStreaming(arguments)
+        if !result.success, !result.cancelled {
+            lastError = .commandFailed(command: arguments.joined(separator: " "), output: result.output)
         }
         recordAction(arguments: arguments, packageName: nil, packageSource: nil, success: result.success, output: result.output)
         return result

--- a/Brewy/Models/BrewService+Updates.swift
+++ b/Brewy/Models/BrewService+Updates.swift
@@ -22,11 +22,12 @@ extension BrewService {
         defer { isPerformingAction = false }
 
         let arguments = ["update"]
-        let result = await runBrewCommand(arguments)
-        actionOutput = result.output
+        let result = await runBrewCommandStreaming(arguments)
 
         if !result.success {
-            lastError = .commandFailed(command: "update", output: result.output)
+            if !result.cancelled {
+                lastError = .commandFailed(command: "update", output: result.output)
+            }
         } else {
             let parsed = BrewUpdateParser.parse(result.output)
             lastUpdateResult = parsed

--- a/Brewy/Models/BrewService.swift
+++ b/Brewy/Models/BrewService.swift
@@ -81,6 +81,7 @@ final class BrewService {
     var isLoading: Bool { loadingCount > 0 }
     var isPerformingAction = false
     var actionOutput: String = ""
+    var canCancelCurrentAction = false
     var lastError: BrewError?
     /// Failure from a background auto-refresh, surfaced non-modally (sidebar footer)
     /// instead of the error alert so a broken brew doesn't raise a modal every interval.
@@ -104,6 +105,7 @@ final class BrewService {
     @ObservationIgnored private var isBatchingUpdates = false
     @ObservationIgnored var infoCache: [String: String] = [:]
     @ObservationIgnored private var tapHealthTask: Task<Void, Never>?
+    @ObservationIgnored var actionCommandTask: Task<CommandResult, Never>?
 
     // MARK: - Cached Derived State
 
@@ -391,24 +393,25 @@ extension BrewService {
         let casks = packages.filter { $0.source == .cask }.map(\.name)
         let masCount = packages.filter(\.isMas).count
         var errorOutputs: [String] = []
+        var wasCancelled = false
 
         if !formulae.isEmpty {
             let args = ["upgrade", "--"] + formulae
-            let result = await runBrewCommand(args)
-            actionOutput += result.output
-            if !result.success { errorOutputs.append(result.output) }
+            let result = await runBrewCommandStreaming(args)
+            wasCancelled = result.cancelled
+            if !result.success, !result.cancelled { errorOutputs.append(result.output) }
             recordAction(arguments: args, packageName: nil, packageSource: .formula, success: result.success, output: result.output)
         }
-        if !casks.isEmpty {
+        if !casks.isEmpty, !wasCancelled {
             let args = ["upgrade", "--cask", "--"] + casks
-            let result = await runBrewCommand(args)
-            actionOutput += result.output
-            if !result.success { errorOutputs.append(result.output) }
+            let result = await runBrewCommandStreaming(args)
+            wasCancelled = result.cancelled
+            if !result.success, !result.cancelled { errorOutputs.append(result.output) }
             recordAction(arguments: args, packageName: nil, packageSource: .cask, success: result.success, output: result.output)
         }
         if !errorOutputs.isEmpty {
             lastError = .commandFailed(command: "upgrade", output: errorOutputs.joined(separator: "\n\n"))
-        } else if masCount > 0 {
+        } else if masCount > 0, !wasCancelled {
             lastError = .commandFailed(command: "upgrade", output: Self.masUpgradeMessage(count: masCount))
         }
         await refresh()

--- a/Brewy/Models/BrewService.swift
+++ b/Brewy/Models/BrewService.swift
@@ -416,7 +416,11 @@ extension BrewService {
 
     func runBrewCommand(_ arguments: [String]) async -> CommandResult {
         let brewPath = CommandRunner.resolvedBrewPath(preferred: customBrewPath)
-        return await commandRunner.run(arguments, brewPath: brewPath)
+        return await commandRunner.run(
+            arguments,
+            brewPath: brewPath,
+            timeout: CommandRunner.timeout(forBrewArguments: arguments)
+        )
     }
 
 }

--- a/Brewy/Models/CommandRunner.swift
+++ b/Brewy/Models/CommandRunner.swift
@@ -9,30 +9,18 @@ private let logger = Logger(subsystem: "io.linnane.brewy", category: "CommandRun
 struct CommandResult: Sendable {
     let output: String
     let success: Bool
+    /// True when the process was terminated because the awaiting task was cancelled,
+    /// so callers can skip failure alerts for user-requested cancellation.
+    let cancelled: Bool
+
+    init(output: String, success: Bool, cancelled: Bool = false) {
+        self.output = output
+        self.success = success
+        self.cancelled = cancelled
+    }
 }
 
 // MARK: - Thread-safe Value Containers
-
-/// Thread-safe accumulator for data chunks.
-private final class LockedData: Sendable {
-    private let lock = NSLock()
-    nonisolated(unsafe) private var chunks: [Data] = []
-
-    func append(_ data: Data) {
-        lock.lock()
-        chunks.append(data)
-        lock.unlock()
-    }
-
-    func combined() -> Data {
-        lock.lock()
-        var result = Data()
-        result.reserveCapacity(chunks.reduce(0) { $0 + $1.count })
-        for chunk in chunks { result.append(chunk) }
-        lock.unlock()
-        return result
-    }
-}
 
 private final class LockedFlag: Sendable {
     private let lock = NSLock()
@@ -46,11 +34,54 @@ private final class LockedFlag: Sendable {
     }
 }
 
+/// Thread-safe handle bridging a launched `Process` to a task-cancellation handler,
+/// which may fire before the process has even launched.
+private final class ProcessHandle: @unchecked Sendable {
+    private let lock = NSLock()
+    private var process: Process?
+    private var signalTarget: Int32?
+    private var cancelled = false
+
+    /// Registers the launched process; returns false when cancellation already
+    /// happened, in which case the caller must tear the process down itself.
+    func register(_ process: Process) -> Bool {
+        let signalTarget = CommandRunner.signalTarget(for: process)
+        lock.lock(); defer { lock.unlock() }
+        guard !cancelled else { return false }
+        self.process = process
+        self.signalTarget = signalTarget
+        return true
+    }
+
+    var wasCancelled: Bool {
+        lock.lock(); defer { lock.unlock() }
+        return cancelled
+    }
+
+    func cancel(killGracePeriod: Duration) {
+        lock.lock()
+        cancelled = true
+        let running = process
+        let target = signalTarget
+        lock.unlock()
+        guard let running, let target else { return }
+        CommandRunner.terminateThenKill(running, signalTarget: target, after: killGracePeriod)
+    }
+}
+
 // MARK: - Command Running Protocol
 
 protocol CommandRunning: Sendable {
     func run(_ arguments: [String], brewPath: String, timeout: Duration) async -> CommandResult
     func runExecutable(_ executablePath: String, arguments: [String], timeout: Duration) async -> CommandResult
+    /// Runs the command, delivering output incrementally as it arrives. `onOutput` may be
+    /// called from arbitrary threads; the returned result still carries the full output.
+    func runStreaming(
+        _ arguments: [String],
+        brewPath: String,
+        timeout: Duration,
+        onOutput: @escaping @Sendable (String) -> Void
+    ) async -> CommandResult
 }
 
 extension CommandRunning {
@@ -60,6 +91,19 @@ extension CommandRunning {
 
     func runExecutable(_ executablePath: String, arguments: [String]) async -> CommandResult {
         await runExecutable(executablePath, arguments: arguments, timeout: CommandRunner.defaultTimeout)
+    }
+
+    /// Non-streaming fallback so simple runners (test mocks) satisfy the protocol:
+    /// the full output arrives as a single chunk on completion.
+    func runStreaming(
+        _ arguments: [String],
+        brewPath: String,
+        timeout: Duration,
+        onOutput: @escaping @Sendable (String) -> Void
+    ) async -> CommandResult {
+        let result = await run(arguments, brewPath: brewPath, timeout: timeout)
+        onOutput(result.output)
+        return result
     }
 }
 
@@ -73,6 +117,15 @@ struct DefaultCommandRunner: CommandRunning {
     func runExecutable(_ executablePath: String, arguments: [String], timeout: Duration) async -> CommandResult {
         await CommandRunner.runExecutable(executablePath, arguments: arguments, timeout: timeout)
     }
+
+    func runStreaming(
+        _ arguments: [String],
+        brewPath: String,
+        timeout: Duration,
+        onOutput: @escaping @Sendable (String) -> Void
+    ) async -> CommandResult {
+        await CommandRunner.runExecutable(brewPath, arguments: arguments, timeout: timeout, onOutput: onOutput)
+    }
 }
 
 // MARK: - Command Runner
@@ -80,11 +133,13 @@ struct DefaultCommandRunner: CommandRunning {
 enum CommandRunner {
 
     static let defaultTimeout: Duration = .seconds(300)
+
     static let preventHomebrewAutoUpdateKey = "preventHomebrewAutoUpdate"
     private static let standardBrewPaths = ["/opt/homebrew/bin/brew", "/usr/local/bin/brew"]
 
     /// Grace period between SIGTERM and SIGKILL when a process exceeds its timeout.
     private static let killGracePeriod: Duration = .seconds(3)
+    private static let pipeDrainGracePeriod: Duration = .seconds(5)
 
     static func resolvedBrewPath(preferred: String) -> String {
         if FileManager.default.isExecutableFile(atPath: preferred) { return preferred }
@@ -119,7 +174,8 @@ enum CommandRunner {
     static func runExecutable(
         _ executablePath: String,
         arguments: [String],
-        timeout: Duration = defaultTimeout
+        timeout: Duration = defaultTimeout,
+        onOutput: (@Sendable (String) -> Void)? = nil
     ) async -> CommandResult {
         let execName = URL(fileURLWithPath: executablePath).lastPathComponent
         let commandDescription = "\(execName) \(arguments.joined(separator: " "))"
@@ -127,18 +183,27 @@ enum CommandRunner {
         let startTime = ContinuousClock.now
         let preventHomebrewAutoUpdate = preventsHomebrewAutoUpdate()
 
-        let result = await Task.detached(priority: .medium) {
-            executeProcess(
-                arguments: arguments,
-                brewPath: executablePath,
-                timeout: timeout,
-                commandDescription: commandDescription,
-                preventHomebrewAutoUpdate: preventHomebrewAutoUpdate
-            )
-        }.value
+        let execution = ProcessExecution(
+            executablePath: executablePath,
+            arguments: arguments,
+            timeout: timeout,
+            commandDescription: commandDescription,
+            preventHomebrewAutoUpdate: preventHomebrewAutoUpdate
+        )
+        let handle = ProcessHandle()
+        let result = await withTaskCancellationHandler {
+            await Task.detached(priority: .medium) {
+                executeProcess(execution, handle: handle, onOutput: onOutput)
+            }.value
+        } onCancel: {
+            logger.info("Task cancelled, terminating: \(commandDescription)")
+            handle.cancel(killGracePeriod: killGracePeriod)
+        }
 
         let elapsed = ContinuousClock.now - startTime
-        if result.success {
+        if result.cancelled {
+            logger.info("\(commandDescription) cancelled after \(elapsed)")
+        } else if result.success {
             logger.info("\(commandDescription) completed in \(elapsed)")
         } else {
             logger.warning("\(commandDescription) failed after \(elapsed): \(result.output.prefix(200))")
@@ -199,50 +264,71 @@ enum CommandRunner {
         return .nanoseconds(Int(totalNanos))
     }
 
-    private static func executeProcess(
-        arguments: [String],
-        brewPath: String,
-        timeout: Duration,
-        commandDescription: String,
-        preventHomebrewAutoUpdate: Bool
-    ) -> CommandResult {
-        let process = Process()
-        let stdoutPipe = Pipe()
-        let stderrPipe = Pipe()
+    private struct ProcessExecution: Sendable {
+        let executablePath: String
+        let arguments: [String]
+        let timeout: Duration
+        let commandDescription: String
+        let preventHomebrewAutoUpdate: Bool
+    }
 
-        process.executableURL = URL(fileURLWithPath: brewPath)
-        process.arguments = arguments
-        process.environment = buildEnvironment(
-            brewPath: brewPath,
-            preventHomebrewAutoUpdate: preventHomebrewAutoUpdate
-        )
-        process.standardOutput = stdoutPipe
-        process.standardError = stderrPipe
+    private static func executeProcess(
+        _ execution: ProcessExecution,
+        handle: ProcessHandle,
+        onOutput: (@Sendable (String) -> Void)?
+    ) -> CommandResult {
+        guard !handle.wasCancelled else {
+            return CommandResult(output: "Command was cancelled.", success: false, cancelled: true)
+        }
+        let (process, stdoutPipe, stderrPipe) = configuredProcess(for: execution)
 
         do {
             try process.run()
         } catch {
             logger.error("Failed to launch process: \(error.localizedDescription)")
             return CommandResult(
-                output: "Failed to run \(commandDescription): \(error.localizedDescription)",
+                output: "Failed to run \(execution.commandDescription): \(error.localizedDescription)",
                 success: false
             )
         }
 
-        let (stdoutData, stderrData) = drainPipesInParallel(stdout: stdoutPipe, stderr: stderrPipe)
-        let (timedOut, timeoutWork) = scheduleTimeout(for: process, after: timeout, commandDescription: commandDescription)
+        if !handle.register(process) {
+            // Cancellation raced the launch; the handler never saw the process, so tear it down here.
+            terminateThenKill(process, after: killGracePeriod)
+        }
+
+        let (stdoutData, stderrData) = drainPipesInParallel(stdout: stdoutPipe, stderr: stderrPipe, onOutput: onOutput)
+        let (timedOut, timeoutWork) = scheduleTimeout(
+            for: process,
+            after: execution.timeout,
+            commandDescription: execution.commandDescription
+        )
 
         process.waitUntilExit()
         // Process finished; cancel the pending timeout so it can't fire later.
         timeoutWork.cancel()
-        let out = stdoutData.wait()
-        let err = stderrData.wait()
+        var drainDeadline: DispatchTime?
+        let requestedDrainDeadline = {
+            if drainDeadline == nil, handle.wasCancelled || timedOut.isSet {
+                drainDeadline = DispatchTime.now() + dispatchInterval(from: pipeDrainGracePeriod)
+            }
+            return drainDeadline
+        }
+        let out = stdoutData.wait(untilRequested: requestedDrainDeadline)
+        let err = stderrData.wait(untilRequested: requestedDrainDeadline)
         let stdout = String(data: out, encoding: .utf8) ?? ""
         let stderr = String(data: err, encoding: .utf8) ?? ""
 
+        if handle.wasCancelled {
+            return CommandResult(
+                output: cancelledOutput(stdout: stdout, stderr: stderr),
+                success: false,
+                cancelled: true
+            )
+        }
         if timedOut.isSet {
             return CommandResult(
-                output: timeoutOutput(stdout: stdout, stderr: stderr, timeout: timeout),
+                output: timeoutOutput(stdout: stdout, stderr: stderr, timeout: execution.timeout),
                 success: false
             )
         }
@@ -250,6 +336,62 @@ enum CommandRunner {
             output: commandOutput(stdout: stdout, stderr: stderr, terminationStatus: process.terminationStatus),
             success: process.terminationStatus == 0
         )
+    }
+
+    private static func configuredProcess(for execution: ProcessExecution) -> (Process, Pipe, Pipe) {
+        let process = Process()
+        let stdoutPipe = Pipe()
+        let stderrPipe = Pipe()
+        process.executableURL = URL(fileURLWithPath: execution.executablePath)
+        process.arguments = execution.arguments
+        process.environment = buildEnvironment(
+            brewPath: execution.executablePath,
+            preventHomebrewAutoUpdate: execution.preventHomebrewAutoUpdate
+        )
+        process.standardOutput = stdoutPipe
+        process.standardError = stderrPipe
+        return (process, stdoutPipe, stderrPipe)
+    }
+
+    /// Signals the process group when Foundation launched an isolated group, falling back to
+    /// the direct process otherwise.
+    static func terminateThenKill(_ process: Process, after grace: Duration) {
+        terminateThenKill(process, signalTarget: signalTarget(for: process), after: grace)
+    }
+
+    fileprivate static func signalTarget(for process: Process) -> Int32 {
+        let pid = process.processIdentifier
+        errno = 0
+        let processGroupID = getpgid(pid)
+        if processGroupID == pid || (processGroupID == -1 && errno == ESRCH) {
+            return -pid
+        }
+        logger.warning("Process \(pid) is not its group leader; terminating only the direct process")
+        return pid
+    }
+
+    fileprivate static func terminateThenKill(
+        _ process: Process,
+        signalTarget: Int32,
+        after grace: Duration
+    ) {
+        if signalTarget < 0 {
+            errno = 0
+            guard kill(signalTarget, SIGTERM) == 0 || errno == EPERM else { return }
+        } else {
+            guard process.isRunning else { return }
+            kill(signalTarget, SIGTERM)
+        }
+        DispatchQueue.global(qos: .utility).asyncAfter(deadline: .now() + dispatchInterval(from: grace)) { [weak process] in
+            if signalTarget < 0 {
+                errno = 0
+                guard kill(signalTarget, 0) == 0 || errno == EPERM else { return }
+            } else {
+                guard let process, process.isRunning else { return }
+            }
+            logger.warning("SIGTERM did not stop all processes, sending SIGKILL to target \(signalTarget)")
+            kill(signalTarget, SIGKILL)
+        }
     }
 
     private static func commandOutput(stdout: String, stderr: String, terminationStatus: Int32) -> String {
@@ -283,9 +425,22 @@ enum CommandRunner {
         return "Command timed out after \(timeout).\n\(partialOutput)"
     }
 
-    private static func drainPipesInParallel(stdout: Pipe, stderr: Pipe) -> (stdout: PipeReader, stderr: PipeReader) {
-        let stdoutReader = PipeReader(pipe: stdout)
-        let stderrReader = PipeReader(pipe: stderr)
+    private static func cancelledOutput(stdout: String, stderr: String) -> String {
+        let partialOutput = combinedStreams(stdout: stdout, stderr: stderr)
+            .trimmingCharacters(in: .whitespacesAndNewlines)
+        guard !partialOutput.isEmpty else {
+            return "Command was cancelled."
+        }
+        return "Command was cancelled.\n\(partialOutput)"
+    }
+
+    private static func drainPipesInParallel(
+        stdout: Pipe,
+        stderr: Pipe,
+        onOutput: (@Sendable (String) -> Void)?
+    ) -> (stdout: PipeReader, stderr: PipeReader) {
+        let stdoutReader = PipeReader(pipe: stdout, onText: onOutput)
+        let stderrReader = PipeReader(pipe: stderr, onText: onOutput)
         stdoutReader.start()
         stderrReader.start()
         return (stdoutReader, stderrReader)
@@ -301,44 +456,12 @@ enum CommandRunner {
             guard let process, process.isRunning else { return }
             logger.warning("Timeout exceeded, sending SIGTERM: \(commandDescription)")
             timedOut.set()
-            process.terminate()
-            let pid = process.processIdentifier
-            let graceDispatch = dispatchInterval(from: killGracePeriod)
-            DispatchQueue.global(qos: .utility).asyncAfter(deadline: .now() + graceDispatch) { [weak process] in
-                guard let process, process.isRunning else { return }
-                logger.warning("SIGTERM ignored, sending SIGKILL: \(commandDescription)")
-                kill(pid, SIGKILL)
-            }
+            terminateThenKill(process, after: killGracePeriod)
         }
         DispatchQueue.global(qos: .utility).asyncAfter(
             deadline: .now() + dispatchInterval(from: timeout),
             execute: timeoutWork
         )
         return (timedOut, timeoutWork)
-    }
-}
-
-// MARK: - Pipe Reader
-
-/// Drains a `Pipe` to EOF on a background queue so the subprocess cannot deadlock on a full buffer.
-private final class PipeReader: @unchecked Sendable {
-    private let pipe: Pipe
-    private let accumulator = LockedData()
-    private let semaphore = DispatchSemaphore(value: 0)
-
-    init(pipe: Pipe) { self.pipe = pipe }
-
-    func start() {
-        DispatchQueue.global(qos: .utility).async { [weak self] in
-            guard let self else { return }
-            let data = pipe.fileHandleForReading.readDataToEndOfFile()
-            accumulator.append(data)
-            semaphore.signal()
-        }
-    }
-
-    func wait() -> Data {
-        semaphore.wait()
-        return accumulator.combined()
     }
 }

--- a/Brewy/Models/CommandRunner.swift
+++ b/Brewy/Models/CommandRunner.swift
@@ -134,6 +134,23 @@ enum CommandRunner {
 
     static let defaultTimeout: Duration = .seconds(300)
 
+    /// Mutating commands legitimately run far past `defaultTimeout` (large downloads, source
+    /// builds, post-install scripts); SIGKILLing them mid-flight can leave a broken keg.
+    static let extendedTimeout: Duration = .seconds(3_600)
+
+    /// Brew verbs that mutate the installation and may run long.
+    private static let longRunningVerbs: Set<String> = [
+        "install", "uninstall", "reinstall", "upgrade", "fetch",
+        "bundle", "update", "cleanup", "autoremove", "tap", "untap"
+    ]
+
+    static func timeout(forBrewArguments arguments: [String]) -> Duration {
+        guard let verb = arguments.first, longRunningVerbs.contains(verb) else {
+            return defaultTimeout
+        }
+        return extendedTimeout
+    }
+
     static let preventHomebrewAutoUpdateKey = "preventHomebrewAutoUpdate"
     private static let standardBrewPaths = ["/opt/homebrew/bin/brew", "/usr/local/bin/brew"]
 

--- a/Brewy/Models/MasService.swift
+++ b/Brewy/Models/MasService.swift
@@ -144,13 +144,11 @@ extension BrewService {
         lastError = nil
         defer { isPerformingAction = false }
 
-        let brewPath = CommandRunner.resolvedBrewPath(preferred: customBrewPath)
-        let result = await commandRunner.run(["install", "mas"], brewPath: brewPath)
-        actionOutput = result.output
+        let result = await runBrewCommandStreaming(["install", "mas"])
         if result.success {
             isMasAvailable = true
             await refresh()
-        } else {
+        } else if !result.cancelled {
             lastError = .commandFailed(command: "install mas", output: result.output)
         }
     }

--- a/Brewy/Models/PipeReader.swift
+++ b/Brewy/Models/PipeReader.swift
@@ -1,0 +1,78 @@
+import Foundation
+
+// MARK: - Locked Data
+
+/// Thread-safe accumulator for data chunks.
+final class LockedData: Sendable {
+    private let lock = NSLock()
+    nonisolated(unsafe) private var chunks: [Data] = []
+
+    func append(_ data: Data) {
+        lock.lock()
+        chunks.append(data)
+        lock.unlock()
+    }
+
+    func combined() -> Data {
+        lock.lock()
+        var result = Data()
+        result.reserveCapacity(chunks.reduce(0) { $0 + $1.count })
+        for chunk in chunks { result.append(chunk) }
+        lock.unlock()
+        return result
+    }
+}
+
+// MARK: - Pipe Reader
+
+/// Drains a `Pipe` to EOF on a background queue so the subprocess cannot deadlock on a full
+/// buffer, optionally forwarding each chunk as decoded text while it arrives.
+final class PipeReader: @unchecked Sendable {
+    private let pipe: Pipe
+    private let onText: (@Sendable (String) -> Void)?
+    private let accumulator = LockedData()
+    private let semaphore = DispatchSemaphore(value: 0)
+    /// Only touched from the single reader queue.
+    private var decoder = UTF8StreamDecoder()
+
+    init(pipe: Pipe, onText: (@Sendable (String) -> Void)? = nil) {
+        self.pipe = pipe
+        self.onText = onText
+    }
+
+    func start() {
+        DispatchQueue.global(qos: .utility).async { [weak self] in
+            guard let self else { return }
+            let fileHandle = pipe.fileHandleForReading
+            while true {
+                let data = fileHandle.availableData
+                guard !data.isEmpty else { break }
+                accumulator.append(data)
+                if let onText {
+                    let text = decoder.decode(data)
+                    if !text.isEmpty { onText(text) }
+                }
+            }
+            if let onText {
+                let remainder = decoder.flush()
+                if !remainder.isEmpty { onText(remainder) }
+            }
+            semaphore.signal()
+        }
+    }
+
+    func wait(untilRequested deadline: () -> DispatchTime?) -> Data {
+        while true {
+            if let deadline = deadline() {
+                if semaphore.wait(timeout: deadline) == .success {
+                    return accumulator.combined()
+                }
+                try? pipe.fileHandleForReading.close()
+                return accumulator.combined()
+            }
+            if semaphore.wait(timeout: .now() + .milliseconds(100)) == .success {
+                return accumulator.combined()
+            }
+        }
+    }
+}

--- a/Brewy/Models/UTF8StreamDecoder.swift
+++ b/Brewy/Models/UTF8StreamDecoder.swift
@@ -1,0 +1,71 @@
+import Foundation
+
+/// Decodes UTF-8 arriving in arbitrary chunks, holding back a trailing partial scalar so
+/// multi-byte characters split across pipe reads never turn into replacement characters.
+struct UTF8StreamDecoder {
+    private var pending = Data()
+
+    mutating func decode(_ chunk: Data) -> String {
+        var buffer = pending
+        buffer.append(chunk)
+        pending = Data()
+        guard !buffer.isEmpty else { return "" }
+        let splitIndex = Self.trailingPartialScalarStart(of: buffer)
+        let complete = buffer[buffer.startIndex..<splitIndex]
+        pending = Data(buffer[splitIndex...])
+        guard !complete.isEmpty else { return "" }
+        return Self.lossyDecode(complete)
+    }
+
+    /// Emits any held-back bytes (decoded with replacement characters if truly malformed).
+    mutating func flush() -> String {
+        defer { pending = Data() }
+        guard !pending.isEmpty else { return "" }
+        return Self.lossyDecode(pending)
+    }
+
+    /// Explicitly lossy: streamed console output must render even around malformed bytes,
+    /// so errors become U+FFFD instead of dropping the whole chunk.
+    private static func lossyDecode(_ data: Data) -> String {
+        var result = ""
+        result.reserveCapacity(data.count)
+        var decoder = UTF8()
+        var iterator = data.makeIterator()
+        while true {
+            switch decoder.decode(&iterator) {
+            case .scalarValue(let scalar):
+                result.unicodeScalars.append(scalar)
+            case .emptyInput:
+                return result
+            case .error:
+                result.unicodeScalars.append("\u{FFFD}")
+            }
+        }
+    }
+
+    /// Index where a trailing incomplete UTF-8 scalar begins, or `endIndex` when the
+    /// buffer ends on a scalar boundary (or with bytes no future chunk can repair).
+    private static func trailingPartialScalarStart(of data: Data) -> Data.Index {
+        var index = data.endIndex
+        var continuationBytes = 0
+        while index > data.startIndex, continuationBytes < 4 {
+            let previous = data.index(before: index)
+            let byte = data[previous]
+            if byte & 0xC0 == 0x80 {
+                index = previous
+                continuationBytes += 1
+                continue
+            }
+            let scalarLength: Int
+            switch byte {
+            case _ where byte & 0x80 == 0x00: scalarLength = 1
+            case _ where byte & 0xE0 == 0xC0: scalarLength = 2
+            case _ where byte & 0xF0 == 0xE0: scalarLength = 3
+            case _ where byte & 0xF8 == 0xF0: scalarLength = 4
+            default: return data.endIndex
+            }
+            return scalarLength > continuationBytes + 1 ? previous : data.endIndex
+        }
+        return data.endIndex
+    }
+}

--- a/Brewy/Views/ContentView.swift
+++ b/Brewy/Views/ContentView.swift
@@ -84,6 +84,19 @@ struct ContentView: View {
             detailView
         }
         .environment(\.selectPackage) { name in navigateToPackage(name) }
+        .overlay {
+            if brewService.isPerformingAction {
+                ZStack {
+                    Color.black.opacity(0.12)
+                    ActionOverlay(
+                        output: brewService.actionOutput,
+                        canCancel: brewService.canCancelCurrentAction,
+                        onCancel: brewService.cancelCurrentAction
+                    )
+                }
+                .accessibilityAddTraits(.isModal)
+            }
+        }
         .task {
 #if DEBUG
             if BrewyRuntime.isUITesting {

--- a/Brewy/Views/HistoryView.swift
+++ b/Brewy/Views/HistoryView.swift
@@ -96,11 +96,6 @@ struct HistoryDetailView: View {
         }
         .formStyle(.grouped)
         .navigationTitle(entry.packageName ?? entry.command)
-        .overlay {
-            if brewService.isPerformingAction {
-                ActionOverlay(output: brewService.actionOutput)
-            }
-        }
         .confirmationDialog("Retry Command?", isPresented: $showRetryConfirmation) {
             Button("Retry", role: .destructive) {
                 Task { await brewService.retryAction(entry) }

--- a/Brewy/Views/PackageDetailView.swift
+++ b/Brewy/Views/PackageDetailView.swift
@@ -72,11 +72,6 @@ struct PackageDetailView: View {
         } message: {
             Text("This will remove \(package.name) from your system. This action cannot be undone.")
         }
-        .overlay {
-            if brewService.isPerformingAction {
-                ActionOverlay(output: brewService.actionOutput)
-            }
-        }
     }
 }
 

--- a/Brewy/Views/SharedViews.swift
+++ b/Brewy/Views/SharedViews.swift
@@ -225,22 +225,36 @@ struct ConsoleOutput: View {
 
 struct ActionOverlay: View {
     let output: String
+    let canCancel: Bool
+    let onCancel: () -> Void
 
     var body: some View {
         VStack(spacing: 16) {
             ProgressView()
                 .scaleEffect(1.2)
-            Text("Running...")
+            Text(canCancel ? "Running..." : "Finishing...")
                 .font(.headline)
             if !output.isEmpty {
-                ScrollView {
-                    Text(output)
-                        .font(.system(.caption, design: .monospaced))
-                        .frame(maxWidth: .infinity, alignment: .leading)
-                        .padding(8)
+                ScrollViewReader { proxy in
+                    ScrollView {
+                        Text(output)
+                            .font(.system(.caption, design: .monospaced))
+                            .frame(maxWidth: .infinity, alignment: .leading)
+                            .padding(8)
+                        Color.clear
+                            .frame(height: 1)
+                            .id("actionOverlayBottom")
+                    }
+                    .frame(maxHeight: 200)
+                    .background(.quaternary.opacity(0.3), in: .rect(cornerRadius: 8))
+                    .onChange(of: output, initial: true) {
+                        proxy.scrollTo("actionOverlayBottom", anchor: .bottom)
+                    }
                 }
-                .frame(maxHeight: 200)
-                .background(.quaternary.opacity(0.3), in: .rect(cornerRadius: 8))
+            }
+            if canCancel {
+                Button("Cancel", action: onCancel)
+                    .keyboardShortcut(.cancelAction)
             }
         }
         .padding(24)

--- a/Brewy/Views/TapListView.swift
+++ b/Brewy/Views/TapListView.swift
@@ -158,8 +158,6 @@ private struct AddTapSheet: View {
     @Environment(\.dismiss)
     private var dismiss
     @State private var tapName = ""
-    @State private var isAdding = false
-    @State private var errorMessage: String?
 
     private var isValidTapName: Bool {
         let trimmed = tapName.trimmingCharacters(in: .whitespaces)
@@ -178,47 +176,24 @@ private struct AddTapSheet: View {
                 .foregroundStyle(.secondary)
             TextField("user/repo", text: $tapName)
                 .textFieldStyle(.roundedBorder)
-                .disabled(isAdding)
-                .onChange(of: tapName) { errorMessage = nil }
             if !tapName.isEmpty, !isValidTapName {
                 Text("Tap name must be in user/repo format.")
                     .font(.caption)
                     .foregroundStyle(.red)
-            }
-            if let errorMessage {
-                Text(errorMessage)
-                    .font(.caption)
-                    .foregroundStyle(.red)
-            }
-            if isAdding {
-                ProgressView("Adding \(tapName.trimmingCharacters(in: .whitespaces))…")
-                    .font(.callout)
             }
             HStack {
                 Button("Cancel") {
                     dismiss()
                 }
                 .keyboardShortcut(.cancelAction)
-                .disabled(isAdding)
                 Button("Add") {
                     let name = tapName.trimmingCharacters(in: .whitespaces)
                     guard isValidTapName else { return }
-                    isAdding = true
-                    errorMessage = nil
-                    Task {
-                        let result = await brewService.addTap(name: name)
-                        if !result.success {
-                            errorMessage = BrewError.commandFailed(command: "tap \(name)", output: result.output)
-                                .localizedDescription
-                            brewService.lastError = nil
-                            isAdding = false
-                        } else {
-                            dismiss()
-                        }
-                    }
+                    dismiss()
+                    Task { await brewService.addTap(name: name) }
                 }
                 .keyboardShortcut(.defaultAction)
-                .disabled(!isValidTapName || isAdding)
+                .disabled(!isValidTapName)
             }
         }
         .padding(20)

--- a/BrewyTests/ActionStreamingTests.swift
+++ b/BrewyTests/ActionStreamingTests.swift
@@ -1,0 +1,186 @@
+@testable import Brewy
+import Foundation
+import Testing
+
+// MARK: - Streaming Mock Runner
+
+/// Streams configured chunks with a delay before each, honoring task cancellation the way
+/// the real runner does (cancelled result, no error alert expected).
+private final class StreamingMockRunner: CommandRunning, @unchecked Sendable {
+    private let lock = NSLock()
+    private var _streamedCommands: [[String]] = []
+    private let chunks: [String]
+    private let chunkDelay: Duration
+    private let finalResult: CommandResult
+
+    var streamedCommands: [[String]] {
+        lock.withLock { _streamedCommands }
+    }
+
+    init(chunks: [String], chunkDelay: Duration = .milliseconds(20), finalResult: CommandResult) {
+        self.chunks = chunks
+        self.chunkDelay = chunkDelay
+        self.finalResult = finalResult
+    }
+
+    /// Post-action refreshes must decode cleanly so they never set lastError themselves.
+    func run(_ arguments: [String], brewPath: String, timeout: Duration) async -> CommandResult {
+        switch arguments {
+        case ["info", "--installed", "--json=v2"]:
+            return CommandResult(output: TestJSON.emptyFormulae, success: true)
+        case ["outdated", "--json=v2"]:
+            return CommandResult(output: TestJSON.emptyOutdated, success: true)
+        case ["tap-info", "--json=v1", "--installed"]:
+            return CommandResult(output: TestJSON.emptyTaps, success: true)
+        default:
+            return finalResult
+        }
+    }
+
+    func runExecutable(_ executablePath: String, arguments: [String], timeout: Duration) async -> CommandResult {
+        finalResult
+    }
+
+    func runStreaming(
+        _ arguments: [String],
+        brewPath: String,
+        timeout: Duration,
+        onOutput: @escaping @Sendable (String) -> Void
+    ) async -> CommandResult {
+        lock.withLock { _streamedCommands.append(arguments) }
+        for chunk in chunks {
+            do {
+                try await Task.sleep(for: chunkDelay)
+            } catch {
+                return CommandResult(output: "Command was cancelled.", success: false, cancelled: true)
+            }
+            onOutput(chunk)
+        }
+        return finalResult
+    }
+}
+
+// MARK: - Streaming Action Tests
+
+@Suite("BrewService Streaming Actions")
+@MainActor
+struct ActionStreamingTests {
+
+    @Test("Streamed chunks reach actionOutput while the command runs")
+    func chunksReachActionOutputMidFlight() async {
+        let runner = StreamingMockRunner(
+            chunks: ["first-chunk\n", "second-chunk\n"],
+            chunkDelay: .milliseconds(50),
+            finalResult: CommandResult(output: "first-chunk\nsecond-chunk\n", success: true)
+        )
+        let service = BrewService(commandRunner: runner)
+
+        let action = Task { await service.performBrewAction(["upgrade"]) }
+        var sawPartial = false
+        for _ in 0..<200 {
+            try? await Task.sleep(for: .milliseconds(5))
+            if service.actionOutput.contains("first-chunk"), !service.actionOutput.contains("second-chunk") {
+                sawPartial = true
+                break
+            }
+        }
+        _ = await action.value
+
+        #expect(sawPartial)
+        #expect(service.actionOutput == "first-chunk\nsecond-chunk\n")
+    }
+
+    @Test("actionOutput is canonicalized to the final result on completion")
+    func outputCanonicalizedOnCompletion() async {
+        let mock = MockCommandRunner()
+        let (service, _) = makeService(mock: mock)
+        setupRefreshMock(mock)
+        mock.setResult(for: ["autoremove"], output: "Removed nothing")
+
+        await service.performBrewAction(["autoremove"])
+
+        #expect(service.actionOutput == "Removed nothing")
+    }
+
+    @Test("actionOutput remains byte-bounded for multi-byte command output")
+    func actionOutputRemainsBounded() async {
+        let output = String(repeating: "🍺", count: BrewService.actionOutputByteLimit)
+        let runner = StreamingMockRunner(
+            chunks: [output],
+            finalResult: CommandResult(output: output, success: true)
+        )
+        let service = BrewService(commandRunner: runner)
+
+        await service.performBrewAction(["upgrade"])
+
+        #expect(service.actionOutput.utf8.count <= BrewService.actionOutputByteLimit)
+        #expect(service.actionOutput.hasSuffix("🍺"))
+    }
+
+    @Test("cancelCurrentAction stops the command without raising the error alert")
+    func cancelSkipsErrorAlert() async {
+        let runner = StreamingMockRunner(
+            chunks: ["never-finishes"],
+            chunkDelay: .seconds(30),
+            finalResult: CommandResult(output: "unused", success: true)
+        )
+        let service = BrewService(commandRunner: runner)
+
+        let action = Task { await service.performBrewAction(["upgrade"]) }
+        for _ in 0..<200 where !service.isPerformingAction {
+            try? await Task.sleep(for: .milliseconds(5))
+        }
+        service.cancelCurrentAction()
+        _ = await action.value
+
+        #expect(service.lastError == nil)
+        #expect(!service.isPerformingAction)
+        #expect(service.actionHistory.first?.status == .failure)
+        #expect(service.actionHistory.first?.output.contains("cancelled") == true)
+    }
+
+    @Test("upgradeSelected skips the cask command after cancellation")
+    func upgradeSelectedSkipsCasksAfterCancel() async {
+        let runner = StreamingMockRunner(
+            chunks: ["upgrading"],
+            chunkDelay: .seconds(30),
+            finalResult: CommandResult(output: "unused", success: true)
+        )
+        let service = BrewService(commandRunner: runner)
+        let packages = [
+            makePackage(name: "wget", source: .formula),
+            makePackage(name: "firefox", source: .cask)
+        ]
+
+        let action = Task { await service.upgradeSelected(packages: packages) }
+        for _ in 0..<200 where !service.isPerformingAction {
+            try? await Task.sleep(for: .milliseconds(5))
+        }
+        service.cancelCurrentAction()
+        await action.value
+
+        #expect(runner.streamedCommands == [["upgrade", "--", "wget"]])
+        #expect(service.lastError == nil)
+    }
+
+    @Test("upgradeAll cancellation does not raise the Mac App Store message")
+    func upgradeAllCancelSkipsMasMessage() async {
+        let runner = StreamingMockRunner(
+            chunks: ["upgrading"],
+            chunkDelay: .seconds(30),
+            finalResult: CommandResult(output: "unused", success: true)
+        )
+        let service = BrewService(commandRunner: runner)
+        service.outdatedPackages = [makePackage(name: "123456", source: .mas, isOutdated: true)]
+
+        let action = Task { await service.upgradeAll() }
+        for _ in 0..<200 where !service.canCancelCurrentAction {
+            try? await Task.sleep(for: .milliseconds(5))
+        }
+        service.cancelCurrentAction()
+        await action.value
+
+        #expect(service.lastError == nil)
+        #expect(!service.canCancelCurrentAction)
+    }
+}

--- a/BrewyTests/BrewBundleTests.swift
+++ b/BrewyTests/BrewBundleTests.swift
@@ -401,22 +401,21 @@ struct BrewServiceBundleTests {
         }
     }
 
-    @Test("dumpBundle never passes force and surfaces existing-file failure")
-    func dumpBundleExistingFileFailure() async throws {
+    @Test("dumpBundle passes force so a panel-confirmed replace overwrites")
+    func dumpBundleForcesOverwrite() async throws {
         let brewfile = try Self.makeBrewfile()
         let mock = MockCommandRunner()
         let (service, _) = makeService(mock: mock)
         mock.setResult(
-            for: ["bundle", "dump", "--file", brewfile.path],
-            output: "Error: Brewfile already exists at \(brewfile.path)\n",
+            for: ["bundle", "dump", "--force", "--file", brewfile.path],
+            output: "brew crashed\n",
             success: false
         )
 
         let result = await service.dumpBundle(to: brewfile)
 
         #expect(result.success == false)
-        #expect(mock.executedCommands == [["bundle", "dump", "--file", brewfile.path]])
-        #expect(mock.executedCommands[0].contains("--force") == false)
+        #expect(mock.executedCommands == [["bundle", "dump", "--force", "--file", brewfile.path]])
         #expect(service.lastError != nil)
         #expect(service.actionHistory.count == 1)
         #expect(service.actionHistory[0].status == .failure)
@@ -427,7 +426,7 @@ struct BrewServiceBundleTests {
         let brewfile = try Self.makeBrewfile()
         let mock = MockCommandRunner()
         let (service, _) = makeService(mock: mock)
-        mock.setResult(for: ["bundle", "dump", "--file", brewfile.path], output: "Using Brewfile\n")
+        mock.setResult(for: ["bundle", "dump", "--force", "--file", brewfile.path], output: "Using Brewfile\n")
         Self.setEmptyBundleListResults(mock, path: brewfile.path)
         mock.setResult(
             for: ["bundle", "check", "--verbose", "--file", brewfile.path],

--- a/BrewyTests/BundleRetryTests.swift
+++ b/BrewyTests/BundleRetryTests.swift
@@ -1,0 +1,44 @@
+@testable import Brewy
+import Foundation
+import Testing
+
+@Suite("Brew Bundle History Retry")
+@MainActor
+struct BundleRetryTests {
+    @Test("retrying bundle dump restores trust and refreshes bundle state")
+    func retryBundleDumpRestoresPostconditions() async throws {
+        let brewfile = try Self.makeBrewfile()
+        let arguments = ["bundle", "dump", "--force", "--file", brewfile.path]
+        let entry = ActionHistoryEntry(
+            id: UUID(), command: "bundle", arguments: arguments,
+            packageName: nil, packageSource: nil,
+            status: .failure, output: "brew crashed", timestamp: Date()
+        )
+        let mock = MockCommandRunner()
+        let (service, _) = makeService(mock: mock)
+        mock.setResult(for: arguments, output: "Using Brewfile\n")
+        for flag in ["--formula", "--cask", "--tap", "--mas"] {
+            mock.setResult(for: ["bundle", "list", flag, "--file", brewfile.path], output: "")
+        }
+        mock.setResult(
+            for: ["bundle", "check", "--verbose", "--file", brewfile.path],
+            output: "The Brewfile's dependencies are satisfied.\n"
+        )
+
+        await service.retryAction(entry)
+
+        #expect(service.customBrewfilePath == brewfile.path)
+        #expect(service.trustedBrewfilePath == brewfile.path)
+        #expect(!service.trustedBrewfileDigest.isEmpty)
+        #expect(service.bundleCheckStatus == .satisfied)
+    }
+
+    private static func makeBrewfile() throws -> URL {
+        let directory = FileManager.default.temporaryDirectory
+            .appendingPathComponent("BrewyBundleRetryTests-\(UUID().uuidString)", isDirectory: true)
+        try FileManager.default.createDirectory(at: directory, withIntermediateDirectories: true)
+        let brewfile = directory.appendingPathComponent("Brewfile")
+        try "".write(to: brewfile, atomically: true, encoding: .utf8)
+        return brewfile
+    }
+}

--- a/BrewyTests/CommandRunnerTests.swift
+++ b/BrewyTests/CommandRunnerTests.swift
@@ -1,4 +1,5 @@
 @testable import Brewy
+import Darwin
 import Foundation
 import Testing
 
@@ -154,5 +155,232 @@ struct CommandRunnerProcessTests {
         #expect(result.success)
         let lineCount = result.output.split(separator: "\n").count
         #expect(lineCount >= 10_000)
+    }
+
+    @Test("Task cancellation terminates the child process")
+    func cancellationTerminatesProcess() async {
+        let task = Task {
+            await CommandRunner.runExecutable("/bin/sh", arguments: ["-c", "sleep 30"])
+        }
+        try? await Task.sleep(for: .milliseconds(300))
+        let cancelStart = ContinuousClock.now
+        task.cancel()
+        let result = await task.value
+        let elapsed = ContinuousClock.now - cancelStart
+
+        #expect(!result.success)
+        #expect(result.cancelled)
+        #expect(result.output.contains("cancelled"))
+        #expect(elapsed < .seconds(10))
+    }
+
+    @Test("Cancellation before launch skips running the process")
+    func preCancelledSkipsLaunch() async {
+        let task = Task { () -> CommandResult in
+            // Cancelled during this sleep, so the command starts pre-cancelled.
+            try? await Task.sleep(for: .seconds(5))
+            return await CommandRunner.runExecutable("/bin/echo", arguments: ["never-runs"])
+        }
+        task.cancel()
+        let result = await task.value
+
+        #expect(!result.success)
+        #expect(result.cancelled)
+        #expect(!result.output.contains("never-runs"))
+    }
+
+    @Test("Cancelled result keeps partial output")
+    func cancelledResultKeepsPartialOutput() async {
+        let task = Task {
+            await CommandRunner.runExecutable(
+                "/bin/sh",
+                arguments: ["-c", "echo before-cancel; sleep 30"]
+            )
+        }
+        try? await Task.sleep(for: .milliseconds(500))
+        task.cancel()
+        let result = await task.value
+
+        #expect(result.cancelled)
+        #expect(result.output.contains("before-cancel"))
+    }
+
+    @Test("Cancellation kills descendants that ignore SIGTERM and hold pipes open")
+    func cancellationKillsProcessGroup() async throws {
+        let pidURL = FileManager.default.temporaryDirectory
+            .appendingPathComponent("brewy-descendant-\(UUID().uuidString).pid")
+        defer { try? FileManager.default.removeItem(at: pidURL) }
+        let script = """
+        (trap "" TERM HUP; sleep 30) &
+        child=$!
+        printf "%s" "$child" > "$1"
+        wait
+        """
+        let task = Task {
+            await CommandRunner.runExecutable(
+                "/bin/sh",
+                arguments: ["-c", script, "brewy-cancel-test", pidURL.path]
+            )
+        }
+        defer { task.cancel() }
+
+        for _ in 0..<1_000 where !FileManager.default.fileExists(atPath: pidURL.path) {
+            try await Task.sleep(for: .milliseconds(10))
+        }
+        let pidText = try String(contentsOf: pidURL, encoding: .utf8)
+        let descendantPID = try #require(Int32(pidText))
+        defer { kill(descendantPID, SIGKILL) }
+
+        let cancelStart = ContinuousClock.now
+        task.cancel()
+        let result = await task.value
+        let elapsed = ContinuousClock.now - cancelStart
+
+        for _ in 0..<200 where kill(descendantPID, 0) == 0 {
+            try await Task.sleep(for: .milliseconds(10))
+        }
+        #expect(result.cancelled)
+        #expect(elapsed < .seconds(10))
+        #expect(kill(descendantPID, 0) == -1)
+    }
+
+    @Test("Cancellation still reaches the group after its leader exits")
+    func cancellationAfterLeaderExitKillsProcessGroup() async throws {
+        let pidURL = FileManager.default.temporaryDirectory
+            .appendingPathComponent("brewy-exited-leader-\(UUID().uuidString).pid")
+        defer { try? FileManager.default.removeItem(at: pidURL) }
+        let script = """
+        (trap "" TERM HUP; sleep 30) &
+        child=$!
+        printf "%s %s" "$$" "$child" > "$1"
+        exit 0
+        """
+        let task = Task {
+            await CommandRunner.runExecutable(
+                "/bin/sh",
+                arguments: ["-c", script, "brewy-cancel-test", pidURL.path]
+            )
+        }
+        defer { task.cancel() }
+
+        for _ in 0..<1_000 where !FileManager.default.fileExists(atPath: pidURL.path) {
+            try await Task.sleep(for: .milliseconds(10))
+        }
+        let pids = try String(contentsOf: pidURL, encoding: .utf8)
+            .split(separator: " ")
+            .compactMap { Int32($0) }
+        #expect(pids.count == 2)
+        let leaderPID = try #require(pids.first)
+        let descendantPID = try #require(pids.last)
+        defer { kill(descendantPID, SIGKILL) }
+
+        for _ in 0..<200 where kill(leaderPID, 0) == 0 {
+            try await Task.sleep(for: .milliseconds(10))
+        }
+        #expect(kill(leaderPID, 0) == -1)
+        #expect(kill(descendantPID, 0) == 0)
+
+        let cancelStart = ContinuousClock.now
+        task.cancel()
+        let result = await task.value
+        let elapsed = ContinuousClock.now - cancelStart
+
+        for _ in 0..<200 where kill(descendantPID, 0) == 0 {
+            try await Task.sleep(for: .milliseconds(10))
+        }
+        #expect(result.cancelled)
+        #expect(elapsed < .seconds(10))
+        #expect(kill(descendantPID, 0) == -1)
+    }
+
+    @Test("Streaming delivers output and matches the final result")
+    func streamingDeliversOutput() async {
+        let chunks = LockedChunks()
+        let result = await CommandRunner.runExecutable(
+            "/bin/sh",
+            arguments: ["-c", "printf first; sleep 0.3; printf second"],
+            onOutput: { chunks.append($0) }
+        )
+
+        #expect(result.success)
+        #expect(chunks.joined() == "firstsecond")
+        #expect(result.output == "firstsecond")
+    }
+
+    @Test("Streaming forwards stderr as it arrives")
+    func streamingForwardsStderr() async {
+        let chunks = LockedChunks()
+        let result = await CommandRunner.runExecutable(
+            "/bin/sh",
+            arguments: ["-c", "echo err-line >&2; exit 1"],
+            onOutput: { chunks.append($0) }
+        )
+
+        #expect(!result.success)
+        #expect(chunks.joined().contains("err-line"))
+    }
+}
+
+/// Thread-safe chunk collector for streaming tests.
+private final class LockedChunks: @unchecked Sendable {
+    private let lock = NSLock()
+    private var chunks: [String] = []
+
+    func append(_ chunk: String) {
+        lock.withLock { chunks.append(chunk) }
+    }
+
+    func joined() -> String {
+        lock.withLock { chunks.joined() }
+    }
+}
+
+@Suite("UTF8StreamDecoder")
+struct UTF8StreamDecoderTests {
+
+    @Test("ASCII chunks pass straight through")
+    func asciiPassesThrough() {
+        var decoder = UTF8StreamDecoder()
+        #expect(decoder.decode(Data("hello ".utf8)) == "hello ")
+        #expect(decoder.decode(Data("world".utf8)) == "world")
+        #expect(decoder.flush().isEmpty)
+    }
+
+    @Test("Multi-byte scalar split across chunks reassembles")
+    func splitScalarReassembles() {
+        var decoder = UTF8StreamDecoder()
+        let arrow = Data("→".utf8) // 3 bytes: E2 86 92
+        var output = decoder.decode(Data("a".utf8) + arrow.prefix(2))
+        #expect(output == "a")
+        output += decoder.decode(arrow.suffix(1) + Data("b".utf8))
+        #expect(output == "a→b")
+        #expect(decoder.flush().isEmpty)
+    }
+
+    @Test("Four-byte emoji split across chunks reassembles")
+    func splitEmojiReassembles() {
+        var decoder = UTF8StreamDecoder()
+        let emoji = Data("🍺".utf8) // 4 bytes
+        var output = decoder.decode(emoji.prefix(1))
+        output += decoder.decode(emoji.dropFirst(1).prefix(2))
+        output += decoder.decode(emoji.suffix(1))
+        #expect(output == "🍺")
+    }
+
+    @Test("Flush emits held-back partial bytes as a replacement character")
+    func flushEmitsPending() {
+        var decoder = UTF8StreamDecoder()
+        let arrow = Data("→".utf8)
+        #expect(decoder.decode(arrow.prefix(2)).isEmpty)
+        // A truncated scalar is one maximal subpart, so it decodes to a single U+FFFD.
+        #expect(decoder.flush() == "\u{FFFD}")
+    }
+
+    @Test("Invalid lead byte decodes as replacement instead of stalling")
+    func invalidLeadByteDecodes() {
+        var decoder = UTF8StreamDecoder()
+        let output = decoder.decode(Data([0x61, 0xFF]))
+        #expect(output == "a\u{FFFD}")
+        #expect(decoder.flush().isEmpty)
     }
 }

--- a/BrewyTests/CommandRunnerTests.swift
+++ b/BrewyTests/CommandRunnerTests.swift
@@ -45,6 +45,76 @@ struct MockCommandRunnerBehaviorTests {
     }
 }
 
+@Suite("Command Timeout Selection")
+struct CommandTimeoutSelectionTests {
+
+    @Test("Mutating verbs get the extended timeout", arguments: [
+        ["install", "--", "wget"],
+        ["uninstall", "--cask", "--", "firefox"],
+        ["reinstall", "--", "wget"],
+        ["upgrade"],
+        ["upgrade", "--cask", "--", "firefox"],
+        ["fetch", "--", "wget"],
+        ["bundle", "dump", "--file", "/tmp/Brewfile"],
+        ["update"],
+        ["cleanup", "--prune=all", "-s"],
+        ["autoremove"],
+        ["tap", "user/repo"],
+        ["untap", "user/repo"]
+    ])
+    func mutatingVerbsGetExtendedTimeout(arguments: [String]) {
+        #expect(CommandRunner.timeout(forBrewArguments: arguments) == CommandRunner.extendedTimeout)
+    }
+
+    @Test("Read-only verbs keep the default timeout", arguments: [
+        ["info", "--installed", "--json=v2"],
+        ["outdated", "--json=v2"],
+        ["search", "--formula", "--", "wget"],
+        ["doctor"],
+        ["services", "list", "--json"],
+        ["config"],
+        ["tap-info", "--json=v1", "--installed"],
+        []
+    ])
+    func readOnlyVerbsKeepDefaultTimeout(arguments: [String]) {
+        #expect(CommandRunner.timeout(forBrewArguments: arguments) == CommandRunner.defaultTimeout)
+    }
+
+    @Test("Extended timeout comfortably exceeds the default")
+    func extendedExceedsDefault() {
+        #expect(CommandRunner.extendedTimeout > CommandRunner.defaultTimeout)
+    }
+}
+
+@Suite("BrewService Timeout Propagation")
+@MainActor
+struct BrewServiceTimeoutPropagationTests {
+
+    @Test("Package actions pass the extended timeout")
+    func actionUsesExtendedTimeout() async {
+        let mock = MockCommandRunner()
+        let (service, _) = makeService(mock: mock)
+        setupRefreshMock(mock)
+        mock.setResult(for: ["install", "--", "wget"], output: "ok")
+
+        await service.install(package: makePackage(name: "wget", source: .formula))
+
+        #expect(mock.recordedTimeout(for: ["install", "--", "wget"]) == CommandRunner.extendedTimeout)
+    }
+
+    @Test("Refresh fetches keep the default timeout")
+    func fetchesUseDefaultTimeout() async {
+        let mock = MockCommandRunner()
+        let (service, _) = makeService(mock: mock)
+        setupRefreshMock(mock)
+
+        await service.refresh()
+
+        #expect(mock.recordedTimeout(for: ["info", "--installed", "--json=v2"]) == CommandRunner.defaultTimeout)
+        #expect(mock.recordedTimeout(for: ["outdated", "--json=v2"]) == CommandRunner.defaultTimeout)
+    }
+}
+
 // `/Users/runner` is the GitHub Actions runner home; `CI` / `GITHUB_ACTIONS`
 // don't reliably reach the test host under `xcodebuild test`.
 @Suite(

--- a/BrewyTests/ErrorPersistenceTests.swift
+++ b/BrewyTests/ErrorPersistenceTests.swift
@@ -20,6 +20,19 @@ struct ErrorPersistenceTests {
         #expect(service.lastError?.localizedDescription.contains("Refusing to untap") == true)
     }
 
+    @Test("addTap exposes the full failed command to the root error presenter")
+    func addTapExposesGlobalFailure() async {
+        let mock = MockCommandRunner()
+        let (service, _) = makeService(mock: mock)
+        setupRefreshMock(mock)
+        mock.setResult(for: ["tap", "user/repo"], output: "", success: false)
+
+        let result = await service.addTap(name: "user/repo")
+
+        #expect(!result.success)
+        #expect(service.lastError?.localizedDescription == "brew tap user/repo failed.")
+    }
+
     @Test("performBrewAction preserves command failure after refresh")
     func brewActionPreservesFailureAfterRefresh() async {
         let mock = MockCommandRunner()

--- a/BrewyTests/HistoryTests.swift
+++ b/BrewyTests/HistoryTests.swift
@@ -143,6 +143,20 @@ struct ActionHistoryEntryTests {
         #expect(entry.isMutatingCommand == false)
     }
 
+    @Test("bundle dump requires retry confirmation and exposes its file")
+    func bundleDumpIsMutating() {
+        let entry = ActionHistoryEntry(
+            id: UUID(), command: "bundle",
+            arguments: ["bundle", "dump", "--force", "--file", "/tmp/Brewfile"],
+            packageName: nil, packageSource: nil,
+            status: .failure, output: "Error", timestamp: Date()
+        )
+
+        #expect(entry.isMutatingCommand)
+        #expect(entry.isBundleDump)
+        #expect(entry.bundleDumpURL?.path == "/tmp/Brewfile")
+    }
+
     @Test("Status raw values encode correctly")
     func statusRawValues() {
         #expect(ActionHistoryEntry.Status.success.rawValue == "success")

--- a/BrewyTests/TestHelpers.swift
+++ b/BrewyTests/TestHelpers.swift
@@ -10,6 +10,7 @@ final class MockCommandRunner: CommandRunning, @unchecked Sendable {
     private var _delays: [[String]: Duration] = [:]
     private var _executedCommands: [[String]] = []
     private var _executedExecutables: [(path: String, arguments: [String])] = []
+    private var _recordedTimeouts: [[String]: Duration] = [:]
 
     var executedCommands: [[String]] {
         lock.withLock { _executedCommands }
@@ -33,10 +34,16 @@ final class MockCommandRunner: CommandRunning, @unchecked Sendable {
         }
     }
 
+    /// The timeout the service passed for these arguments (last invocation wins).
+    func recordedTimeout(for arguments: [String]) -> Duration? {
+        lock.withLock { _recordedTimeouts[arguments] }
+    }
+
     func run(_ arguments: [String], brewPath: String, timeout: Duration) async -> CommandResult {
         let (delay, result) = lock.withLock {
             _executedCommands.append(arguments)
             _executedExecutables.append((path: brewPath, arguments: arguments))
+            _recordedTimeouts[arguments] = timeout
             return (_delays[arguments], _results[arguments] ?? CommandResult(output: "", success: false))
         }
         if let delay {
@@ -49,6 +56,7 @@ final class MockCommandRunner: CommandRunning, @unchecked Sendable {
         let (delay, result) = lock.withLock {
             _executedCommands.append(arguments)
             _executedExecutables.append((path: executablePath, arguments: arguments))
+            _recordedTimeouts[arguments] = timeout
             return (_delays[arguments], _results[arguments] ?? CommandResult(output: "", success: false))
         }
         if let delay {


### PR DESCRIPTION
Four commits covering command execution, timeouts, the action UI, and Brewfile dump consent.

CommandRunner buffered both pipes to EOF and ran the process inside a detached task that ignored Swift cancellation, so a debounce-cancelled search or MaintenanceView's doctorTask.cancel() abandoned the child without stopping it, and callers saw nothing until the command finished. Output is now read incrementally and forwarded as it arrives, holding back a trailing partial UTF-8 scalar so a multi-byte character split across reads never renders as a replacement character.

Cancellation signals the child's process group rather than its pid. brew is a driver that shells out to curl, git, and cask installers; signalling only the direct pid left those descendants running, and because they inherit the stdout and stderr write ends the drain could not reach EOF, so the call did not return until they exited on their own. Foundation launches the child as its own group leader, which is verified before signalling so a non-leader falls back to the direct process and Brewy's own group is never a target. The post-exit drain is bounded so a surviving writer cannot stall the return either.

Mutating verbs get an hour-long timeout instead of a flat 300 seconds. A large upgrade, a bundle install, or a cask download on a slow connection was previously SIGTERMed then SIGKILLed at five minutes, possibly while brew was mid-link, leaving a possibly broken keg behind a "Command timed out" message. Read-only fetches keep the short timeout so a wedged refresh still gives up quickly.

isPerformingAction blocked the UI behind a bare "Running..." spinner with no progress and no way out. Two views had their own overlay, while Maintenance, Bundle, Taps, Mac App Store setup, and the Upgrade All entry points had neither, which combined with the longer timeout would have made those the worst places to be stuck. One overlay now sits at the root of ContentView so every action surface gets live output and Cancel, and all eight action paths route through a shared streaming helper. The overlay distinguishes a running command from the refresh that follows it, so Cancel is offered only while there is something to cancel. Cancellation is treated as user intent: cancelled results skip the error alert, history records the partial output, and upgradeSelected stops before the cask leg. The displayed buffer is byte-bounded so a long upgrade cannot grow it without limit and stall the main actor rendering it, while the full output still reaches history and errors.

`brew bundle dump` refuses to overwrite without --force, so "Create from Installed Packages" failed against an existing file even after the user confirmed Replace in the save panel. It now passes --force, treating the panel as the consent step. That inverts a previously pinned test, so the consent has to hold everywhere the command can run again: history classified `bundle` as non-mutating, which meant a failed dump could be replayed from the History detail with one click and no confirmation, overwriting whatever now sits at that path without the panel that authorised --force. A bundle dump is now treated as mutating so retry goes through the confirmation dialog, and a successful retry restores the trust digest and bundle state.

Two known gaps. The overlay has no automated UI coverage, so the presentation is unverified even though the behaviour underneath is unit tested, including real-process cancellation with a descendant that ignores SIGTERM and holds the pipes open. Separately, "Cancelled result keeps partial output" is timing-sensitive and has been observed to fail once locally when the bounded drain deadline expires before the partial output is collected; it is worth watching on the sanitizer legs.
