### PR TITLE
refactor(cache): make package cache persistence testable

### DIFF
--- a/Brewy/Models/BrewService+Taps.swift
+++ b/Brewy/Models/BrewService+Taps.swift
@@ -15,7 +15,7 @@ extension BrewService {
         }
         installedTaps = fetchedTaps
         tapsLoaded = true
-        saveToCache()
+        await saveToCache()
     }
 
     // MARK: - Tap Management

--- a/Brewy/Models/BrewService.swift
+++ b/Brewy/Models/BrewService.swift
@@ -38,6 +38,8 @@ enum BrewError: LocalizedError {
 @MainActor
 final class BrewService {
     @ObservationIgnored let commandRunner: CommandRunning
+    @ObservationIgnored private let packageCacheURL: URL?
+    @ObservationIgnored private let packageCacheWritesEnabled: Bool
 
     @AppStorage("brewPath")
     @ObservationIgnored var customBrewPath = "/opt/homebrew/bin/brew"
@@ -51,8 +53,14 @@ final class BrewService {
     @AppStorage("trustedBrewfileDigest")
     @ObservationIgnored var trustedBrewfileDigest = ""
 
-    init(commandRunner: CommandRunning = DefaultCommandRunner()) {
+    init(
+        commandRunner: CommandRunning = DefaultCommandRunner(),
+        packageCacheURL: URL? = BrewService.runtimeDefaultPackageCacheURL,
+        packageCacheWritesEnabled: Bool = !BrewyRuntime.isRunningTests
+    ) {
         self.commandRunner = commandRunner
+        self.packageCacheURL = packageCacheURL
+        self.packageCacheWritesEnabled = packageCacheWritesEnabled
     }
 
     deinit {
@@ -185,7 +193,13 @@ extension BrewService {
         return dir
     }()
 
-    nonisolated private static let cacheURL: URL? = cacheDirectory?.appendingPathComponent("packageCache.json")
+    nonisolated private static let defaultPackageCacheURL: URL? =
+        cacheDirectory?.appendingPathComponent("packageCache.json")
+
+    nonisolated private static var runtimeDefaultPackageCacheURL: URL? {
+        guard !BrewyRuntime.isRunningTests else { return nil }
+        return defaultPackageCacheURL
+    }
 
     /// Current schema version for the package cache. Bump when `CachedData` gains a non-optional
     /// field or changes semantics so old caches are deleted rather than silently discarded each launch.
@@ -202,13 +216,15 @@ extension BrewService {
     }
 
     func loadFromCache() {
-        guard let cacheURL = Self.cacheURL else { return }
+        guard let packageCacheURL else { return }
         do {
-            let data = try Data(contentsOf: cacheURL)
+            let data = try Data(contentsOf: packageCacheURL)
             let cached = try JSONDecoder().decode(CachedData.self, from: data)
             guard cached.schemaVersion == Self.cacheSchemaVersion else {
                 logger.warning("Cache schema version \(cached.schemaVersion) != \(Self.cacheSchemaVersion), discarding")
-                try? FileManager.default.removeItem(at: cacheURL)
+                if packageCacheWritesEnabled {
+                    try? FileManager.default.removeItem(at: packageCacheURL)
+                }
                 return
             }
             let masApps = cached.masApps ?? []
@@ -221,13 +237,14 @@ extension BrewService {
             logger.info("Loaded \(cached.formulae.count) formulae and \(cached.casks.count) casks from cache")
         } catch {
             logger.warning("Failed to load cache: \(error.localizedDescription)")
-            try? FileManager.default.removeItem(at: cacheURL)
+            if packageCacheWritesEnabled {
+                try? FileManager.default.removeItem(at: packageCacheURL)
+            }
         }
     }
 
-    func saveToCache() {
-        guard let cacheURL = Self.cacheURL,
-              !BrewyRuntime.isRunningTests else { return }
+    func saveToCache() async {
+        guard let packageCacheURL, packageCacheWritesEnabled else { return }
         let cached = CachedData(
             schemaVersion: Self.cacheSchemaVersion,
             formulae: installedFormulae,
@@ -237,14 +254,14 @@ extension BrewService {
             taps: installedTaps,
             lastUpdated: lastUpdated ?? Date()
         )
-        Task.detached(priority: .utility) {
-            do {
+        do {
+            try await Task.detached(priority: .utility) {
                 let data = try JSONEncoder().encode(cached)
-                try data.write(to: cacheURL, options: .atomic)
-                logger.debug("Cache saved successfully")
-            } catch {
-                logger.error("Failed to save cache: \(error.localizedDescription)")
-            }
+                try data.write(to: packageCacheURL, options: .atomic)
+            }.value
+            logger.debug("Cache saved successfully")
+        } catch {
+            logger.error("Failed to save cache: \(error.localizedDescription)")
         }
     }
 
@@ -362,7 +379,7 @@ extension BrewService {
         let masCount = fetchedMasApps.count
         let outdatedCount = allOutdated.count
         logger.info("Refresh complete: \(fetchedFormulae.count) formulae, \(fetchedCasks.count) casks, \(masCount) mas, \(outdatedCount) outdated")
-        saveToCache()
+        await saveToCache()
         // Cancel any in-flight check unconditionally so a prior refresh's task can't overwrite
         // tapHealthStatuses after the tap list has changed.
         tapHealthTask?.cancel()

--- a/BrewyTests/PackageCacheTests.swift
+++ b/BrewyTests/PackageCacheTests.swift
@@ -1,0 +1,178 @@
+@testable import Brewy
+import Foundation
+import Testing
+
+@Suite("Package cache")
+@MainActor
+struct PackageCacheTests {
+    @Test("Package cache round-trips all package sources and derived state")
+    func roundTrip() async throws {
+        let fixture = try CacheFixture()
+        defer { fixture.remove() }
+
+        let formula = makePackage(name: "wget", pinned: true, dependencies: ["openssl@3"])
+        let cask = makePackage(name: "firefox", source: .cask)
+        let mas = makePackage(name: "Xcode", source: .mas)
+        let outdated = makePackage(
+            name: "wget",
+            isOutdated: true,
+            installedVersion: "1.0",
+            latestVersion: "2.0"
+        )
+        let tap = BrewTap(
+            name: "homebrew/core",
+            remote: "https://github.com/Homebrew/homebrew-core",
+            isOfficial: true,
+            formulaNames: ["wget"],
+            caskTokens: []
+        )
+        let lastUpdated = Date(timeIntervalSince1970: 1_700_000_000)
+
+        let writer = BrewService(
+            commandRunner: MockCommandRunner(),
+            packageCacheURL: fixture.url,
+            packageCacheWritesEnabled: true
+        )
+        writer.installedFormulae = [formula]
+        writer.installedCasks = [cask]
+        writer.installedMasApps = [mas]
+        writer.outdatedPackages = [outdated]
+        writer.installedTaps = [tap]
+        writer.lastUpdated = lastUpdated
+
+        await writer.saveToCache()
+
+        let reader = BrewService(commandRunner: MockCommandRunner(), packageCacheURL: fixture.url)
+        reader.loadFromCache()
+
+        #expect(reader.installedFormulae == [formula])
+        #expect(reader.installedCasks == [cask])
+        #expect(reader.installedMasApps == [mas])
+        #expect(reader.outdatedPackages == [outdated])
+        #expect(reader.installedTaps == [tap])
+        #expect(reader.tapsLoaded)
+        #expect(reader.isMasAvailable)
+        #expect(reader.lastUpdated == lastUpdated)
+        #expect(reader.allInstalled.map(\.id) == [formula.id, cask.id, mas.id])
+        #expect(reader.pinnedPackages.map(\.id) == [formula.id])
+        #expect(reader.dependents(of: "openssl@3").map(\.id) == [formula.id])
+    }
+
+    @Test("Package cache tolerates snapshots written before MAS apps were stored")
+    func loadsLegacySnapshotWithoutMasApps() async throws {
+        let fixture = try CacheFixture()
+        defer { fixture.remove() }
+
+        let writer = BrewService(
+            commandRunner: MockCommandRunner(),
+            packageCacheURL: fixture.url,
+            packageCacheWritesEnabled: true
+        )
+        writer.installedFormulae = [makePackage(name: "wget")]
+        await writer.saveToCache()
+        try fixture.mutateJSON { $0.removeValue(forKey: "masApps") }
+
+        let reader = BrewService(commandRunner: MockCommandRunner(), packageCacheURL: fixture.url)
+        reader.loadFromCache()
+
+        #expect(reader.installedFormulae.map(\.name) == ["wget"])
+        #expect(reader.installedMasApps.isEmpty)
+    }
+
+    @Test("Package cache rejects and deletes an incompatible schema")
+    func rejectsIncompatibleSchema() async throws {
+        let fixture = try CacheFixture()
+        defer { fixture.remove() }
+
+        let writer = BrewService(
+            commandRunner: MockCommandRunner(),
+            packageCacheURL: fixture.url,
+            packageCacheWritesEnabled: true
+        )
+        writer.installedFormulae = [makePackage(name: "wget")]
+        await writer.saveToCache()
+        try fixture.mutateJSON { $0["schemaVersion"] = BrewService.cacheSchemaVersion + 1 }
+
+        let reader = BrewService(
+            commandRunner: MockCommandRunner(),
+            packageCacheURL: fixture.url,
+            packageCacheWritesEnabled: true
+        )
+        reader.loadFromCache()
+
+        #expect(reader.allInstalled.isEmpty)
+        #expect(!FileManager.default.fileExists(atPath: fixture.url.path))
+    }
+
+    @Test("Package cache rejects and deletes corrupt data")
+    func rejectsCorruptData() throws {
+        let fixture = try CacheFixture()
+        defer { fixture.remove() }
+        try Data("not-json".utf8).write(to: fixture.url)
+
+        let reader = BrewService(
+            commandRunner: MockCommandRunner(),
+            packageCacheURL: fixture.url,
+            packageCacheWritesEnabled: true
+        )
+        reader.loadFromCache()
+
+        #expect(reader.allInstalled.isEmpty)
+        #expect(!FileManager.default.fileExists(atPath: fixture.url.path))
+    }
+
+    @Test("Read-only package cache does not save data")
+    func readOnlyCacheDoesNotSave() async throws {
+        let fixture = try CacheFixture()
+        defer { fixture.remove() }
+
+        let service = BrewService(commandRunner: MockCommandRunner(), packageCacheURL: fixture.url)
+        service.installedFormulae = [makePackage(name: "wget")]
+
+        await service.saveToCache()
+
+        #expect(!FileManager.default.fileExists(atPath: fixture.url.path))
+    }
+
+    @Test("Read-only package cache does not delete corrupt data")
+    func readOnlyCacheDoesNotDeleteCorruptData() throws {
+        let fixture = try CacheFixture()
+        defer { fixture.remove() }
+        try Data("not-json".utf8).write(to: fixture.url)
+
+        let service = BrewService(commandRunner: MockCommandRunner(), packageCacheURL: fixture.url)
+        service.loadFromCache()
+
+        #expect(service.allInstalled.isEmpty)
+        #expect(FileManager.default.fileExists(atPath: fixture.url.path))
+    }
+}
+
+private struct CacheFixture {
+    let directory: URL
+    let url: URL
+
+    init() throws {
+        directory = FileManager.default.temporaryDirectory
+            .appendingPathComponent("brewy-package-cache-\(UUID().uuidString)", isDirectory: true)
+        url = directory.appendingPathComponent("packageCache.json")
+        try FileManager.default.createDirectory(at: directory, withIntermediateDirectories: true)
+    }
+
+    func mutateJSON(_ mutation: (inout [String: Any]) -> Void) throws {
+        let data = try Data(contentsOf: url)
+        guard var object = try JSONSerialization.jsonObject(with: data) as? [String: Any] else {
+            throw CacheFixtureError.invalidJSONObject
+        }
+        mutation(&object)
+        try JSONSerialization.data(withJSONObject: object).write(to: url)
+    }
+
+    func remove() {
+        try? FileManager.default.removeItem(at: directory)
+    }
+}
+
+private enum CacheFixtureError: Error {
+    case invalidJSONObject
+}


### PR DESCRIPTION
The package cache location and a write-enabled flag are now injected, so unit tests exercise persistence against a temporary file rather than the real application cache. Under tests the injected location resolves to nil and writes are disabled, which also stops a decode failure from deleting a real cache during a test run.

`saveToCache` is async and awaited by its callers, with JSON encoding and the atomic write both off the main actor. Awaiting also serializes the tap-refresh and full-refresh saves that previously raced as detached tasks.

Tests cover a round trip across every package source and its derived state, a legacy snapshot written before Mac App Store apps were stored, an incompatible schema version, corrupt data, and the read-only path.

AI disclosure: Claude Opus 5 with manual testing and review.
