### PR TITLE
feat(settings): add a toggle to hide the menu bar icon

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -41,7 +41,7 @@ Please follow these guidelines when contributing.
 - `Brewy/Models/TapHealthChecker.swift`: GitHub API tap health checks for archived, moved, and missing taps.
 - `Brewy/Views/`: SwiftUI views for navigation, lists, details, services, groups, history, settings, maintenance, taps, and release notes.
 - `BrewyTests/`: Swift Testing unit tests and shared `MockCommandRunner` helpers.
-- `BrewyUITests/`: sidebar navigation UI tests.
+- `BrewyUITests/`: macOS UI tests for navigation and settings behavior.
 - `.github/workflows/ci.yml`: PR/push checks with dynamic matrix.
 - `.github/workflows/link-check.yml`: weekly README and CONTRIBUTING link check.
 - `.github/workflows/release.yml`: manual release workflow for archive, signing, notarization, Sparkle signing, appcast, GitHub release, and tap cask bump.

--- a/Brewy.xcodeproj/xcshareddata/xcschemes/Brewy.xcscheme
+++ b/Brewy.xcodeproj/xcshareddata/xcschemes/Brewy.xcscheme
@@ -67,7 +67,7 @@
          </TestableReference>
          <TestableReference
             skipped = "NO"
-            parallelizable = "YES">
+            parallelizable = "NO">
             <BuildableReference
                BuildableIdentifier = "primary"
                BlueprintIdentifier = "CD5C118B2F4D38C10022A138"

--- a/Brewy/BrewyApp.swift
+++ b/Brewy/BrewyApp.swift
@@ -25,6 +25,8 @@ struct BrewyApp: App {
     private var appTheme = AppTheme.system.rawValue
     @AppStorage("appIcon")
     private var appIcon = AppIconSelection.current.rawValue
+    @AppStorage("showMenuBarIcon")
+    private var showMenuBarIcon = true
 
     private static func colorScheme(for appearance: NSAppearance) -> ColorScheme? {
         switch appearance.bestMatch(from: [.aqua, .darkAqua]) {
@@ -93,7 +95,7 @@ struct BrewyApp: App {
             SettingsView()
         }
 
-        MenuBarExtra {
+        MenuBarExtra(isInserted: $showMenuBarIcon) {
             MenuBarView()
                 .environment(brewService)
         } label: {

--- a/Brewy/Views/SettingsView.swift
+++ b/Brewy/Views/SettingsView.swift
@@ -31,6 +31,8 @@ struct SettingsView: View {
     private var appTheme = AppTheme.system.rawValue
     @AppStorage("appIcon")
     private var appIcon = AppIconSelection.current.rawValue
+    @AppStorage("showMenuBarIcon")
+    private var showMenuBarIcon = true
 
     private var isBrewPathValid: Bool {
         FileManager.default.isExecutableFile(atPath: brewPath)
@@ -88,6 +90,10 @@ struct SettingsView: View {
                 }
             }
 
+            Toggle("Show menu bar icon", isOn: $showMenuBarIcon)
+                .accessibilityIdentifier("show-menu-bar-icon-toggle")
+                .help("Shows package status and quick actions in the menu bar.")
+
             Toggle("Show Casks by default", isOn: $showCasksByDefault)
         }
         .formStyle(.grouped)
@@ -96,7 +102,7 @@ struct SettingsView: View {
         .onChange(of: appIcon, initial: true) {
             AppIconSelection.apply(rawValue: appIcon)
         }
-        .frame(width: 560, height: 410)
+        .frame(width: 560, height: 440)
     }
 
     private var brewfileOverrideSetting: some View {

--- a/BrewyUITests/SidebarNavigationUITests.swift
+++ b/BrewyUITests/SidebarNavigationUITests.swift
@@ -38,6 +38,7 @@ final class SidebarNavigationUITests: XCTestCase {
             "-autoRefreshInterval", "0",
             "-brewfilePath", "",
             "-showCasksByDefault", "NO",
+            "-showMenuBarIcon", "YES",
             "-trustedBrewfilePath", brewfileURL.path,
             "-trustedBrewfileDigest", brewfileDigest
         ]
@@ -270,6 +271,141 @@ final class SidebarNavigationUITests: XCTestCase {
     }
 
     /// True when the Thread Sanitizer runtime is loaded into this process.
+    private static var isThreadSanitizerActive: Bool {
+        (0..<_dyld_image_count()).contains { index in
+            guard let name = _dyld_get_image_name(index) else { return false }
+            return String(cString: name).contains("libclang_rt.tsan")
+        }
+    }
+}
+
+@MainActor
+final class MenuBarSettingsUITests: XCTestCase {
+    private static let timeoutScale: TimeInterval = isThreadSanitizerActive ? 4 : 1
+    private static let launchTimeout: TimeInterval = 30 * timeoutScale
+    private static let transitionTimeout: TimeInterval = 10 * timeoutScale
+
+    private var app: XCUIApplication!
+    private var fixtureDirectory: URL!
+    private var initialMenuBarIconState: Bool?
+
+    override func setUp() async throws {
+        continueAfterFailure = false
+        fixtureDirectory = FileManager.default.temporaryDirectory
+            .appendingPathComponent("brewy-menu-bar-ui-tests-\(ProcessInfo.processInfo.globallyUniqueString)")
+        try FileManager.default.createDirectory(at: fixtureDirectory, withIntermediateDirectories: true)
+
+        app = XCUIApplication()
+        app.terminate()
+        // This class intentionally omits showMenuBarIcon so the toggle can write through AppStorage.
+        app.launchArguments += [
+            "-NSConstraintBasedLayoutVisualizeMutuallyExclusiveConstraints", "YES",
+            "-autoRefreshInterval", "0",
+            "-brewfilePath", "",
+            "-showCasksByDefault", "NO"
+        ]
+        app.launchEnvironment["BREWY_UI_TESTING"] = "1"
+        app.launchEnvironment["XDG_CONFIG_HOME"] = fixtureDirectory.path
+        app.launch()
+        app.activate()
+    }
+
+    override func tearDown() async throws {
+        restoreInitialMenuBarIconStateIfNeeded()
+        app?.terminate()
+        app = nil
+        try? FileManager.default.removeItem(at: fixtureDirectory)
+        fixtureDirectory = nil
+    }
+
+    func testMenuBarIconVisibilityPersistsAcrossRelaunch() throws {
+        let toggle = try openMenuBarIconSetting()
+        let initialState = try XCTUnwrap(checkedValue(of: toggle))
+        initialMenuBarIconState = initialState
+
+        XCTAssertTrue(waitForMenuBarCount(initialState ? 2 : 1))
+
+        let toggledState = !initialState
+        toggle.click()
+        XCTAssertTrue(waitUntil { self.checkedValue(of: toggle) == toggledState })
+        XCTAssertTrue(waitForMenuBarCount(toggledState ? 2 : 1))
+
+        app.terminate()
+        app.launch()
+        app.activate()
+
+        let relaunchedToggle = try openMenuBarIconSetting()
+        XCTAssertEqual(checkedValue(of: relaunchedToggle), toggledState)
+        XCTAssertTrue(waitForMenuBarCount(toggledState ? 2 : 1))
+
+        relaunchedToggle.click()
+        XCTAssertTrue(waitUntil { self.checkedValue(of: relaunchedToggle) == initialState })
+        XCTAssertTrue(waitForMenuBarCount(initialState ? 2 : 1))
+        initialMenuBarIconState = nil
+    }
+
+    private func openMenuBarIconSetting() throws -> XCUIElement {
+        app.typeKey(",", modifierFlags: .command)
+
+        let settingsWindow = app.windows["Brewy Settings"]
+        _ = try XCTUnwrap(
+            settingsWindow.waitForExistence(timeout: Self.launchTimeout) ? settingsWindow : nil,
+            "Settings window should appear"
+        )
+
+        let toggle = settingsWindow.switches["show-menu-bar-icon-toggle"]
+        return try XCTUnwrap(
+            toggle.waitForExistence(timeout: Self.transitionTimeout) ? toggle : nil,
+            "Menu bar icon setting should appear"
+        )
+    }
+
+    private func checkedValue(of toggle: XCUIElement) -> Bool? {
+        if let number = toggle.value as? NSNumber {
+            return number.boolValue
+        }
+
+        guard let string = toggle.value as? String else { return nil }
+        switch string.lowercased() {
+        case "1", "true", "on": return true
+        case "0", "false", "off": return false
+        default: return nil
+        }
+    }
+
+    private func waitForMenuBarCount(_ count: Int) -> Bool {
+        waitUntil { self.app.menuBars.count == count }
+    }
+
+    private func waitUntil(_ condition: () -> Bool) -> Bool {
+        let deadline = Date(timeIntervalSinceNow: Self.transitionTimeout)
+        repeat {
+            if condition() { return true }
+            RunLoop.current.run(until: Date(timeIntervalSinceNow: 0.1))
+        } while Date() < deadline
+        return condition()
+    }
+
+    private func restoreInitialMenuBarIconStateIfNeeded() {
+        guard let initialMenuBarIconState else { return }
+
+        if app.state == .notRunning {
+            app.launch()
+        }
+        app.activate()
+        app.typeKey(",", modifierFlags: .command)
+
+        let toggle = app.windows["Brewy Settings"].switches["show-menu-bar-icon-toggle"]
+        guard toggle.waitForExistence(timeout: Self.launchTimeout),
+              let currentState = checkedValue(of: toggle),
+              currentState != initialMenuBarIconState else {
+            return
+        }
+
+        toggle.click()
+        _ = waitUntil { self.checkedValue(of: toggle) == initialMenuBarIconState }
+    }
+
     private static var isThreadSanitizerActive: Bool {
         (0..<_dyld_image_count()).contains { index in
             guard let name = _dyld_get_image_name(index) else { return false }

--- a/README.md
+++ b/README.md
@@ -28,7 +28,7 @@ It is designed for people who already use Homebrew and want a fast, inspectable 
 - Review action history and retry failed commands when it is safe to do so.
 - Run `brew doctor`, update Homebrew, remove orphaned packages, and clear caches with dry-run previews for destructive maintenance.
 - Use the menu bar extra to see the current outdated count and trigger quick refresh or upgrade actions.
-- Choose light, dark, or system appearance, configure the `brew` path, and set an auto-refresh interval.
+- Choose light, dark, or system appearance, show or hide the menu bar icon, configure the `brew` path, and set an auto-refresh interval.
 - Receive app updates through Sparkle.
 
 ## Requirements


### PR DESCRIPTION
Adds a "Show menu bar icon" toggle in Settings, backed by `@AppStorage`. `MenuBarExtra` reads the same default through an `isInserted:` binding, so toggling inserts or removes the icon immediately and the choice survives relaunch. It defaults to on, so existing users keep the icon.

Brewy keeps its Dock icon, so hiding the extra never removes access to the app or Settings.

`BrewyUITests` also drops scheme parallelization. The new settings test class is the target's second, and parallel runners would drive and terminate the same app instance.

Closes #282.

AI disclosure: Claude Opus 5 with manual testing and review.
