### PR TITLE
ci: resolve stable Homebrew before the cask bump

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -346,6 +346,11 @@ jobs:
     env:
       VERSION: ${{ needs.build.outputs.tag }}
     steps:
+      - name: Set up Homebrew
+        uses: Homebrew/actions/setup-homebrew@df4b09108a1de9d6f995fe68f302b3f68bd6d2ef # 2026.07.20.1
+        with:
+          stable: true
+
       - name: Mint bot token for tap
         id: tap-token
         uses: actions/create-github-app-token@bcd2ba49218906704ab6c1aa796996da409d3eb1 # v3.2.0


### PR DESCRIPTION
Resolve the latest stable Homebrew tag in the `bump-cask` job with the SHA-pinned `setup-homebrew` action before running `brew bump-cask-pr`, instead of using whatever brew the macos-26 runner image bakes. This keeps the brew that writes cask bumps aligned with the tap CI's move to stable-tag Homebrew, closing the skew where an image-lagged brew formats a cask that the tap's newer stable style check rejects.

AI disclosure: prepared with Claude Code (Claude Fable 5), which authored the workflow edit and ran the local checks (`zizmor --persona auditor`, `pinprick audit`, actionlint, all clean); the diff and check output were reviewed by the maintainer before this PR was opened.