### PR TITLE
fix(dependencies): render trees reliably and keep navigation selection

### DIFF
--- a/Brewy/Models/UITestFixtures.swift
+++ b/Brewy/Models/UITestFixtures.swift
@@ -43,6 +43,12 @@ struct UITestCommandRunner: CommandRunning {
         if arguments == ["config"] {
             return CommandResult(output: Self.configOutput, success: true)
         }
+        if arguments == ["cleanup", "--prune=all", "-s", "--dry-run"] {
+            if ProcessInfo.processInfo.environment["BREWY_UI_CLEANUP_PREVIEW_FAILURE"] == "1" {
+                return CommandResult(output: "Fixture cleanup preview failed", success: false)
+            }
+            return CommandResult(output: "Fixture cleanup preview", success: true)
+        }
         if arguments.starts(with: ["bundle", "list"]) {
             return Self.bundleListResult(arguments)
         }

--- a/Brewy/Views/ContentView.swift
+++ b/Brewy/Views/ContentView.swift
@@ -31,12 +31,13 @@ struct ContentView: View {
     private var lastSeenVersion = ""
     @State private var selectedCategory: SidebarCategory? = .installed
     @State private var selectedPackage: BrewPackage?
+    @State private var pendingPackageSelection: BrewPackage?
     @State private var selectedTap: BrewTap?
     @State private var selectedServiceItem: BrewServiceItem?
     @State private var selectedGroupItem: PackageGroup?
     @State private var selectedHistoryEntry: ActionHistoryEntry?
     @State private var servicesRefreshTrigger = 0
-    // periphery:ignore - Mutated through PackageListView's searchable binding.
+    // periphery:ignore - Mutated through PackageListView's search binding.
     @State private var searchText = ""
     @State private var showWhatsNew = false
     @State private var showCleanupConfirm = false
@@ -128,6 +129,10 @@ struct ContentView: View {
             selectedServiceItem = nil
             selectedGroupItem = nil
             selectedHistoryEntry = nil
+            if let pendingPackageSelection {
+                selectedPackage = pendingPackageSelection
+                self.pendingPackageSelection = nil
+            }
         }
         .alert(
             "Error",
@@ -214,12 +219,18 @@ struct ContentView: View {
 
     private func navigateToPackage(_ name: String) {
         if let match = brewService.allInstalled.first(where: { $0.name == name }) {
-            switch match.source {
-            case .formula: selectedCategory = .formulae
-            case .cask: selectedCategory = .casks
-            case .mas: selectedCategory = .masApps
+            let destination: SidebarCategory = switch match.source {
+            case .formula: .formulae
+            case .cask: .casks
+            case .mas: .masApps
             }
-            selectedPackage = match
+            if selectedCategory == destination {
+                pendingPackageSelection = nil
+                selectedPackage = match
+            } else {
+                pendingPackageSelection = match
+                selectedCategory = destination
+            }
         }
     }
 }

--- a/Brewy/Views/DependencyTreeView.swift
+++ b/Brewy/Views/DependencyTreeView.swift
@@ -9,10 +9,11 @@ struct DependencyTreeSection: View {
     @State private var pulledInExpanded = false
     // periphery:ignore - Read and written through DisclosureGroup's projected binding.
     @State private var pullsInExpanded = false
-    @State private var reverse: [DependencyTreeNode] = []
-    @State private var forward: [DependencyTreeNode] = []
 
     var body: some View {
+        let reverse = brewService.reverseDependencyTree(for: package.name)
+        let forward = brewService.forwardDependencyTree(for: package.name)
+
         Group {
             if !reverse.isEmpty || !forward.isEmpty {
                 VStack(alignment: .leading, spacing: 12) {
@@ -24,7 +25,8 @@ struct DependencyTreeSection: View {
                             title: "Pulled in by",
                             help: "Installed packages that depend on \(package.name), recursively up to the user-requested install.",
                             nodes: reverse,
-                            isExpanded: $pulledInExpanded
+                            isExpanded: $pulledInExpanded,
+                            accessibilityIdentifier: "dependency-tree-reverse-disclosure"
                         )
                     }
 
@@ -33,17 +35,14 @@ struct DependencyTreeSection: View {
                             title: "Pulls in",
                             help: "What \(package.name) depends on, recursively.",
                             nodes: forward,
-                            isExpanded: $pullsInExpanded
+                            isExpanded: $pullsInExpanded,
+                            accessibilityIdentifier: "dependency-tree-forward-disclosure"
                         )
                     }
                 }
                 .padding(.horizontal)
                 .padding(.vertical, 12)
             }
-        }
-        .task(id: package.id) {
-            reverse = brewService.reverseDependencyTree(for: package.name)
-            forward = brewService.forwardDependencyTree(for: package.name)
         }
     }
 }
@@ -53,6 +52,7 @@ private struct DependencyTreeDisclosure: View {
     let help: String
     let nodes: [DependencyTreeNode]
     @Binding var isExpanded: Bool
+    let accessibilityIdentifier: String
 
     var body: some View {
         DisclosureGroup(isExpanded: $isExpanded) {
@@ -60,6 +60,7 @@ private struct DependencyTreeDisclosure: View {
                 DependencyTreeRows(nodes: nodes, depth: 0)
             }
             .padding(.top, 6)
+            .frame(maxWidth: .infinity, alignment: .leading)
         } label: {
             HStack(spacing: 6) {
                 Text(title)
@@ -74,6 +75,7 @@ private struct DependencyTreeDisclosure: View {
             }
             .help(help)
         }
+        .accessibilityIdentifier(accessibilityIdentifier)
     }
 }
 
@@ -126,5 +128,6 @@ private struct DependencyTreeRow: View {
                     .help("Already shown above in this chain")
             }
         }
+        .frame(maxWidth: .infinity, alignment: .leading)
     }
 }

--- a/Brewy/Views/PackageDetailView.swift
+++ b/Brewy/Views/PackageDetailView.swift
@@ -38,6 +38,7 @@ struct PackageDetailView: View {
             }
             .padding(.vertical)
         }
+        .accessibilityIdentifier("package-detail-scroll")
         .frame(maxWidth: .infinity, maxHeight: .infinity, alignment: .topLeading)
         .background(.background)
         // Keyed on version too, so the info reloads after an in-place upgrade (id alone is stable).

--- a/BrewyUITests/DependencyNavigationUITests.swift
+++ b/BrewyUITests/DependencyNavigationUITests.swift
@@ -1,0 +1,136 @@
+import XCTest
+
+extension SidebarNavigationUITests {
+    func testDependencyTreeRendersFixtureData() throws {
+        let package = app.staticTexts["package-row-ripgrep"]
+        assertExists(package, timeout: Self.launchTimeout, "Fixture package should appear")
+        package.click()
+
+        let detailScroll = app.scrollViews["package-detail-scroll"]
+        assertExists(detailScroll, timeout: Self.elementTimeout, "Package detail should appear")
+        detailScroll.scroll(byDeltaX: 0, deltaY: -500)
+
+        let disclosure = app.disclosureTriangles["dependency-tree-forward-disclosure"]
+        assertExists(disclosure, timeout: Self.elementTimeout, "Forward dependency tree should appear")
+        XCTAssertEqual(disclosure.label, "Pulls in, 1", "Fixture dependency count should render")
+    }
+
+    func testExpandedDependencyTreesRenderRowsAndNavigate() throws {
+        let package = app.staticTexts["package-row-ripgrep"]
+        assertExists(package, timeout: Self.launchTimeout, "Fixture package should appear")
+        package.click()
+
+        let detailScroll = app.scrollViews["package-detail-scroll"]
+        assertExists(detailScroll, timeout: Self.elementTimeout, "Package detail should appear")
+        detailScroll.scroll(byDeltaX: 0, deltaY: -500)
+
+        let forwardDisclosure = app.disclosureTriangles["dependency-tree-forward-disclosure"]
+        assertExists(forwardDisclosure, timeout: Self.elementTimeout, "Forward dependency tree should appear")
+        clickDisclosureTriangle(forwardDisclosure)
+        XCTAssertEqual(
+            (forwardDisclosure.value as? NSNumber)?.intValue,
+            1,
+            "Forward dependency tree should expand"
+        )
+
+        let dependency = app.buttons["pcre2"].firstMatch
+        assertExists(dependency, timeout: Self.elementTimeout, "Expanded forward tree should show pcre2")
+        XCTAssertLessThanOrEqual(
+            dependency.frame.width,
+            80,
+            "Expanded dependency buttons should keep their intrinsic width"
+        )
+        XCTAssertLessThan(
+            dependency.frame.midX,
+            detailScroll.frame.midX - 40,
+            "Expanded dependency rows should align with the leading edge"
+        )
+        dependency.click()
+
+        let updatedDetailScroll = app.scrollViews["package-detail-scroll"]
+        assertExists(updatedDetailScroll, timeout: Self.elementTimeout, "Navigated package detail should appear")
+        updatedDetailScroll.scroll(byDeltaX: 0, deltaY: -500)
+
+        let reverseDisclosure = app.disclosureTriangles["dependency-tree-reverse-disclosure"]
+        assertExists(reverseDisclosure, timeout: Self.elementTimeout, "Reverse dependency tree should appear")
+        XCTAssertEqual(reverseDisclosure.label, "Pulled in by, 1", "Reverse dependency count should render")
+        clickDisclosureTriangle(reverseDisclosure)
+        XCTAssertEqual(
+            (reverseDisclosure.value as? NSNumber)?.intValue,
+            1,
+            "Reverse dependency tree should expand"
+        )
+        updatedDetailScroll.scroll(byDeltaX: 0, deltaY: -200)
+        let dependent = app.buttons.matching(NSPredicate(format: "label == %@", "ripgrep")).firstMatch
+        assertExists(
+            dependent,
+            timeout: Self.elementTimeout,
+            "Expanded reverse tree should show ripgrep"
+        )
+        XCTAssertLessThan(
+            dependent.frame.midX,
+            updatedDetailScroll.frame.midX - 40,
+            "Expanded reverse-dependency rows should align with the leading edge"
+        )
+    }
+
+    func testCleanupPreviewEnablesConfirmationAfterSuccessfulDryRun() throws {
+        openCleanupPreview()
+
+        assertExists(
+            app.staticTexts["Fixture cleanup preview"],
+            timeout: Self.elementTimeout,
+            "Successful dry-run output should appear"
+        )
+        let confirm = app.buttons["Clear Cache"]
+        assertExists(confirm, timeout: Self.elementTimeout, "Clear Cache confirmation should appear")
+        XCTAssertTrue(confirm.isEnabled, "A successful preview should enable confirmation")
+        confirm.click()
+
+        XCTAssertTrue(
+            app.staticTexts["Clear Download Cache?"].waitForNonExistence(timeout: Self.elementTimeout),
+            "Confirming should dismiss the preview"
+        )
+    }
+
+    func testCleanupPreviewFailureKeepsConfirmationDisabled() throws {
+        app.terminate()
+        app.launchEnvironment["BREWY_UI_CLEANUP_PREVIEW_FAILURE"] = "1"
+        app.launch()
+        app.activate()
+
+        openCleanupPreview()
+
+        assertExists(app.staticTexts["Preview failed"], timeout: Self.elementTimeout, "Failure state should appear")
+        assertExists(
+            app.staticTexts["Fixture cleanup preview failed"],
+            timeout: Self.elementTimeout,
+            "Dry-run failure output should appear"
+        )
+        let confirm = app.buttons["Clear Cache"]
+        assertExists(confirm, timeout: Self.elementTimeout, "Clear Cache confirmation should appear")
+        XCTAssertFalse(confirm.isEnabled, "A failed preview must keep confirmation disabled")
+    }
+
+    private func openCleanupPreview() {
+        let fileMenu = app.menuBars.menuBarItems["File"]
+        assertExists(fileMenu, timeout: Self.launchTimeout, "File menu should exist")
+        fileMenu.click()
+
+        let cleanup = app.menuItems["Cleanup..."]
+        assertExists(cleanup, timeout: Self.elementTimeout, "Cleanup command should exist")
+        cleanup.click()
+
+        assertExists(
+            app.staticTexts["Clear Download Cache?"],
+            timeout: Self.elementTimeout,
+            "Cleanup preview should appear"
+        )
+    }
+
+    private func clickDisclosureTriangle(_ disclosure: XCUIElement) {
+        // SwiftUI includes leading padding and the label in this frame, so target the glyph at a fixed offset.
+        let leadingEdge = disclosure.coordinate(withNormalizedOffset: CGVector(dx: 0, dy: 0.5))
+        leadingEdge.withOffset(CGVector(dx: 26, dy: 0)).click()
+    }
+}

--- a/BrewyUITests/SidebarNavigationUITests.swift
+++ b/BrewyUITests/SidebarNavigationUITests.swift
@@ -11,10 +11,10 @@ final class SidebarNavigationUITests: XCTestCase {
     // the same scheme setting as the app, so its presence in this process is a
     // reliable proxy for "the app under test is instrumented too".
     private static let timeoutScale: TimeInterval = isThreadSanitizerActive ? 4 : 1
-    private static let launchTimeout: TimeInterval = 30 * timeoutScale
-    private static let elementTimeout: TimeInterval = 10 * timeoutScale
+    static let launchTimeout: TimeInterval = 30 * timeoutScale
+    static let elementTimeout: TimeInterval = 10 * timeoutScale
 
-    private var app: XCUIApplication!
+    var app: XCUIApplication!
     private var fixtureDirectory: URL!
 
     override func setUp() async throws {
@@ -250,7 +250,7 @@ final class SidebarNavigationUITests: XCTestCase {
     /// Waits for `element` to exist via an explicit `XCTWaiter` expectation and
     /// asserts it appeared. Wrapping `waitForExistence` this way lets every wait
     /// share the TSan-scaled timeouts and keeps the assertion message intact.
-    private func assertExists(
+    func assertExists(
         _ element: XCUIElement,
         timeout: TimeInterval,
         _ message: @autoclosure () -> String,


### PR DESCRIPTION
Dependency trees are computed in the view body instead of a task keyed on the package, which never ran while the section rendered empty, so both sections appear and stay current when a refresh changes the graph.

Navigating to a dependency in another category previously set the selection before the category switch cleared it, leaving the detail pane on its empty state. The selection is now held until the category change lands and applied there.

Expanded rows fill the available width and align to the leading edge, and the disclosure controls carry accessibility identifiers.

AI disclosure: Claude Opus 5 with manual testing and review.
