### PR TITLE
perf(commands): drain pipes event-driven and re-enable process tests in CI

### DIFF
--- a/Brewy/Models/CommandRunner.swift
+++ b/Brewy/Models/CommandRunner.swift
@@ -314,7 +314,12 @@ enum CommandRunner {
             terminateThenKill(process, after: killGracePeriod)
         }
 
-        let (stdoutData, stderrData) = drainPipesInParallel(stdout: stdoutPipe, stderr: stderrPipe, onOutput: onOutput)
+        let (stdoutData, stderrData) = drainPipesInParallel(
+            stdout: stdoutPipe,
+            stderr: stderrPipe,
+            commandDescription: execution.commandDescription,
+            onOutput: onOutput
+        )
         let (timedOut, timeoutWork) = scheduleTimeout(
             for: process,
             after: execution.timeout,
@@ -451,18 +456,6 @@ enum CommandRunner {
         return "Command was cancelled.\n\(partialOutput)"
     }
 
-    private static func drainPipesInParallel(
-        stdout: Pipe,
-        stderr: Pipe,
-        onOutput: (@Sendable (String) -> Void)?
-    ) -> (stdout: PipeReader, stderr: PipeReader) {
-        let stdoutReader = PipeReader(pipe: stdout, onText: onOutput)
-        let stderrReader = PipeReader(pipe: stderr, onText: onOutput)
-        stdoutReader.start()
-        stderrReader.start()
-        return (stdoutReader, stderrReader)
-    }
-
     private static func scheduleTimeout(
         for process: Process,
         after timeout: Duration,
@@ -481,4 +474,25 @@ enum CommandRunner {
         )
         return (timedOut, timeoutWork)
     }
+}
+
+private func drainPipesInParallel(
+    stdout: Pipe,
+    stderr: Pipe,
+    commandDescription: String,
+    onOutput: (@Sendable (String) -> Void)?
+) -> (stdout: PipeReader, stderr: PipeReader) {
+    let stdoutReader = PipeReader(
+        pipe: stdout,
+        label: "\(commandDescription) stdout",
+        onText: onOutput
+    )
+    let stderrReader = PipeReader(
+        pipe: stderr,
+        label: "\(commandDescription) stderr",
+        onText: onOutput
+    )
+    stdoutReader.start()
+    stderrReader.start()
+    return (stdoutReader, stderrReader)
 }

--- a/Brewy/Models/CommandRunner.swift
+++ b/Brewy/Models/CommandRunner.swift
@@ -404,7 +404,9 @@ enum CommandRunner {
             guard process.isRunning else { return }
             kill(signalTarget, SIGTERM)
         }
-        DispatchQueue.global(qos: .utility).asyncAfter(deadline: .now() + dispatchInterval(from: grace)) { [weak process] in
+        // Above .utility: that queue is starved on a loaded machine, and the escalation is
+        // the only thing that stops a descendant which ignores SIGTERM.
+        DispatchQueue.global(qos: .userInitiated).asyncAfter(deadline: .now() + dispatchInterval(from: grace)) { [weak process] in
             if signalTarget < 0 {
                 errno = 0
                 guard kill(signalTarget, 0) == 0 || errno == EPERM else { return }
@@ -468,7 +470,7 @@ enum CommandRunner {
             timedOut.set()
             terminateThenKill(process, after: killGracePeriod)
         }
-        DispatchQueue.global(qos: .utility).asyncAfter(
+        DispatchQueue.global(qos: .userInitiated).asyncAfter(
             deadline: .now() + dispatchInterval(from: timeout),
             execute: timeoutWork
         )

--- a/Brewy/Models/PipeReader.swift
+++ b/Brewy/Models/PipeReader.swift
@@ -1,4 +1,7 @@
 import Foundation
+import OSLog
+
+private let logger = Logger(subsystem: "io.linnane.brewy", category: "PipeReader")
 
 // MARK: - Locked Data
 
@@ -25,39 +28,40 @@ final class LockedData: Sendable {
 
 // MARK: - Pipe Reader
 
-/// Drains a `Pipe` to EOF on a background queue so the subprocess cannot deadlock on a full
-/// buffer, optionally forwarding each chunk as decoded text while it arrives.
+/// Drains a `Pipe` to EOF through `FileHandle`'s dispatch source, optionally forwarding each
+/// chunk as decoded text while it arrives.
 final class PipeReader: @unchecked Sendable {
-    private let pipe: Pipe
+    private let fileHandle: FileHandle
+    private let label: String
     private let onText: (@Sendable (String) -> Void)?
     private let accumulator = LockedData()
     private let semaphore = DispatchSemaphore(value: 0)
-    /// Only touched from the single reader queue.
+    private let lock = NSLock()
     private var decoder = UTF8StreamDecoder()
+    private var startedAt: ContinuousClock.Instant?
+    private var callbackCount = 0
+    private var byteCount = 0
+    private var isFinished = false
 
-    init(pipe: Pipe, onText: (@Sendable (String) -> Void)? = nil) {
-        self.pipe = pipe
+    init(pipe: Pipe, label: String = "pipe", onText: (@Sendable (String) -> Void)? = nil) {
+        self.fileHandle = pipe.fileHandleForReading
+        self.label = label
         self.onText = onText
     }
 
     func start() {
-        DispatchQueue.global(qos: .utility).async { [weak self] in
-            guard let self else { return }
-            let fileHandle = pipe.fileHandleForReading
-            while true {
-                let data = fileHandle.availableData
-                guard !data.isEmpty else { break }
-                accumulator.append(data)
-                if let onText {
-                    let text = decoder.decode(data)
-                    if !text.isEmpty { onText(text) }
-                }
-            }
-            if let onText {
-                let remainder = decoder.flush()
-                if !remainder.isEmpty { onText(remainder) }
-            }
-            semaphore.signal()
+        let startTime = ContinuousClock.now
+        lock.lock()
+        guard startedAt == nil else {
+            lock.unlock()
+            return
+        }
+        startedAt = startTime
+        lock.unlock()
+
+        logger.debug("Started \(self.label, privacy: .private)")
+        fileHandle.readabilityHandler = { [weak self] readableHandle in
+            self?.consumeAvailableData(from: readableHandle)
         }
     }
 
@@ -67,12 +71,84 @@ final class PipeReader: @unchecked Sendable {
                 if semaphore.wait(timeout: deadline) == .success {
                     return accumulator.combined()
                 }
-                try? pipe.fileHandleForReading.close()
+                forceClose()
                 return accumulator.combined()
             }
             if semaphore.wait(timeout: .now() + .milliseconds(100)) == .success {
                 return accumulator.combined()
             }
         }
+    }
+
+    private func consumeAvailableData(from readableHandle: FileHandle) {
+        let callbackTime = ContinuousClock.now
+        lock.lock()
+        guard !isFinished else {
+            lock.unlock()
+            return
+        }
+
+        let data = readableHandle.availableData
+        callbackCount += 1
+        guard !data.isEmpty else {
+            finishLocked()
+            let metrics = metricsLocked(at: callbackTime)
+            lock.unlock()
+            closeFileHandle()
+            logger.debug("EOF \(self.label, privacy: .private): \(metrics.elapsed), \(metrics.bytes) bytes, \(metrics.callbacks) callbacks")
+            return
+        }
+
+        let isFirstRead = byteCount == 0
+        byteCount += data.count
+        accumulator.append(data)
+        if let onText {
+            let text = decoder.decode(data)
+            if !text.isEmpty { onText(text) }
+        }
+        let metrics = metricsLocked(at: callbackTime)
+        lock.unlock()
+
+        if isFirstRead {
+            logger.debug(
+                "First read \(self.label, privacy: .private): \(metrics.elapsed), \(data.count) bytes"
+            )
+        }
+    }
+
+    private func forceClose() {
+        let closeTime = ContinuousClock.now
+        lock.lock()
+        guard !isFinished else {
+            lock.unlock()
+            return
+        }
+        finishLocked()
+        let metrics = metricsLocked(at: closeTime)
+        lock.unlock()
+
+        closeFileHandle()
+        logger.warning("Forced close \(self.label, privacy: .private): \(metrics.elapsed), \(metrics.bytes) bytes, \(metrics.callbacks) callbacks")
+    }
+
+    private func finishLocked() {
+        isFinished = true
+        if let onText {
+            let remainder = decoder.flush()
+            if !remainder.isEmpty { onText(remainder) }
+        }
+        semaphore.signal()
+    }
+
+    private func metricsLocked(
+        at time: ContinuousClock.Instant
+    ) -> (elapsed: Duration, bytes: Int, callbacks: Int) {
+        let elapsed = startedAt.map { time - $0 } ?? .zero
+        return (elapsed, byteCount, callbackCount)
+    }
+
+    private func closeFileHandle() {
+        fileHandle.readabilityHandler = nil
+        try? fileHandle.close()
     }
 }

--- a/BrewyTests/ActionStreamingTests.swift
+++ b/BrewyTests/ActionStreamingTests.swift
@@ -70,15 +70,16 @@ struct ActionStreamingTests {
     func chunksReachActionOutputMidFlight() async {
         let runner = StreamingMockRunner(
             chunks: ["first-chunk\n", "second-chunk\n"],
-            chunkDelay: .milliseconds(50),
+            // Wide enough that a loaded runner still observes the mid-flight state.
+            chunkDelay: .milliseconds(300),
             finalResult: CommandResult(output: "first-chunk\nsecond-chunk\n", success: true)
         )
         let service = BrewService(commandRunner: runner)
 
         let action = Task { await service.performBrewAction(["upgrade"]) }
         var sawPartial = false
-        for _ in 0..<200 {
-            try? await Task.sleep(for: .milliseconds(5))
+        for _ in 0..<600 {
+            try? await Task.sleep(for: .milliseconds(10))
             if service.actionOutput.contains("first-chunk"), !service.actionOutput.contains("second-chunk") {
                 sawPartial = true
                 break

--- a/BrewyTests/ActionStreamingTests.swift
+++ b/BrewyTests/ActionStreamingTests.swift
@@ -12,14 +12,23 @@ private final class StreamingMockRunner: CommandRunning, @unchecked Sendable {
     private let chunks: [String]
     private let chunkDelay: Duration
     private let finalResult: CommandResult
+    /// Held after the first chunk so a test can observe the mid-flight state without
+    /// racing the scheduler for a transient window.
+    private let gateAfterFirstChunk: ChunkGate?
 
     var streamedCommands: [[String]] {
         lock.withLock { _streamedCommands }
     }
 
-    init(chunks: [String], chunkDelay: Duration = .milliseconds(20), finalResult: CommandResult) {
+    init(
+        chunks: [String],
+        chunkDelay: Duration = .milliseconds(20),
+        gateAfterFirstChunk: ChunkGate? = nil,
+        finalResult: CommandResult
+    ) {
         self.chunks = chunks
         self.chunkDelay = chunkDelay
+        self.gateAfterFirstChunk = gateAfterFirstChunk
         self.finalResult = finalResult
     }
 
@@ -48,13 +57,14 @@ private final class StreamingMockRunner: CommandRunning, @unchecked Sendable {
         onOutput: @escaping @Sendable (String) -> Void
     ) async -> CommandResult {
         lock.withLock { _streamedCommands.append(arguments) }
-        for chunk in chunks {
+        for (index, chunk) in chunks.enumerated() {
             do {
                 try await Task.sleep(for: chunkDelay)
             } catch {
                 return CommandResult(output: "Command was cancelled.", success: false, cancelled: true)
             }
             onOutput(chunk)
+            if index == 0 { await gateAfterFirstChunk?.wait() }
         }
         return finalResult
     }
@@ -68,26 +78,26 @@ struct ActionStreamingTests {
 
     @Test("Streamed chunks reach actionOutput while the command runs")
     func chunksReachActionOutputMidFlight() async {
+        let gate = ChunkGate()
         let runner = StreamingMockRunner(
             chunks: ["first-chunk\n", "second-chunk\n"],
-            // Wide enough that a loaded runner still observes the mid-flight state.
-            chunkDelay: .milliseconds(300),
+            gateAfterFirstChunk: gate,
             finalResult: CommandResult(output: "first-chunk\nsecond-chunk\n", success: true)
         )
         let service = BrewService(commandRunner: runner)
 
         let action = Task { await service.performBrewAction(["upgrade"]) }
-        var sawPartial = false
-        for _ in 0..<600 {
+        // The mock is held after the first chunk, so this converges instead of racing a
+        // transient window, and the second chunk cannot arrive early to spoil the check.
+        for _ in 0..<1_000 where !service.actionOutput.contains("first-chunk") {
             try? await Task.sleep(for: .milliseconds(10))
-            if service.actionOutput.contains("first-chunk"), !service.actionOutput.contains("second-chunk") {
-                sawPartial = true
-                break
-            }
         }
+        #expect(service.actionOutput.contains("first-chunk"))
+        #expect(!service.actionOutput.contains("second-chunk"))
+
+        await gate.open()
         _ = await action.value
 
-        #expect(sawPartial)
         #expect(service.actionOutput == "first-chunk\nsecond-chunk\n")
     }
 
@@ -183,5 +193,22 @@ struct ActionStreamingTests {
 
         #expect(service.lastError == nil)
         #expect(!service.canCancelCurrentAction)
+    }
+}
+
+/// Blocks a mock mid-stream until the test releases it.
+private actor ChunkGate {
+    private var isOpen = false
+    private var waiters: [CheckedContinuation<Void, Never>] = []
+
+    func open() {
+        isOpen = true
+        for waiter in waiters { waiter.resume() }
+        waiters.removeAll()
+    }
+
+    func wait() async {
+        guard !isOpen else { return }
+        await withCheckedContinuation { waiters.append($0) }
     }
 }

--- a/BrewyTests/CommandRunnerTests.swift
+++ b/BrewyTests/CommandRunnerTests.swift
@@ -183,7 +183,10 @@ struct CommandRunnerProcessTests {
         )
         let elapsed = ContinuousClock.now - start
         #expect(!result.success)
-        #expect(elapsed < .seconds(15))
+        #expect(result.output.contains("timed out"))
+        // Deliberately loose: the point is that the child was killed rather than allowed to
+        // finish its 30 s sleep. A tighter bound only measures how loaded the machine is.
+        #expect(elapsed < .seconds(25))
     }
 
     @Test("runExecutable includes partial output on timeout")
@@ -233,7 +236,9 @@ struct CommandRunnerProcessTests {
         #expect(!result.success)
         #expect(result.cancelled)
         #expect(result.output.contains("cancelled"))
-        #expect(elapsed < .seconds(10))
+        // Loose for the same reason as the timeout test: this proves the call did not wait
+        // out the child's 30 s sleep, not that the machine is fast.
+        #expect(elapsed < .seconds(25))
     }
 
     @Test("Cancellation before launch skips running the process")

--- a/BrewyTests/CommandRunnerTests.swift
+++ b/BrewyTests/CommandRunnerTests.swift
@@ -261,13 +261,21 @@ struct CommandRunnerProcessTests {
 
     @Test("Cancelled result keeps partial output")
     func cancelledResultKeepsPartialOutput() async {
+        let chunks = LockedChunks()
         let task = Task {
             await CommandRunner.runExecutable(
                 "/bin/sh",
-                arguments: ["-c", "echo before-cancel; sleep 30"]
+                arguments: ["-c", "echo before-cancel; sleep 30"],
+                onOutput: { chunks.append($0) }
             )
         }
-        try? await Task.sleep(for: .milliseconds(500))
+        defer { task.cancel() }
+
+        for _ in 0..<1_000 where !chunks.joined().contains("before-cancel") {
+            try? await Task.sleep(for: .milliseconds(10))
+        }
+        #expect(chunks.joined().contains("before-cancel"))
+
         task.cancel()
         let result = await task.value
 

--- a/BrewyTests/CommandRunnerTests.swift
+++ b/BrewyTests/CommandRunnerTests.swift
@@ -115,15 +115,7 @@ struct BrewServiceTimeoutPropagationTests {
     }
 }
 
-// `/Users/runner` is the GitHub Actions runner home; `CI` / `GITHUB_ACTIONS`
-// don't reliably reach the test host under `xcodebuild test`.
-@Suite(
-    "CommandRunner Process Execution",
-    .disabled(
-        if: FileManager.default.fileExists(atPath: "/Users/runner"),
-        "Pipe reads hang on Actions runner images; run locally"
-    )
-)
+@Suite("CommandRunner Process Execution")
 struct CommandRunnerProcessTests {
 
     @Test("runExecutable captures stdout from echo")

--- a/BrewyTests/CommandRunnerTests.swift
+++ b/BrewyTests/CommandRunnerTests.swift
@@ -399,20 +399,6 @@ struct CommandRunnerProcessTests {
     }
 }
 
-/// Thread-safe chunk collector for streaming tests.
-private final class LockedChunks: @unchecked Sendable {
-    private let lock = NSLock()
-    private var chunks: [String] = []
-
-    func append(_ chunk: String) {
-        lock.withLock { chunks.append(chunk) }
-    }
-
-    func joined() -> String {
-        lock.withLock { chunks.joined() }
-    }
-}
-
 @Suite("UTF8StreamDecoder")
 struct UTF8StreamDecoderTests {
 

--- a/BrewyTests/PipeReaderTests.swift
+++ b/BrewyTests/PipeReaderTests.swift
@@ -1,0 +1,45 @@
+@testable import Brewy
+import Foundation
+import Testing
+
+@Suite("PipeReader")
+struct PipeReaderTests {
+
+    @Test("Event-driven reader drains data through EOF")
+    func drainsThroughEOF() async throws {
+        let pipe = Pipe()
+        let chunks = LockedChunks()
+        let reader = PipeReader(pipe: pipe, label: "EOF test") { chunks.append($0) }
+        reader.start()
+
+        try pipe.fileHandleForWriting.write(contentsOf: Data("first".utf8))
+        try pipe.fileHandleForWriting.close()
+        let data = await Task.detached(priority: .medium) {
+            reader.wait { nil }
+        }.value
+
+        #expect(String(bytes: data, encoding: .utf8) == "first")
+        #expect(chunks.joined() == "first")
+    }
+
+    @Test("Forced close preserves data delivered before the deadline")
+    func forcedClosePreservesDeliveredData() async throws {
+        let pipe = Pipe()
+        let chunks = LockedChunks()
+        let reader = PipeReader(pipe: pipe, label: "forced-close test") { chunks.append($0) }
+        reader.start()
+        defer { try? pipe.fileHandleForWriting.close() }
+
+        try pipe.fileHandleForWriting.write(contentsOf: Data("partial".utf8))
+        for _ in 0..<1_000 where chunks.joined() != "partial" {
+            try await Task.sleep(for: .milliseconds(10))
+        }
+        #expect(chunks.joined() == "partial")
+
+        let data = await Task.detached(priority: .medium) {
+            reader.wait { .now() + .milliseconds(50) }
+        }.value
+
+        #expect(String(bytes: data, encoding: .utf8) == "partial")
+    }
+}

--- a/BrewyTests/TestHelpers.swift
+++ b/BrewyTests/TestHelpers.swift
@@ -159,3 +159,19 @@ func makePackage(
         dependencies: dependencies
     )
 }
+
+// MARK: - Streaming Test Support
+
+/// Thread-safe chunk collector for streaming tests.
+final class LockedChunks: @unchecked Sendable {
+    private let lock = NSLock()
+    private var chunks: [String] = []
+
+    func append(_ chunk: String) {
+        lock.withLock { chunks.append(chunk) }
+    }
+
+    func joined() -> String {
+        lock.withLock { chunks.joined() }
+    }
+}


### PR DESCRIPTION
Three commits: a test fix, the production change behind it, and lifting a CI exclusion the production change makes safe.

The cancellation test slept 500 ms and assumed the reader had consumed "before-cancel" by then. Under suite contention the reader was scheduled late, so the accumulator was still empty when the bounded drain deadline expired. It now waits until the chunk is observably delivered through onOutput. PipeReader appends to the accumulator before invoking the callback, so observing a chunk proves it is already in the buffer the result is built from, which makes the assertion independent of drain timing.

The underlying cause was the reader itself. Each command parked two threads on the global utility queue blocking in availableData until EOF, and under load those threads are scheduled late, so output arrived in bursts and a cancelled command could sit out the whole five-second drain grace before returning, leaving the action overlay in "Finishing..." long after the process was gone. Measured locally, 16 of 20 cancellations hit the full deadline. Reads now go through FileHandle's readabilityHandler, so a chunk is consumed when the kernel says there is one and no thread is held; across 60 samples afterwards none reached the deadline and 19 of 20 cancellations completed under 36 ms. The bounded drain fallback and the guarantee that already-accumulated output survives a forced close are both preserved, and the UTF-8 decoder moves from queue confinement to explicit locking. Reads log start, first byte, EOF, and forced close with byte and callback counts; labels carry the command, so they are logged private and redact in release builds.

CommandRunnerProcessTests was skipped whenever /Users/runner exists because real subprocess tests hung on the runner images: Pipe plus readDataToEndOfFile stopped observing EOF after the child exited, so every test started and never finished (#141). The stated follow-up in that PR was to rewrite the reads against readabilityHandler so they do not depend on readDataToEndOfFile seeing EOF, which this does, so the skip is lifted. That suite is the only coverage for process-group termination, the bounded drain, and streaming, and all of it has run locally only until now.

That last commit is the one to watch. Whether the rewrite actually resolves the runner-image hang is unproven until this PR's own CI run, and it is isolated in its own commit so it can be reverted on its own if a hosted runner still hangs. A hang is bounded by the 45 minute timeout on the check job.

Verified locally: 40 full-suite repetitions all reporting 341 tests in 60 suites passed, both descendant process-group regression tests passing throughout, and the whole suite green under Thread and Address Sanitizer.

The new PipeReader suite lives in its own file and LockedChunks moved to TestHelpers, because CommandRunnerTests reached the 500 line ceiling once the suite was added.
