### PR TITLE
fix(commands): await process group termination before returning

### DIFF
--- a/Brewy/Models/CommandRunner.swift
+++ b/Brewy/Models/CommandRunner.swift
@@ -268,16 +268,15 @@ enum CommandRunner {
             commandDescription: execution.commandDescription,
             onOutput: onOutput
         )
-        let timeoutWork = scheduleTimeout(
-            for: process,
+        let timeoutWatchdog = scheduleTimeout(
             handle: handle,
             after: execution.timeout,
             commandDescription: execution.commandDescription
         )
 
         process.waitUntilExit()
-        // Process finished; cancel the pending timeout so it can't fire later.
-        timeoutWork.cancel()
+        handle.processDidExit()
+        timeoutWatchdog.cancel()
         _ = handle.waitForTermination()
         var drainDeadline: DispatchTime?
         let requestedDrainDeadline = {
@@ -406,21 +405,35 @@ enum CommandRunner {
     }
 
     private static func scheduleTimeout(
-        for process: Process,
         handle: ProcessHandle,
         after timeout: Duration,
         commandDescription: String
-    ) -> DispatchWorkItem {
-        let timeoutWork = DispatchWorkItem { [weak process] in
-            guard let process, process.isRunning else { return }
+    ) -> TimeoutWatchdog {
+        TimeoutWatchdog(deadline: .now() + dispatchInterval(from: timeout)) {
+            guard handle.timeOut() else { return }
             logger.warning("Timeout exceeded, sending SIGTERM: \(commandDescription)")
-            handle.timeOut()
         }
-        DispatchQueue.global(qos: .userInitiated).asyncAfter(
-            deadline: .now() + dispatchInterval(from: timeout),
-            execute: timeoutWork
-        )
-        return timeoutWork
+    }
+}
+
+final class TimeoutWatchdog: @unchecked Sendable {
+    private let cancellation: DispatchSemaphore
+    private let thread: Thread
+
+    init(deadline: DispatchTime, action: @escaping @Sendable () -> Void) {
+        let cancellation = DispatchSemaphore(value: 0)
+        self.cancellation = cancellation
+        self.thread = Thread {
+            guard cancellation.wait(timeout: deadline) == .timedOut else { return }
+            action()
+        }
+        thread.name = "Brewy command timeout"
+        thread.qualityOfService = .userInitiated
+        thread.start()
+    }
+
+    func cancel() {
+        cancellation.signal()
     }
 }
 

--- a/Brewy/Models/CommandRunner.swift
+++ b/Brewy/Models/CommandRunner.swift
@@ -20,55 +20,6 @@ struct CommandResult: Sendable {
     }
 }
 
-// MARK: - Thread-safe Value Containers
-
-private final class LockedFlag: Sendable {
-    private let lock = NSLock()
-    nonisolated(unsafe) private var value = false
-
-    func set() { lock.lock(); value = true; lock.unlock() }
-
-    var isSet: Bool {
-        lock.lock(); defer { lock.unlock() }
-        return value
-    }
-}
-
-/// Thread-safe handle bridging a launched `Process` to a task-cancellation handler,
-/// which may fire before the process has even launched.
-private final class ProcessHandle: @unchecked Sendable {
-    private let lock = NSLock()
-    private var process: Process?
-    private var signalTarget: Int32?
-    private var cancelled = false
-
-    /// Registers the launched process; returns false when cancellation already
-    /// happened, in which case the caller must tear the process down itself.
-    func register(_ process: Process) -> Bool {
-        let signalTarget = CommandRunner.signalTarget(for: process)
-        lock.lock(); defer { lock.unlock() }
-        guard !cancelled else { return false }
-        self.process = process
-        self.signalTarget = signalTarget
-        return true
-    }
-
-    var wasCancelled: Bool {
-        lock.lock(); defer { lock.unlock() }
-        return cancelled
-    }
-
-    func cancel(killGracePeriod: Duration) {
-        lock.lock()
-        cancelled = true
-        let running = process
-        let target = signalTarget
-        lock.unlock()
-        guard let running, let target else { return }
-        CommandRunner.terminateThenKill(running, signalTarget: target, after: killGracePeriod)
-    }
-}
-
 // MARK: - Command Running Protocol
 
 protocol CommandRunning: Sendable {
@@ -214,7 +165,7 @@ enum CommandRunner {
             }.value
         } onCancel: {
             logger.info("Task cancelled, terminating: \(commandDescription)")
-            handle.cancel(killGracePeriod: killGracePeriod)
+            handle.cancel()
         }
 
         let elapsed = ContinuousClock.now - startTime
@@ -309,10 +260,7 @@ enum CommandRunner {
             )
         }
 
-        if !handle.register(process) {
-            // Cancellation raced the launch; the handler never saw the process, so tear it down here.
-            terminateThenKill(process, after: killGracePeriod)
-        }
+        handle.register(process, killGracePeriod: killGracePeriod)
 
         let (stdoutData, stderrData) = drainPipesInParallel(
             stdout: stdoutPipe,
@@ -320,8 +268,9 @@ enum CommandRunner {
             commandDescription: execution.commandDescription,
             onOutput: onOutput
         )
-        let (timedOut, timeoutWork) = scheduleTimeout(
+        let timeoutWork = scheduleTimeout(
             for: process,
+            handle: handle,
             after: execution.timeout,
             commandDescription: execution.commandDescription
         )
@@ -329,9 +278,10 @@ enum CommandRunner {
         process.waitUntilExit()
         // Process finished; cancel the pending timeout so it can't fire later.
         timeoutWork.cancel()
+        _ = handle.waitForTermination()
         var drainDeadline: DispatchTime?
         let requestedDrainDeadline = {
-            if drainDeadline == nil, handle.wasCancelled || timedOut.isSet {
+            if drainDeadline == nil, handle.wasInterrupted {
                 drainDeadline = DispatchTime.now() + dispatchInterval(from: pipeDrainGracePeriod)
             }
             return drainDeadline
@@ -340,17 +290,43 @@ enum CommandRunner {
         let err = stderrData.wait(untilRequested: requestedDrainDeadline)
         let stdout = String(data: out, encoding: .utf8) ?? ""
         let stderr = String(data: err, encoding: .utf8) ?? ""
+        return commandResult(
+            process: process,
+            execution: execution,
+            handle: handle,
+            stdout: stdout,
+            stderr: stderr
+        )
+    }
 
-        if handle.wasCancelled {
+    private static func commandResult(
+        process: Process,
+        execution: ProcessExecution,
+        handle: ProcessHandle,
+        stdout: String,
+        stderr: String
+    ) -> CommandResult {
+        let interruption = handle.interruptionAfterWaiting()
+
+        if interruption.cancelled {
             return CommandResult(
-                output: cancelledOutput(stdout: stdout, stderr: stderr),
+                output: cancelledOutput(
+                    stdout: stdout,
+                    stderr: stderr,
+                    terminationSucceeded: interruption.terminationSucceeded
+                ),
                 success: false,
                 cancelled: true
             )
         }
-        if timedOut.isSet {
+        if interruption.timedOut {
             return CommandResult(
-                output: timeoutOutput(stdout: stdout, stderr: stderr, timeout: execution.timeout),
+                output: timeoutOutput(
+                    stdout: stdout,
+                    stderr: stderr,
+                    timeout: execution.timeout,
+                    terminationSucceeded: interruption.terminationSucceeded
+                ),
                 success: false
             )
         }
@@ -375,49 +351,6 @@ enum CommandRunner {
         return (process, stdoutPipe, stderrPipe)
     }
 
-    /// Signals the process group when Foundation launched an isolated group, falling back to
-    /// the direct process otherwise.
-    static func terminateThenKill(_ process: Process, after grace: Duration) {
-        terminateThenKill(process, signalTarget: signalTarget(for: process), after: grace)
-    }
-
-    fileprivate static func signalTarget(for process: Process) -> Int32 {
-        let pid = process.processIdentifier
-        errno = 0
-        let processGroupID = getpgid(pid)
-        if processGroupID == pid || (processGroupID == -1 && errno == ESRCH) {
-            return -pid
-        }
-        logger.warning("Process \(pid) is not its group leader; terminating only the direct process")
-        return pid
-    }
-
-    fileprivate static func terminateThenKill(
-        _ process: Process,
-        signalTarget: Int32,
-        after grace: Duration
-    ) {
-        if signalTarget < 0 {
-            errno = 0
-            guard kill(signalTarget, SIGTERM) == 0 || errno == EPERM else { return }
-        } else {
-            guard process.isRunning else { return }
-            kill(signalTarget, SIGTERM)
-        }
-        // Above .utility: that queue is starved on a loaded machine, and the escalation is
-        // the only thing that stops a descendant which ignores SIGTERM.
-        DispatchQueue.global(qos: .userInitiated).asyncAfter(deadline: .now() + dispatchInterval(from: grace)) { [weak process] in
-            if signalTarget < 0 {
-                errno = 0
-                guard kill(signalTarget, 0) == 0 || errno == EPERM else { return }
-            } else {
-                guard let process, process.isRunning else { return }
-            }
-            logger.warning("SIGTERM did not stop all processes, sending SIGKILL to target \(signalTarget)")
-            kill(signalTarget, SIGKILL)
-        }
-    }
-
     private static func commandOutput(stdout: String, stderr: String, terminationStatus: Int32) -> String {
         if terminationStatus == 0 {
             return stdout.isEmpty ? stderr : stdout
@@ -440,41 +373,54 @@ enum CommandRunner {
         }
     }
 
-    private static func timeoutOutput(stdout: String, stderr: String, timeout: Duration) -> String {
+    private static func timeoutOutput(
+        stdout: String,
+        stderr: String,
+        timeout: Duration,
+        terminationSucceeded: Bool
+    ) -> String {
         let partialOutput = combinedStreams(stdout: stdout, stderr: stderr)
             .trimmingCharacters(in: .whitespacesAndNewlines)
-        guard !partialOutput.isEmpty else {
-            return "Command timed out after \(timeout)."
-        }
-        return "Command timed out after \(timeout).\n\(partialOutput)"
+        let message = partialOutput.isEmpty
+            ? "Command timed out after \(timeout)."
+            : "Command timed out after \(timeout).\n\(partialOutput)"
+        return terminationOutput(message, succeeded: terminationSucceeded)
     }
 
-    private static func cancelledOutput(stdout: String, stderr: String) -> String {
+    private static func cancelledOutput(
+        stdout: String,
+        stderr: String,
+        terminationSucceeded: Bool
+    ) -> String {
         let partialOutput = combinedStreams(stdout: stdout, stderr: stderr)
             .trimmingCharacters(in: .whitespacesAndNewlines)
-        guard !partialOutput.isEmpty else {
-            return "Command was cancelled."
-        }
-        return "Command was cancelled.\n\(partialOutput)"
+        let message = partialOutput.isEmpty
+            ? "Command was cancelled."
+            : "Command was cancelled.\n\(partialOutput)"
+        return terminationOutput(message, succeeded: terminationSucceeded)
+    }
+
+    static func terminationOutput(_ message: String, succeeded: Bool) -> String {
+        guard !succeeded else { return message }
+        return "\(message)\nSome child processes may still be running."
     }
 
     private static func scheduleTimeout(
         for process: Process,
+        handle: ProcessHandle,
         after timeout: Duration,
         commandDescription: String
-    ) -> (flag: LockedFlag, work: DispatchWorkItem) {
-        let timedOut = LockedFlag()
+    ) -> DispatchWorkItem {
         let timeoutWork = DispatchWorkItem { [weak process] in
             guard let process, process.isRunning else { return }
             logger.warning("Timeout exceeded, sending SIGTERM: \(commandDescription)")
-            timedOut.set()
-            terminateThenKill(process, after: killGracePeriod)
+            handle.timeOut()
         }
         DispatchQueue.global(qos: .userInitiated).asyncAfter(
             deadline: .now() + dispatchInterval(from: timeout),
             execute: timeoutWork
         )
-        return (timedOut, timeoutWork)
+        return timeoutWork
     }
 }
 

--- a/Brewy/Models/ProcessTermination.swift
+++ b/Brewy/Models/ProcessTermination.swift
@@ -1,0 +1,327 @@
+import Darwin
+import Foundation
+import OSLog
+
+private let logger = Logger(subsystem: "io.linnane.brewy", category: "ProcessTermination")
+
+final class ProcessTermination: @unchecked Sendable {
+    typealias SignalFunction = @Sendable (Int32, Int32) -> Int32
+
+    private enum SignalOutcome {
+        case delivered
+        case gone
+        case notPermitted
+        case failed(Int32)
+    }
+
+    private enum WaitOutcome {
+        case finished
+        case notPermitted
+        case timedOut(lastProbeDenied: Bool)
+        case failed(Int32)
+    }
+
+    private static let confirmationPeriod: Duration = .seconds(5)
+    private static let permissionProbeGracePeriod: Duration = .milliseconds(100)
+    private static let pollInterval: useconds_t = 10_000
+
+    private let signalTarget: Int32
+    private let gracePeriod: Duration
+    private let signalFunction: SignalFunction
+    private let completion = DispatchGroup()
+    private let lock = NSLock()
+    private var started = false
+    private var succeeded = false
+
+    init(
+        process: Process,
+        gracePeriod: Duration,
+        signalFunction: @escaping SignalFunction = { Darwin.kill($0, $1) }
+    ) {
+        self.signalTarget = Self.signalTarget(for: process)
+        self.gracePeriod = gracePeriod
+        self.signalFunction = signalFunction
+    }
+
+    func start() {
+        guard beginTermination() else { return }
+
+        switch send(SIGTERM, to: signalTarget) {
+        case .delivered:
+            startEscalationThread(hadPartialDelivery: false)
+        case .gone:
+            finish(succeeded: true)
+        case .notPermitted:
+            guard signalTarget < 0 else {
+                finishAfterSignalFailure(SIGTERM, error: EPERM)
+                return
+            }
+            logger.warning("SIGTERM reached only part of process group \(-self.signalTarget); escalating")
+            startEscalationThread(hadPartialDelivery: true)
+        case let .failed(error):
+            finishAfterSignalFailure(SIGTERM, error: error)
+        }
+    }
+
+    private func beginTermination() -> Bool {
+        lock.lock(); defer { lock.unlock() }
+        guard !started else { return false }
+        started = true
+        completion.enter()
+        return true
+    }
+
+    private func startEscalationThread(hadPartialDelivery: Bool) {
+        let escalationDeadline = ContinuousClock.now.advanced(by: gracePeriod)
+        let target = signalTarget
+        // A dedicated thread keeps process cleanup independent of dispatch-pool starvation.
+        let thread = Thread { [self] in
+            waitForGracePeriod(
+                until: escalationDeadline,
+                target: target,
+                hadPartialDelivery: hadPartialDelivery
+            )
+        }
+        thread.name = "Brewy process termination"
+        thread.qualityOfService = .userInitiated
+        thread.start()
+    }
+
+    private func waitForGracePeriod(
+        until deadline: ContinuousClock.Instant,
+        target: Int32,
+        hadPartialDelivery: Bool
+    ) {
+        switch waitForExit(until: deadline, toleratingPermissionDenial: hadPartialDelivery) {
+        case .finished:
+            finish(succeeded: !hadPartialDelivery)
+        case .notPermitted:
+            guard target < 0 else {
+                finishAfterProbeFailure(error: EPERM)
+                return
+            }
+            logger.warning("Could not verify all members of process group \(-target); honoring remaining grace period")
+            switch waitForExit(until: deadline, toleratingPermissionDenial: true) {
+            case .finished:
+                // Initial partial delivery uses the permission-tolerating outer wait,
+                // so reaching this branch proves the original SIGTERM was fully delivered.
+                finish(succeeded: true)
+            case .notPermitted:
+                logger.warning("Could not verify all members of process group \(-target); sending SIGKILL")
+                sendKill(to: target, hadPartialDelivery: true)
+            case let .timedOut(lastProbeDenied):
+                if lastProbeDenied {
+                    logger.warning("Could not verify all members of process group \(-target); sending SIGKILL")
+                } else {
+                    logger.warning("SIGTERM did not stop all processes, sending SIGKILL to target \(target)")
+                }
+                sendKill(to: target, hadPartialDelivery: lastProbeDenied)
+            case let .failed(error):
+                finishAfterProbeFailure(error: error)
+            }
+        case let .failed(error):
+            finishAfterProbeFailure(error: error)
+        case let .timedOut(lastProbeDenied):
+            let hadIncompleteDelivery = hadPartialDelivery || lastProbeDenied
+            let scope = hadIncompleteDelivery ? "all signalable processes" : "all processes"
+            logger.warning("SIGTERM did not stop \(scope), sending SIGKILL to target \(target)")
+            sendKill(to: target, hadPartialDelivery: hadIncompleteDelivery)
+        }
+    }
+
+    private func sendKill(to target: Int32, hadPartialDelivery: Bool) {
+        switch send(SIGKILL, to: target) {
+        case .delivered:
+            confirmKill(target: target, hadPartialDelivery: hadPartialDelivery)
+        case .gone:
+            finish(succeeded: !hadPartialDelivery)
+        case .notPermitted:
+            finishAfterSignalFailure(SIGKILL, error: EPERM)
+        case let .failed(error):
+            finishAfterSignalFailure(SIGKILL, error: error)
+        }
+    }
+
+    private func confirmKill(target: Int32, hadPartialDelivery: Bool) {
+        let deadline = ContinuousClock.now.advanced(by: Self.confirmationPeriod)
+        switch waitForExit(until: deadline) {
+        case .finished:
+            finish(succeeded: !hadPartialDelivery)
+        case .notPermitted:
+            finishAfterProbeFailure(error: EPERM)
+        case let .failed(error):
+            finishAfterProbeFailure(error: error)
+        case .timedOut:
+            logger.error("Process target \(target) still exists after SIGKILL")
+            finish(succeeded: false)
+        }
+    }
+
+    func wait() -> Bool {
+        lock.lock()
+        let shouldWait = started
+        lock.unlock()
+        guard shouldWait else { return true }
+
+        completion.wait()
+        lock.lock(); defer { lock.unlock() }
+        return succeeded
+    }
+
+    private func send(_ signal: Int32, to target: Int32) -> SignalOutcome {
+        errno = 0
+        guard signalFunction(target, signal) != 0 else { return .delivered }
+        switch errno {
+        case ESRCH:
+            return .gone
+        case EPERM:
+            return .notPermitted
+        default:
+            return .failed(errno)
+        }
+    }
+
+    private func waitForExit(
+        until deadline: ContinuousClock.Instant,
+        toleratingPermissionDenial: Bool = false
+    ) -> WaitOutcome {
+        var permissionDeadline: ContinuousClock.Instant?
+        while true {
+            let now = ContinuousClock.now
+            switch send(0, to: signalTarget) {
+            case .gone:
+                return .finished
+            case .notPermitted:
+                if toleratingPermissionDenial {
+                    guard now < deadline else { return .timedOut(lastProbeDenied: true) }
+                    break
+                }
+                // macOS can return EPERM for a group whose terminated leader is awaiting reap.
+                let retryDeadline = now.advanced(by: Self.permissionProbeGracePeriod)
+                permissionDeadline = permissionDeadline ?? min(deadline, retryDeadline)
+                guard let permissionDeadline, now < permissionDeadline else {
+                    return .notPermitted
+                }
+            case let .failed(error):
+                return .failed(error)
+            case .delivered:
+                permissionDeadline = nil
+                guard now < deadline else { return .timedOut(lastProbeDenied: false) }
+            }
+            usleep(Self.pollInterval)
+        }
+    }
+
+    private func finishAfterSignalFailure(_ signal: Int32, error: Int32) {
+        let target = signalTarget
+        logger.error(
+            "Could not fully deliver signal \(signal) to target \(target), errno \(error); child processes may remain"
+        )
+        finish(succeeded: false)
+    }
+
+    private func finishAfterProbeFailure(error: Int32) {
+        logger.error(
+            "Could not verify process target \(self.signalTarget), errno \(error); child processes may remain"
+        )
+        finish(succeeded: false)
+    }
+
+    private func finish(succeeded: Bool) {
+        lock.lock()
+        self.succeeded = succeeded
+        lock.unlock()
+        completion.leave()
+    }
+
+    private static func signalTarget(for process: Process) -> Int32 {
+        let pid = process.processIdentifier
+        errno = 0
+        let processGroupID = getpgid(pid)
+        if processGroupID == pid || (processGroupID == -1 && errno == ESRCH) {
+            return -pid
+        }
+        logger.warning("Process \(pid) is not its group leader; terminating only the direct process")
+        return pid
+    }
+}
+
+/// Thread-safe handle bridging a launched `Process` to a task-cancellation handler,
+/// which may fire before the process has even launched.
+final class ProcessHandle: @unchecked Sendable {
+    struct Interruption: Sendable {
+        let cancelled: Bool
+        let timedOut: Bool
+        let terminationSucceeded: Bool
+    }
+
+    private let lock = NSLock()
+    private var termination: ProcessTermination?
+    private var cancelled = false
+    private var timedOut = false
+    private var finished = false
+
+    func register(_ process: Process, killGracePeriod: Duration) {
+        let termination = ProcessTermination(
+            process: process,
+            gracePeriod: killGracePeriod
+        )
+        lock.lock()
+        self.termination = termination
+        if cancelled || timedOut { termination.start() }
+        lock.unlock()
+    }
+
+    var wasCancelled: Bool {
+        lock.lock(); defer { lock.unlock() }
+        return cancelled
+    }
+
+    func cancel() {
+        lock.lock()
+        guard !finished else {
+            lock.unlock()
+            return
+        }
+        cancelled = true
+        termination?.start()
+        lock.unlock()
+    }
+
+    func timeOut() {
+        lock.lock()
+        guard !finished else {
+            lock.unlock()
+            return
+        }
+        timedOut = true
+        termination?.start()
+        lock.unlock()
+    }
+
+    var wasInterrupted: Bool {
+        lock.lock(); defer { lock.unlock() }
+        return cancelled || timedOut
+    }
+
+    func waitForTermination() -> Bool {
+        lock.lock()
+        let termination = termination
+        lock.unlock()
+        return termination?.wait() ?? true
+    }
+
+    func interruptionAfterWaiting() -> Interruption {
+        lock.lock()
+        finished = true
+        let wasCancelled = cancelled
+        let didTimeOut = timedOut
+        let termination = termination
+        lock.unlock()
+        return Interruption(
+            cancelled: wasCancelled,
+            timedOut: didTimeOut,
+            terminationSucceeded: termination?.wait() ?? true
+        )
+    }
+}

--- a/Brewy/Models/ProcessTermination.swift
+++ b/Brewy/Models/ProcessTermination.swift
@@ -259,6 +259,7 @@ final class ProcessHandle: @unchecked Sendable {
     private var termination: ProcessTermination?
     private var cancelled = false
     private var timedOut = false
+    private var processExited = false
     private var finished = false
 
     func register(_ process: Process, killGracePeriod: Duration) {
@@ -288,15 +289,23 @@ final class ProcessHandle: @unchecked Sendable {
         lock.unlock()
     }
 
-    func timeOut() {
+    func processDidExit() {
         lock.lock()
-        guard !finished else {
+        processExited = true
+        lock.unlock()
+    }
+
+    @discardableResult
+    func timeOut() -> Bool {
+        lock.lock()
+        guard !processExited, !finished else {
             lock.unlock()
-            return
+            return false
         }
         timedOut = true
         termination?.start()
         lock.unlock()
+        return true
     }
 
     var wasInterrupted: Bool {

--- a/BrewyTests/CommandRunnerProcessGroupTests.swift
+++ b/BrewyTests/CommandRunnerProcessGroupTests.swift
@@ -5,7 +5,7 @@ import Testing
 
 private let incompleteTerminationWarning = "Some child processes may still be running."
 
-@Suite("CommandRunner Process Groups")
+@Suite("CommandRunner Process Groups", .serialized)
 struct CommandRunnerProcessGroupTests {
 
     @Test("Timeout waits for a SIGTERM-ignoring descendant")
@@ -42,6 +42,21 @@ struct CommandRunnerProcessGroupTests {
 }
 
 extension CommandRunnerProcessGroupTests {
+    @Test("Process exit suppresses timeout without suppressing late cancellation")
+    func processExitSuppressesOnlyTimeout() {
+        let handle = ProcessHandle()
+
+        handle.processDidExit()
+
+        #expect(!handle.timeOut())
+        #expect(!handle.wasInterrupted)
+
+        handle.cancel()
+        let interruption = handle.interruptionAfterWaiting()
+        #expect(interruption.cancelled)
+        #expect(!interruption.timedOut)
+    }
+
     @Test("Partial group permission failure still reaches SIGKILL promptly")
     func partialPermissionFailureEscalatesPromptly() throws {
         try withSleepProcess { process, processID in
@@ -388,7 +403,8 @@ extension CommandRunnerProcessGroupTests {
 
     private func waitForPIDs(at url: URL, count: Int) async throws -> [Int32] {
         var pids: [Int32] = []
-        for _ in 0..<1_000 {
+        let deadline = ContinuousClock.now.advanced(by: .seconds(30))
+        while ContinuousClock.now < deadline {
             if let contents = try? String(contentsOf: url, encoding: .utf8) {
                 pids = contents.split(separator: " ").compactMap { Int32($0) }
                 if pids.count == count { break }

--- a/BrewyTests/CommandRunnerProcessGroupTests.swift
+++ b/BrewyTests/CommandRunnerProcessGroupTests.swift
@@ -1,0 +1,469 @@
+@testable import Brewy
+import Darwin
+import Foundation
+import Testing
+
+private let incompleteTerminationWarning = "Some child processes may still be running."
+
+@Suite("CommandRunner Process Groups")
+struct CommandRunnerProcessGroupTests {
+
+    @Test("Timeout waits for a SIGTERM-ignoring descendant")
+    func timeoutWaitsForProcessGroup() async throws {
+        let pidURL = FileManager.default.temporaryDirectory
+            .appendingPathComponent("brewy-timeout-descendant-\(UUID().uuidString).pid")
+        defer { try? FileManager.default.removeItem(at: pidURL) }
+        let script = """
+        (trap "" TERM HUP; exec </dev/null >/dev/null 2>&1; sleep 30) &
+        child=$!
+        printf "%s" "$child" > "$1"
+        wait
+        """
+        let task = Task {
+            await CommandRunner.runExecutable(
+                "/bin/sh",
+                arguments: ["-c", script, "brewy-timeout-test", pidURL.path],
+                timeout: .seconds(3)
+            )
+        }
+        defer { task.cancel() }
+
+        let descendantPID = try #require(await waitForPIDs(at: pidURL, count: 1).first)
+        defer { kill(descendantPID, SIGKILL) }
+        #expect(kill(descendantPID, 0) == 0)
+
+        let result = await task.value
+
+        #expect(!result.success)
+        #expect(result.output.contains("timed out"))
+        #expect(!result.output.contains(incompleteTerminationWarning))
+        #expect(kill(descendantPID, 0) == -1)
+    }
+}
+
+extension CommandRunnerProcessGroupTests {
+    @Test("Partial group permission failure still reaches SIGKILL promptly")
+    func partialPermissionFailureEscalatesPromptly() throws {
+        try withSleepProcess { process, processID in
+            let signals = LockedSignalCalls()
+            let termination = ProcessTermination(
+                process: process,
+                gracePeriod: .milliseconds(50),
+                signalFunction: { target, signal in
+                    signals.append(target: target, signal: signal)
+                    errno = EPERM
+                    return -1
+                }
+            )
+
+            let start = ContinuousClock.now
+            termination.start()
+            let succeeded = termination.wait()
+            let elapsed = ContinuousClock.now - start
+
+            #expect(!succeeded)
+            #expect(elapsed >= .milliseconds(50))
+            #expect(elapsed < .seconds(1))
+            let calls = signals.values
+            #expect(calls.first == SignalCall(target: -processID, signal: SIGTERM))
+            #expect(calls.last == SignalCall(target: -processID, signal: SIGKILL))
+            #expect(calls.dropFirst().dropLast().allSatisfy {
+                $0 == SignalCall(target: -processID, signal: 0)
+            })
+        }
+    }
+
+    @Test("Partial group permission failure exits early once the group is gone")
+    func partialPermissionFailureExitsWhenGroupIsGone() throws {
+        try withSleepProcess { process, processID in
+            let signals = LockedSignalCalls()
+            let termination = ProcessTermination(
+                process: process,
+                gracePeriod: .seconds(1),
+                signalFunction: { target, signal in
+                    signals.append(target: target, signal: signal)
+                    errno = signal == SIGTERM ? EPERM : ESRCH
+                    return -1
+                }
+            )
+
+            let start = ContinuousClock.now
+            termination.start()
+            let succeeded = termination.wait()
+            let elapsed = ContinuousClock.now - start
+
+            #expect(!succeeded)
+            #expect(elapsed < .milliseconds(500))
+            #expect(signals.values == [
+                SignalCall(target: -processID, signal: SIGTERM),
+                SignalCall(target: -processID, signal: 0)
+            ])
+        }
+    }
+
+    @Test("Persistently denied group liveness probe reports incomplete teardown")
+    func persistentlyDeniedProbeReportsIncompleteTeardown() throws {
+        try withSleepProcess { process, processID in
+            let signals = LockedSignalCalls()
+            let termination = ProcessTermination(
+                process: process,
+                gracePeriod: .milliseconds(200),
+                signalFunction: { target, signal in
+                    signals.append(target: target, signal: signal)
+                    guard signal != SIGTERM else { return 0 }
+                    errno = EPERM
+                    return -1
+                }
+            )
+
+            let start = ContinuousClock.now
+            termination.start()
+            let succeeded = termination.wait()
+            let elapsed = ContinuousClock.now - start
+
+            #expect(!succeeded)
+            #expect(elapsed >= .milliseconds(200))
+            #expect(elapsed < .seconds(1))
+            let calls = signals.values
+            #expect(calls.first == SignalCall(target: -processID, signal: SIGTERM))
+            #expect(calls.count >= 3)
+            #expect(calls.last == SignalCall(target: -processID, signal: SIGKILL))
+            #expect(calls.dropFirst().dropLast().allSatisfy {
+                $0 == SignalCall(target: -processID, signal: 0)
+            })
+        }
+    }
+
+    @Test("Denied group probe keeps incomplete status after successful escalation")
+    func deniedProbeEscalationRemainsIncomplete() throws {
+        try withSleepProcess { process, processID in
+            let signals = LockedSignalCalls()
+            let termination = ProcessTermination(
+                process: process,
+                gracePeriod: .milliseconds(200),
+                signalFunction: { target, signal in
+                    signals.append(target: target, signal: signal)
+                    if signal == SIGTERM || signal == SIGKILL { return 0 }
+                    errno = signals.values.contains { $0.signal == SIGKILL } ? ESRCH : EPERM
+                    return -1
+                }
+            )
+
+            termination.start()
+            let succeeded = termination.wait()
+
+            #expect(!succeeded)
+            let calls = signals.values
+            #expect(calls.first == SignalCall(target: -processID, signal: SIGTERM))
+            #expect(calls.contains(SignalCall(target: -processID, signal: SIGKILL)))
+            #expect(calls.last == SignalCall(target: -processID, signal: 0))
+        }
+    }
+
+    @Test("Transiently denied group probe can resolve after reaping")
+    func transientlyDeniedProbeCanFinishCleanly() throws {
+        try withSleepProcess { process, processID in
+            let signals = LockedSignalCalls()
+            let termination = ProcessTermination(
+                process: process,
+                gracePeriod: .seconds(3),
+                signalFunction: { target, signal in
+                    let callCount = signals.append(target: target, signal: signal)
+                    switch callCount {
+                    case 1:
+                        return 0
+                    case 2:
+                        errno = EPERM
+                    default:
+                        errno = ESRCH
+                    }
+                    return -1
+                }
+            )
+
+            termination.start()
+            let succeeded = termination.wait()
+
+            #expect(succeeded)
+            #expect(signals.values == [
+                SignalCall(target: -processID, signal: SIGTERM),
+                SignalCall(target: -processID, signal: 0),
+                SignalCall(target: -processID, signal: 0)
+            ])
+        }
+    }
+
+    @Test("Delayed reap after denied group probes finishes cleanly within the grace period")
+    func delayedReapAfterDeniedProbesFinishesCleanly() throws {
+        try withSleepProcess { process, processID in
+            let signals = LockedSignalCalls()
+            let termination = ProcessTermination(
+                process: process,
+                gracePeriod: .seconds(5),
+                signalFunction: { target, signal in
+                    let callCount = signals.append(target: target, signal: signal)
+                    guard signal != SIGTERM else { return 0 }
+                    errno = callCount < 17 ? EPERM : ESRCH
+                    return -1
+                }
+            )
+
+            termination.start()
+            let succeeded = termination.wait()
+
+            #expect(succeeded)
+            let calls = signals.values
+            #expect(calls.first == SignalCall(target: -processID, signal: SIGTERM))
+            #expect(calls.dropFirst().allSatisfy { $0 == SignalCall(target: -processID, signal: 0) })
+        }
+    }
+
+    @Test("Resolved probe denial allows successful escalation at the grace deadline")
+    func resolvedProbeDenialAllowsSuccessfulEscalation() throws {
+        try withSleepProcess { process, processID in
+            let signals = LockedSignalCalls()
+            let termination = ProcessTermination(
+                process: process,
+                gracePeriod: .seconds(5),
+                signalFunction: { target, signal in
+                    let callCount = signals.append(target: target, signal: signal)
+                    if signal == SIGTERM || signal == SIGKILL { return 0 }
+                    if signals.values.contains(where: { $0.signal == SIGKILL }) {
+                        errno = ESRCH
+                        return -1
+                    }
+                    if callCount < 17 {
+                        errno = EPERM
+                        return -1
+                    }
+                    return 0
+                }
+            )
+
+            termination.start()
+            let succeeded = termination.wait()
+
+            #expect(succeeded)
+            let calls = signals.values
+            #expect(calls.first == SignalCall(target: -processID, signal: SIGTERM))
+            #expect(calls.contains(SignalCall(target: -processID, signal: SIGKILL)))
+            #expect(calls.last == SignalCall(target: -processID, signal: 0))
+        }
+    }
+}
+
+extension CommandRunnerProcessGroupTests {
+    @Test("Cancellation kills descendants that ignore SIGTERM and hold pipes open")
+    func cancellationKillsProcessGroup() async throws {
+        let pidURL = FileManager.default.temporaryDirectory
+            .appendingPathComponent("brewy-descendant-\(UUID().uuidString).pid")
+        defer { try? FileManager.default.removeItem(at: pidURL) }
+        let script = """
+        (trap "" TERM HUP; sleep 30) &
+        child=$!
+        printf "%s" "$child" > "$1"
+        wait
+        """
+        let task = Task {
+            await CommandRunner.runExecutable(
+                "/bin/sh",
+                arguments: ["-c", script, "brewy-cancel-test", pidURL.path]
+            )
+        }
+        defer { task.cancel() }
+
+        let descendantPID = try #require(await waitForPIDs(at: pidURL, count: 1).first)
+        defer { kill(descendantPID, SIGKILL) }
+
+        #expect(kill(descendantPID, 0) == 0)
+        let cancelStart = ContinuousClock.now
+        task.cancel()
+        let result = await task.value
+        let elapsed = ContinuousClock.now - cancelStart
+
+        for _ in 0..<200 where kill(descendantPID, 0) == 0 {
+            try await Task.sleep(for: .milliseconds(10))
+        }
+        #expect(result.cancelled)
+        #expect(!result.output.contains(incompleteTerminationWarning))
+        #expect(elapsed < .seconds(10))
+        #expect(kill(descendantPID, 0) == -1)
+    }
+
+    @Test("Late cancellation waits for a closed-pipe descendant after the leader exits")
+    func lateCancellationWaitsForProcessGroup() async throws {
+        let pidURL = FileManager.default.temporaryDirectory
+            .appendingPathComponent("brewy-closed-pipes-\(UUID().uuidString).pid")
+        defer { try? FileManager.default.removeItem(at: pidURL) }
+        let outputGate = BlockingOutputGate()
+        let script = """
+        (trap "" TERM HUP; exec </dev/null >/dev/null 2>&1; sleep 30) &
+        child=$!
+        printf "%s %s" "$$" "$child" > "$1"
+        printf ready
+        exit 0
+        """
+        let task = Task {
+            await CommandRunner.runExecutable(
+                "/bin/sh",
+                arguments: ["-c", script, "brewy-cancel-test", pidURL.path],
+                onOutput: { _ in outputGate.block() }
+            )
+        }
+        defer {
+            task.cancel()
+            outputGate.open()
+        }
+
+        let pids = try await waitForPIDs(at: pidURL, count: 2)
+        let leaderPID = try #require(pids.first)
+        let descendantPID = try #require(pids.last)
+        defer { kill(descendantPID, SIGKILL) }
+        for _ in 0..<1_000 where !outputGate.wasReached {
+            try await Task.sleep(for: .milliseconds(10))
+        }
+        #expect(outputGate.wasReached)
+
+        for _ in 0..<1_000 where kill(leaderPID, 0) == 0 {
+            try await Task.sleep(for: .milliseconds(10))
+        }
+        #expect(kill(leaderPID, 0) == -1)
+        #expect(kill(descendantPID, 0) == 0)
+
+        let cancelStart = ContinuousClock.now
+        task.cancel()
+        outputGate.open()
+        let result = await task.value
+        let elapsed = ContinuousClock.now - cancelStart
+
+        #expect(result.cancelled)
+        #expect(!result.output.contains(incompleteTerminationWarning))
+        #expect(elapsed < .seconds(10))
+        #expect(kill(descendantPID, 0) == -1)
+    }
+
+    @Test("Cancellation still reaches the group after its leader exits")
+    func cancellationAfterLeaderExitKillsProcessGroup() async throws {
+        let pidURL = FileManager.default.temporaryDirectory
+            .appendingPathComponent("brewy-exited-leader-\(UUID().uuidString).pid")
+        defer { try? FileManager.default.removeItem(at: pidURL) }
+        let script = """
+        (trap "" TERM HUP; sleep 30) &
+        child=$!
+        printf "%s %s" "$$" "$child" > "$1"
+        exit 0
+        """
+        let task = Task {
+            await CommandRunner.runExecutable(
+                "/bin/sh",
+                arguments: ["-c", script, "brewy-cancel-test", pidURL.path]
+            )
+        }
+        defer { task.cancel() }
+
+        let pids = try await waitForPIDs(at: pidURL, count: 2)
+        let leaderPID = try #require(pids.first)
+        let descendantPID = try #require(pids.last)
+        defer { kill(descendantPID, SIGKILL) }
+
+        for _ in 0..<200 where kill(leaderPID, 0) == 0 {
+            try await Task.sleep(for: .milliseconds(10))
+        }
+        #expect(kill(leaderPID, 0) == -1)
+        #expect(kill(descendantPID, 0) == 0)
+
+        let cancelStart = ContinuousClock.now
+        task.cancel()
+        let result = await task.value
+        let elapsed = ContinuousClock.now - cancelStart
+
+        for _ in 0..<200 where kill(descendantPID, 0) == 0 {
+            try await Task.sleep(for: .milliseconds(10))
+        }
+        #expect(result.cancelled)
+        #expect(!result.output.contains(incompleteTerminationWarning))
+        #expect(elapsed < .seconds(10))
+        #expect(kill(descendantPID, 0) == -1)
+    }
+
+    private func waitForPIDs(at url: URL, count: Int) async throws -> [Int32] {
+        var pids: [Int32] = []
+        for _ in 0..<1_000 {
+            if let contents = try? String(contentsOf: url, encoding: .utf8) {
+                pids = contents.split(separator: " ").compactMap { Int32($0) }
+                if pids.count == count { break }
+            }
+            try await Task.sleep(for: .milliseconds(10))
+        }
+        try #require(pids.count == count)
+        return pids
+    }
+}
+
+private final class BlockingOutputGate: @unchecked Sendable {
+    private let lock = NSLock()
+    private let release = DispatchSemaphore(value: 0)
+    private var reached = false
+    private var opened = false
+
+    var wasReached: Bool {
+        lock.withLock { reached }
+    }
+
+    func block() {
+        let shouldWait = lock.withLock {
+            reached = true
+            return !opened
+        }
+        if shouldWait { release.wait() }
+    }
+
+    func open() {
+        let shouldSignal = lock.withLock {
+            guard !opened else { return false }
+            opened = true
+            return true
+        }
+        if shouldSignal { release.signal() }
+    }
+}
+
+private func withSleepProcess(_ body: (Process, Int32) throws -> Void) throws {
+    let process = Process()
+    process.executableURL = URL(fileURLWithPath: "/bin/sleep")
+    process.arguments = ["30"]
+    try process.run()
+    let processID = process.processIdentifier
+    defer {
+        kill(-processID, SIGKILL)
+        kill(processID, SIGKILL)
+        process.waitUntilExit()
+    }
+    try body(process, processID)
+}
+
+private struct SignalCall: Equatable {
+    let target: Int32
+    let signal: Int32
+
+    static func == (lhs: Self, rhs: Self) -> Bool {
+        lhs.target == rhs.target && lhs.signal == rhs.signal
+    }
+}
+
+private final class LockedSignalCalls: @unchecked Sendable {
+    private let lock = NSLock()
+    private var calls: [SignalCall] = []
+
+    var values: [SignalCall] {
+        lock.withLock { calls }
+    }
+
+    @discardableResult
+    func append(target: Int32, signal: Int32) -> Int {
+        lock.withLock {
+            calls.append(SignalCall(target: target, signal: signal))
+            return calls.count
+        }
+    }
+}

--- a/BrewyTests/CommandRunnerTests.swift
+++ b/BrewyTests/CommandRunnerTests.swift
@@ -115,7 +115,7 @@ struct BrewServiceTimeoutPropagationTests {
     }
 }
 
-@Suite("CommandRunner Process Execution")
+@Suite("CommandRunner Process Execution", .serialized)
 struct CommandRunnerProcessTests {
 
     @Test("runExecutable captures stdout from echo")
@@ -187,6 +187,29 @@ struct CommandRunnerProcessTests {
         // Deliberately loose: the point is that the child was killed rather than allowed to
         // finish its 30 s sleep. A tighter bound only measures how loaded the machine is.
         #expect(elapsed < .seconds(25))
+    }
+
+    @Test("Timeout watchdog runs on its dedicated thread")
+    func timeoutWatchdogFires() {
+        let fired = DispatchSemaphore(value: 0)
+        let watchdog = TimeoutWatchdog(deadline: .now() + .milliseconds(50)) {
+            fired.signal()
+        }
+
+        #expect(fired.wait(timeout: .now() + .seconds(10)) == .success)
+        withExtendedLifetime(watchdog) {}
+    }
+
+    @Test("Timeout watchdog cancellation prevents its action")
+    func timeoutWatchdogCancellation() {
+        let fired = DispatchSemaphore(value: 0)
+        let watchdog = TimeoutWatchdog(deadline: .now() + .seconds(30)) {
+            fired.signal()
+        }
+
+        watchdog.cancel()
+
+        #expect(fired.wait(timeout: .now() + .milliseconds(200)) == .timedOut)
     }
 
     @Test("runExecutable includes partial output on timeout")

--- a/BrewyTests/CommandRunnerTests.swift
+++ b/BrewyTests/CommandRunnerTests.swift
@@ -280,92 +280,15 @@ struct CommandRunnerProcessTests {
         #expect(result.output.contains("before-cancel"))
     }
 
-    @Test("Cancellation kills descendants that ignore SIGTERM and hold pipes open")
-    func cancellationKillsProcessGroup() async throws {
-        let pidURL = FileManager.default.temporaryDirectory
-            .appendingPathComponent("brewy-descendant-\(UUID().uuidString).pid")
-        defer { try? FileManager.default.removeItem(at: pidURL) }
-        let script = """
-        (trap "" TERM HUP; sleep 30) &
-        child=$!
-        printf "%s" "$child" > "$1"
-        wait
-        """
-        let task = Task {
-            await CommandRunner.runExecutable(
-                "/bin/sh",
-                arguments: ["-c", script, "brewy-cancel-test", pidURL.path]
-            )
-        }
-        defer { task.cancel() }
+    @Test("Incomplete process teardown appends the user warning")
+    func incompleteTerminationWarning() {
+        let message = "Command was cancelled."
 
-        for _ in 0..<1_000 where !FileManager.default.fileExists(atPath: pidURL.path) {
-            try await Task.sleep(for: .milliseconds(10))
-        }
-        let pidText = try String(contentsOf: pidURL, encoding: .utf8)
-        let descendantPID = try #require(Int32(pidText))
-        defer { kill(descendantPID, SIGKILL) }
-
-        let cancelStart = ContinuousClock.now
-        task.cancel()
-        let result = await task.value
-        let elapsed = ContinuousClock.now - cancelStart
-
-        for _ in 0..<200 where kill(descendantPID, 0) == 0 {
-            try await Task.sleep(for: .milliseconds(10))
-        }
-        #expect(result.cancelled)
-        #expect(elapsed < .seconds(10))
-        #expect(kill(descendantPID, 0) == -1)
-    }
-
-    @Test("Cancellation still reaches the group after its leader exits")
-    func cancellationAfterLeaderExitKillsProcessGroup() async throws {
-        let pidURL = FileManager.default.temporaryDirectory
-            .appendingPathComponent("brewy-exited-leader-\(UUID().uuidString).pid")
-        defer { try? FileManager.default.removeItem(at: pidURL) }
-        let script = """
-        (trap "" TERM HUP; sleep 30) &
-        child=$!
-        printf "%s %s" "$$" "$child" > "$1"
-        exit 0
-        """
-        let task = Task {
-            await CommandRunner.runExecutable(
-                "/bin/sh",
-                arguments: ["-c", script, "brewy-cancel-test", pidURL.path]
-            )
-        }
-        defer { task.cancel() }
-
-        for _ in 0..<1_000 where !FileManager.default.fileExists(atPath: pidURL.path) {
-            try await Task.sleep(for: .milliseconds(10))
-        }
-        let pids = try String(contentsOf: pidURL, encoding: .utf8)
-            .split(separator: " ")
-            .compactMap { Int32($0) }
-        #expect(pids.count == 2)
-        let leaderPID = try #require(pids.first)
-        let descendantPID = try #require(pids.last)
-        defer { kill(descendantPID, SIGKILL) }
-
-        for _ in 0..<200 where kill(leaderPID, 0) == 0 {
-            try await Task.sleep(for: .milliseconds(10))
-        }
-        #expect(kill(leaderPID, 0) == -1)
-        #expect(kill(descendantPID, 0) == 0)
-
-        let cancelStart = ContinuousClock.now
-        task.cancel()
-        let result = await task.value
-        let elapsed = ContinuousClock.now - cancelStart
-
-        for _ in 0..<200 where kill(descendantPID, 0) == 0 {
-            try await Task.sleep(for: .milliseconds(10))
-        }
-        #expect(result.cancelled)
-        #expect(elapsed < .seconds(10))
-        #expect(kill(descendantPID, 0) == -1)
+        #expect(CommandRunner.terminationOutput(message, succeeded: true) == message)
+        #expect(
+            CommandRunner.terminationOutput(message, succeeded: false)
+                == "\(message)\nSome child processes may still be running."
+        )
     }
 
     @Test("Streaming delivers output and matches the final result")

--- a/BrewyTests/PipeReaderTests.swift
+++ b/BrewyTests/PipeReaderTests.swift
@@ -2,7 +2,7 @@
 import Foundation
 import Testing
 
-@Suite("PipeReader")
+@Suite("PipeReader", .serialized)
 struct PipeReaderTests {
 
     @Test("Event-driven reader drains data through EOF")


### PR DESCRIPTION
CI intermittently failed the process-group cancellation tests under Thread Sanitizer with no sanitizer report: a SIGTERM-resistant descendant was still alive after `CommandRunner` returned. SIGTERM was sent synchronously, but the SIGKILL escalation was scheduled with `DispatchQueue.asyncAfter`, and a loaded runner could delay it past the point where the result was built.

Cancellation and timeout now share `ProcessTermination`, one idempotent coordinator that signals the process group, escalates to SIGKILL on a dedicated thread, and polls until the target is gone. The timeout that starts that sequence runs on its own watchdog thread rather than the dispatch pool, for the same reason. `CommandRunner` joins that sequence before classifying the result, and `ProcessHandle` latches once the result is decided so a late cancellation is neither lost nor able to signal a reaped PID. Natural completion still skips the grace period.

`kill(2)` reports `EPERM` for a process group when any member cannot be signaled, so partial delivery still escalates to SIGKILL and can never report a clean teardown. That path is covered through an injected signal function rather than a live administrator-authenticated run.

AI disclosure: Claude Opus 5 with manual testing and review.
