### PR TITLE
feat(settings): add a toggle to hide the Dock icon

### DIFF
--- a/Brewy/BrewyApp.swift
+++ b/Brewy/BrewyApp.swift
@@ -4,6 +4,8 @@ import SwiftUI
 
 @main
 struct BrewyApp: App {
+    @NSApplicationDelegateAdaptor(BrewyApplicationDelegate.self)
+    private var applicationDelegate
     @State private var brewService = Self.makeBrewService()
     // HACK: there is a known color scheme bug in SwiftUI where passing `nil` to `.preferredColorScheme`
     // doesn't change the color of some elements:
@@ -14,6 +16,7 @@ struct BrewyApp: App {
     private let updaterController: SPUStandardUpdaterController
 
     init() {
+        AppVisibilitySettings.prepareDefaults()
         updaterController = SPUStandardUpdaterController(
             startingUpdater: !BrewyRuntime.isRunningTests,
             updaterDelegate: nil,
@@ -25,8 +28,12 @@ struct BrewyApp: App {
     private var appTheme = AppTheme.system.rawValue
     @AppStorage("appIcon")
     private var appIcon = AppIconSelection.current.rawValue
-    @AppStorage("showMenuBarIcon")
+    @AppStorage(AppVisibilitySettings.showMenuBarIconKey)
     private var showMenuBarIcon = true
+    @AppStorage(AppVisibilitySettings.showDockIconKey)
+    private var showDockIcon = true
+    @AppStorage("autoRefreshInterval")
+    private var autoRefreshInterval = 0
 
     private static func colorScheme(for appearance: NSAppearance) -> ColorScheme? {
         switch appearance.bestMatch(from: [.aqua, .darkAqua]) {
@@ -60,12 +67,17 @@ struct BrewyApp: App {
                 .onChange(of: appIcon, initial: true) {
                     AppIconSelection.apply(rawValue: appIcon)
                 }
+                .onChange(of: showDockIcon, initial: true) {
+                    AppVisibilitySettings.applyDockIconVisibility(showDockIcon)
+                }
                 .frame(minWidth: 920, minHeight: 620)
         }
         .windowStyle(.automatic)
         .windowToolbarStyle(.unified)
         .windowResizability(.contentMinSize)
         .defaultSize(width: 960, height: 640)
+        .defaultLaunchBehavior(showDockIcon ? .automatic : .suppressed)
+        .restorationBehavior(showDockIcon ? .automatic : .disabled)
         .commands {
             CommandGroup(after: .appInfo) {
                 CheckForUpdatesView(updater: updaterController.updater)
@@ -104,6 +116,10 @@ struct BrewyApp: App {
                 count > 0 ? "\(count)" : "Brewy",
                 systemImage: count > 0 ? "shippingbox.fill" : "shippingbox"
             )
+            .accessibilityIdentifier("brewy-menu-bar-icon")
+            .task(id: autoRefreshInterval) {
+                brewService.startPackageUpdates(autoRefreshInterval: autoRefreshInterval)
+            }
         }
     }
 }
@@ -172,7 +188,7 @@ private struct MenuBarView: View {
             if homebrewOutdatedCount > 0 {
                 Divider()
                 Button("Upgrade Homebrew Packages") {
-                    openWindow(id: "main")
+                    openMainWindow()
                     Task { await brewService.upgradeAll() }
                 }
             }
@@ -187,10 +203,12 @@ private struct MenuBarView: View {
         }
         .keyboardShortcut("r")
 
+        SettingsLink()
+
         Divider()
 
         Button("Open Brewy") {
-            openWindow(id: "main")
+            openMainWindow()
         }
         .keyboardShortcut("o")
 
@@ -198,5 +216,10 @@ private struct MenuBarView: View {
             NSApplication.shared.terminate(nil)
         }
         .keyboardShortcut("q")
+    }
+
+    private func openMainWindow() {
+        NSApplication.shared.activate()
+        openWindow(id: "main")
     }
 }

--- a/Brewy/Models/AppVisibilitySettings.swift
+++ b/Brewy/Models/AppVisibilitySettings.swift
@@ -1,0 +1,128 @@
+import AppKit
+import Foundation
+import OSLog
+
+private let logger = Logger(subsystem: "io.linnane.brewy", category: "AppVisibilitySettings")
+
+enum AppVisibilitySettings {
+    enum EntryPoint {
+        case dock
+        case menuBar
+    }
+
+    static let showDockIconKey = "showDockIcon"
+    static let showMenuBarIconKey = "showMenuBarIcon"
+
+    static func prepareDefaults(
+        _ defaults: UserDefaults = .standard,
+        repairsInvalidState: Bool = !BrewyRuntime.isUnitTesting
+    ) {
+        defaults.register(defaults: [
+            showDockIconKey: true,
+            showMenuBarIconKey: true
+        ])
+
+        let arguments = defaults.volatileDomain(forName: UserDefaults.argumentDomain)
+        guard repairsInvalidState,
+              shouldRepairHiddenState(
+                  showDockIcon: defaults.bool(forKey: showDockIconKey),
+                  showMenuBarIcon: defaults.bool(forKey: showMenuBarIconKey),
+                  argumentDomain: arguments
+              ) else { return }
+        repairHiddenState(defaults, restoring: .menuBar)
+    }
+
+    @discardableResult
+    static func repairHiddenState(
+        _ defaults: UserDefaults = .standard,
+        restoring entryPoint: EntryPoint
+    ) -> Bool {
+        guard !defaults.bool(forKey: showDockIconKey),
+              !defaults.bool(forKey: showMenuBarIconKey) else { return false }
+
+        let key = switch entryPoint {
+        case .dock: showDockIconKey
+        case .menuBar: showMenuBarIconKey
+        }
+        defaults.set(true, forKey: key)
+        return true
+    }
+
+    static func hasVisibilityArgumentOverrides(_ defaults: UserDefaults = .standard) -> Bool {
+        // Argument-domain values outrank persisted defaults, so repairing under an override would
+        // mutate the user's real preferences without changing the effective value for this launch.
+        let arguments = defaults.volatileDomain(forName: UserDefaults.argumentDomain)
+        return hasVisibilityArgumentOverrides(in: arguments)
+    }
+
+    static func shouldRepairHiddenState(
+        showDockIcon: Bool,
+        showMenuBarIcon: Bool,
+        argumentDomain: [String: Any]
+    ) -> Bool {
+        !hasVisibilityArgumentOverrides(in: argumentDomain) && !showDockIcon && !showMenuBarIcon
+    }
+
+    private static func hasVisibilityArgumentOverrides(in arguments: [String: Any]) -> Bool {
+        arguments[showDockIconKey] != nil || arguments[showMenuBarIconKey] != nil
+    }
+
+    static func activationPolicy(showDockIcon: Bool) -> NSApplication.ActivationPolicy {
+        showDockIcon ? .regular : .accessory
+    }
+
+    @MainActor
+    static func applyDockIconVisibility(_ isVisible: Bool) {
+        guard !BrewyRuntime.isUnitTesting else { return }
+
+        let policy = activationPolicy(showDockIcon: isVisible)
+        let application = NSApplication.shared
+        guard application.activationPolicy() != policy else { return }
+        guard application.setActivationPolicy(policy) else {
+            logger.error("Failed to set application activation policy to \(String(describing: policy))")
+            return
+        }
+        if application.windows.contains(where: \.isVisible) {
+            application.activate()
+        }
+    }
+}
+
+@MainActor
+final class BrewyApplicationDelegate: NSObject, NSApplicationDelegate {
+    private var userDefaultsObserver: (any NSObjectProtocol)?
+
+    func applicationWillFinishLaunching(_ notification: Notification) {
+        AppVisibilitySettings.applyDockIconVisibility(
+            UserDefaults.standard.bool(forKey: AppVisibilitySettings.showDockIconKey)
+        )
+    }
+
+    func applicationDidFinishLaunching(_ notification: Notification) {
+        guard !BrewyRuntime.isUnitTesting else { return }
+        userDefaultsObserver = NotificationCenter.default.addObserver(
+            forName: UserDefaults.didChangeNotification,
+            object: UserDefaults.standard,
+            queue: .main
+        ) { _ in
+            MainActor.assumeIsolated {
+                Self.repairVisibilityIfNeeded()
+            }
+        }
+    }
+
+    func applicationWillTerminate(_ notification: Notification) {
+        if let userDefaultsObserver {
+            NotificationCenter.default.removeObserver(userDefaultsObserver)
+        }
+    }
+
+    private static func repairVisibilityIfNeeded() {
+        let defaults = UserDefaults.standard
+        guard !AppVisibilitySettings.hasVisibilityArgumentOverrides(defaults) else { return }
+        AppVisibilitySettings.repairHiddenState(defaults, restoring: .dock)
+        AppVisibilitySettings.applyDockIconVisibility(
+            defaults.bool(forKey: AppVisibilitySettings.showDockIconKey)
+        )
+    }
+}

--- a/Brewy/Models/BrewService+Startup.swift
+++ b/Brewy/Models/BrewService+Startup.swift
@@ -1,0 +1,43 @@
+import Foundation
+
+extension BrewService {
+    func startPackageUpdates(autoRefreshInterval: Int) {
+        scheduleAutoRefresh(interval: autoRefreshInterval)
+        guard !packageUpdatesStarted else { return }
+        packageUpdatesStarted = true
+
+#if DEBUG
+        if BrewyRuntime.isUITesting {
+            loadUITestFixtures()
+            return
+        }
+#endif
+
+        loadFromCache()
+        guard !BrewyRuntime.isRunningTests else { return }
+        initialRefreshTask = Task { [weak self] in
+            guard let self else { return }
+            await refresh()
+        }
+    }
+
+    private func scheduleAutoRefresh(interval: Int) {
+        guard scheduledAutoRefreshInterval != interval else { return }
+        scheduledAutoRefreshInterval = interval
+        autoRefreshTask?.cancel()
+        autoRefreshTask = nil
+
+        guard interval > 0, !BrewyRuntime.isRunningTests else { return }
+        autoRefreshTask = Task { [weak self] in
+            while !Task.isCancelled {
+                do {
+                    try await Task.sleep(for: .seconds(interval))
+                } catch {
+                    return
+                }
+                guard let self, !Task.isCancelled else { return }
+                await refresh(isUserInitiated: false)
+            }
+        }
+    }
+}

--- a/Brewy/Models/BrewService.swift
+++ b/Brewy/Models/BrewService.swift
@@ -55,6 +55,11 @@ final class BrewService {
         self.commandRunner = commandRunner
     }
 
+    deinit {
+        initialRefreshTask?.cancel()
+        autoRefreshTask?.cancel()
+    }
+
     var installedFormulae: [BrewPackage] = [] {
         didSet {
             guard !isBatchingUpdates else { return }
@@ -106,6 +111,10 @@ final class BrewService {
     @ObservationIgnored var infoCache: [String: String] = [:]
     @ObservationIgnored private var tapHealthTask: Task<Void, Never>?
     @ObservationIgnored var actionCommandTask: Task<CommandResult, Never>?
+    @ObservationIgnored var packageUpdatesStarted = false
+    @ObservationIgnored var scheduledAutoRefreshInterval: Int?
+    @ObservationIgnored var initialRefreshTask: Task<Void, Never>?
+    @ObservationIgnored var autoRefreshTask: Task<Void, Never>?
 
     // MARK: - Cached Derived State
 

--- a/Brewy/Views/ContentView.swift
+++ b/Brewy/Views/ContentView.swift
@@ -99,15 +99,11 @@ struct ContentView: View {
         }
         .task {
 #if DEBUG
-            if BrewyRuntime.isUITesting {
-                brewService.loadUITestFixtures()
-                return
-            }
+            if BrewyRuntime.isUITesting { return }
 #endif
             if showCasksByDefault {
                 selectedCategory = .casks
             }
-            brewService.loadFromCache()
             brewService.loadTapHealthCache()
             brewService.loadGroups()
             brewService.loadHistory()
@@ -119,17 +115,10 @@ struct ContentView: View {
                 lastSeenVersion = currentVersion
                 showWhatsNew = true
             }
-            async let bundleRefresh: Void = brewService.refreshBundle()
-            await brewService.refresh()
-            await bundleRefresh
+            await brewService.refreshBundle()
         }
         .task(id: autoRefreshInterval) {
-            guard autoRefreshInterval > 0 else { return }
-            while !Task.isCancelled {
-                try? await Task.sleep(for: .seconds(autoRefreshInterval))
-                guard !Task.isCancelled else { break }
-                await brewService.refresh(isUserInitiated: false)
-            }
+            brewService.startPackageUpdates(autoRefreshInterval: autoRefreshInterval)
         }
         .onChange(of: selectedCategory) {
             // Cleared here (not in PackageListView, which is torn down when switching to a

--- a/Brewy/Views/SettingsView.swift
+++ b/Brewy/Views/SettingsView.swift
@@ -31,8 +31,10 @@ struct SettingsView: View {
     private var appTheme = AppTheme.system.rawValue
     @AppStorage("appIcon")
     private var appIcon = AppIconSelection.current.rawValue
-    @AppStorage("showMenuBarIcon")
+    @AppStorage(AppVisibilitySettings.showMenuBarIconKey)
     private var showMenuBarIcon = true
+    @AppStorage(AppVisibilitySettings.showDockIconKey)
+    private var showDockIcon = true
 
     private var isBrewPathValid: Bool {
         FileManager.default.isExecutableFile(atPath: brewPath)
@@ -90,9 +92,7 @@ struct SettingsView: View {
                 }
             }
 
-            Toggle("Show menu bar icon", isOn: $showMenuBarIcon)
-                .accessibilityIdentifier("show-menu-bar-icon-toggle")
-                .help("Shows package status and quick actions in the menu bar.")
+            appVisibilitySettings
 
             Toggle("Show Casks by default", isOn: $showCasksByDefault)
         }
@@ -102,7 +102,29 @@ struct SettingsView: View {
         .onChange(of: appIcon, initial: true) {
             AppIconSelection.apply(rawValue: appIcon)
         }
-        .frame(width: 560, height: 440)
+        .onChange(of: showDockIcon, initial: true) {
+            AppVisibilitySettings.applyDockIconVisibility(showDockIcon)
+        }
+        .frame(width: 560, height: 470)
+    }
+
+    private var appVisibilitySettings: some View {
+        Group {
+            Toggle("Show Dock icon", isOn: $showDockIcon)
+                .accessibilityIdentifier("show-dock-icon-toggle")
+                .help("Shows Brewy in the Dock and opens its window at launch. At least one app icon must remain visible.")
+                .disabled(!showMenuBarIcon)
+
+            Toggle("Show menu bar icon", isOn: $showMenuBarIcon)
+                .accessibilityIdentifier("show-menu-bar-icon-toggle")
+                .help("Shows package status and quick actions. At least one app icon must remain visible.")
+                .disabled(!showDockIcon)
+
+            Text("Keep at least one icon visible so you can reopen Brewy.")
+                .font(.caption)
+                .foregroundStyle(.secondary)
+                .fixedSize(horizontal: false, vertical: true)
+        }
     }
 
     private var brewfileOverrideSetting: some View {

--- a/BrewyTests/AppVisibilitySettingsTests.swift
+++ b/BrewyTests/AppVisibilitySettingsTests.swift
@@ -1,0 +1,74 @@
+import AppKit
+@testable import Brewy
+import Foundation
+import Testing
+
+@Suite("AppVisibilitySettings")
+struct AppVisibilitySettingsTests {
+    @Test("Maps Dock visibility to the matching activation policy")
+    func activationPolicy() {
+        #expect(AppVisibilitySettings.activationPolicy(showDockIcon: true) == .regular)
+        #expect(AppVisibilitySettings.activationPolicy(showDockIcon: false) == .accessory)
+    }
+
+    @Test("Defaults keep both app entry points visible")
+    func registersVisibleDefaults() throws {
+        let (defaults, suiteName) = try makeDefaults()
+        defer { defaults.removePersistentDomain(forName: suiteName) }
+
+        AppVisibilitySettings.prepareDefaults(defaults, repairsInvalidState: true)
+
+        #expect(defaults.bool(forKey: AppVisibilitySettings.showDockIconKey))
+        #expect(defaults.bool(forKey: AppVisibilitySettings.showMenuBarIconKey))
+    }
+
+    @Test("Invalid hidden state restores the menu bar entry point")
+    func restoresMenuBarEntryPoint() throws {
+        let (defaults, suiteName) = try makeDefaults()
+        defer { defaults.removePersistentDomain(forName: suiteName) }
+        defaults.set(false, forKey: AppVisibilitySettings.showDockIconKey)
+        defaults.set(false, forKey: AppVisibilitySettings.showMenuBarIconKey)
+
+        AppVisibilitySettings.prepareDefaults(defaults, repairsInvalidState: true)
+
+        #expect(!defaults.bool(forKey: AppVisibilitySettings.showDockIconKey))
+        #expect(defaults.bool(forKey: AppVisibilitySettings.showMenuBarIconKey))
+    }
+
+    @Test("Runtime repair restores the Dock entry point")
+    func restoresDockEntryPoint() throws {
+        let (defaults, suiteName) = try makeDefaults()
+        defer { defaults.removePersistentDomain(forName: suiteName) }
+        defaults.set(false, forKey: AppVisibilitySettings.showDockIconKey)
+        defaults.set(false, forKey: AppVisibilitySettings.showMenuBarIconKey)
+
+        let repaired = AppVisibilitySettings.repairHiddenState(defaults, restoring: .dock)
+
+        #expect(repaired)
+        #expect(defaults.bool(forKey: AppVisibilitySettings.showDockIconKey))
+        #expect(!defaults.bool(forKey: AppVisibilitySettings.showMenuBarIconKey))
+    }
+
+    @Test("Launch arguments suppress persistent visibility repair")
+    func launchArgumentsSuppressRepair() {
+        #expect(
+            !AppVisibilitySettings.shouldRepairHiddenState(
+                showDockIcon: false,
+                showMenuBarIcon: false,
+                argumentDomain: [AppVisibilitySettings.showDockIconKey: false]
+            )
+        )
+        #expect(
+            !AppVisibilitySettings.shouldRepairHiddenState(
+                showDockIcon: false,
+                showMenuBarIcon: false,
+                argumentDomain: [AppVisibilitySettings.showMenuBarIconKey: false]
+            )
+        )
+    }
+
+    private func makeDefaults() throws -> (UserDefaults, String) {
+        let suiteName = "AppVisibilitySettingsTests-\(UUID().uuidString)"
+        return (try #require(UserDefaults(suiteName: suiteName)), suiteName)
+    }
+}

--- a/BrewyUITests/DockIconSettingsUITests.swift
+++ b/BrewyUITests/DockIconSettingsUITests.swift
@@ -1,0 +1,115 @@
+import XCTest
+
+@MainActor
+final class DockIconSettingsUITests: XCTestCase {
+    private static let timeoutScale: TimeInterval = isThreadSanitizerActive ? 4 : 1
+    private static let launchTimeout: TimeInterval = 30 * timeoutScale
+    private static let transitionTimeout: TimeInterval = 10 * timeoutScale
+
+    private var app: XCUIApplication!
+    private var fixtureDirectory: URL!
+
+    override func setUp() async throws {
+        continueAfterFailure = false
+        fixtureDirectory = FileManager.default.temporaryDirectory
+            .appendingPathComponent("brewy-dock-icon-ui-tests-\(ProcessInfo.processInfo.globallyUniqueString)")
+        try FileManager.default.createDirectory(at: fixtureDirectory, withIntermediateDirectories: true)
+
+        app = XCUIApplication()
+        app.terminate()
+        app.launchArguments += [
+            "-ApplePersistenceIgnoreState", "YES",
+            "-autoRefreshInterval", "0",
+            "-brewfilePath", "",
+            "-showCasksByDefault", "NO",
+            "-showDockIcon", "NO",
+            "-showMenuBarIcon", "YES"
+        ]
+        app.launchEnvironment["BREWY_UI_TESTING"] = "1"
+        app.launchEnvironment["XDG_CONFIG_HOME"] = fixtureDirectory.path
+        app.launch()
+    }
+
+    override func tearDown() async throws {
+        app?.terminate()
+        app = nil
+        try? FileManager.default.removeItem(at: fixtureDirectory)
+        fixtureDirectory = nil
+    }
+
+    func testMenuBarOnlyLaunchCanOpenMainWindow() {
+        XCTAssertFalse(
+            app.windows.firstMatch.waitForExistence(timeout: 2 * Self.timeoutScale),
+            "The main window should be suppressed when the Dock icon is hidden"
+        )
+
+        let statusItem = app.menuBars.statusItems["brewy-menu-bar-icon"]
+        XCTAssertTrue(
+            statusItem.waitForExistence(timeout: Self.launchTimeout),
+            "The menu bar icon should remain available"
+        )
+        statusItem.click()
+
+        XCTAssertTrue(
+            app.menuItems["2 packages outdated"].waitForExistence(timeout: Self.transitionTimeout),
+            "The menu bar should load package state without opening the main window"
+        )
+
+        let openBrewy = app.menuItems["Open Brewy"]
+        XCTAssertTrue(
+            openBrewy.waitForExistence(timeout: Self.transitionTimeout),
+            "The menu bar should offer an Open Brewy action"
+        )
+        openBrewy.click()
+
+        XCTAssertTrue(
+            app.wait(for: .runningForeground, timeout: Self.transitionTimeout),
+            "Open Brewy should activate the app"
+        )
+        let mainWindow = app.windows.firstMatch
+        XCTAssertTrue(
+            mainWindow.waitForExistence(timeout: Self.transitionTimeout),
+            "Open Brewy should present the main window"
+        )
+        XCTAssertTrue(mainWindow.isHittable, "The opened main window should be in the foreground")
+    }
+
+    func testMenuBarOnlyLaunchCanOpenSettings() {
+        XCTAssertFalse(
+            app.windows.firstMatch.waitForExistence(timeout: 2 * Self.timeoutScale),
+            "The main window should be suppressed when the Dock icon is hidden"
+        )
+
+        let statusItem = app.menuBars.statusItems["brewy-menu-bar-icon"]
+        XCTAssertTrue(
+            statusItem.waitForExistence(timeout: Self.launchTimeout),
+            "The menu bar icon should remain available"
+        )
+        statusItem.click()
+
+        let settings = statusItem.menuItems["Settings…"]
+        XCTAssertTrue(
+            settings.waitForExistence(timeout: Self.transitionTimeout),
+            "The menu bar should offer a Settings action"
+        )
+        settings.click()
+
+        XCTAssertTrue(
+            app.wait(for: .runningForeground, timeout: Self.transitionTimeout),
+            "Settings should activate the app"
+        )
+        let settingsWindow = app.windows["Brewy Settings"]
+        XCTAssertTrue(
+            settingsWindow.waitForExistence(timeout: Self.transitionTimeout),
+            "Settings should present the Settings window"
+        )
+        XCTAssertTrue(settingsWindow.isHittable, "The Settings window should be in the foreground")
+    }
+
+    private static var isThreadSanitizerActive: Bool {
+        (0..<_dyld_image_count()).contains { index in
+            guard let name = _dyld_get_image_name(index) else { return false }
+            return String(cString: name).contains("libclang_rt.tsan")
+        }
+    }
+}

--- a/BrewyUITests/SidebarNavigationUITests.swift
+++ b/BrewyUITests/SidebarNavigationUITests.swift
@@ -38,6 +38,7 @@ final class SidebarNavigationUITests: XCTestCase {
             "-autoRefreshInterval", "0",
             "-brewfilePath", "",
             "-showCasksByDefault", "NO",
+            "-showDockIcon", "YES",
             "-showMenuBarIcon", "YES",
             "-trustedBrewfilePath", brewfileURL.path,
             "-trustedBrewfileDigest", brewfileDigest
@@ -302,7 +303,8 @@ final class MenuBarSettingsUITests: XCTestCase {
             "-NSConstraintBasedLayoutVisualizeMutuallyExclusiveConstraints", "YES",
             "-autoRefreshInterval", "0",
             "-brewfilePath", "",
-            "-showCasksByDefault", "NO"
+            "-showCasksByDefault", "NO",
+            "-showDockIcon", "YES"
         ]
         app.launchEnvironment["BREWY_UI_TESTING"] = "1"
         app.launchEnvironment["XDG_CONFIG_HOME"] = fixtureDirectory.path


### PR DESCRIPTION
Adds a "Show Dock icon" toggle in Settings so Brewy can run menu-bar-only. The setting maps to the app's activation policy, applied by an application delegate during launch, and the main window's launch and state-restoration behavior follow it, so a menu-bar-only launch starts with no window rather than restoring saved ones. "Open Brewy" and a new "Settings…" item in the status menu bring the app forward and present their window.

The two visibility toggles interlock so the last remaining icon cannot be switched off, and startup repairs a persisted state where both are hidden. A defaults observer covers in-process changes that bypass Settings, such as Command-dragging the status item out of the menu bar. Launch-argument overrides suppress that repair, since argument-domain values outrank persisted ones and repairing would rewrite real preferences without changing the effective value for that launch.

Cache loading, the initial refresh, and the auto-refresh timer move from `ContentView` into `BrewService`. They previously lived in the main window's `.task`, so a menu-bar-only launch would have reported "All packages up to date" with no badge for as long as the window stayed closed.

Closes #286.

AI disclosure: Claude Opus 5 with manual testing and review.
