### PR TITLE
fix(ui): keep package list search and metadata inside the content column

### DIFF
--- a/Brewy/BrewyApp.swift
+++ b/Brewy/BrewyApp.swift
@@ -79,6 +79,7 @@ struct BrewyApp: App {
         .defaultLaunchBehavior(showDockIcon ? .automatic : .suppressed)
         .restorationBehavior(showDockIcon ? .automatic : .disabled)
         .commands {
+            ColumnSearchCommands()
             CommandGroup(after: .appInfo) {
                 CheckForUpdatesView(updater: updaterController.updater)
             }
@@ -120,6 +121,23 @@ struct BrewyApp: App {
             .task(id: autoRefreshInterval) {
                 brewService.startPackageUpdates(autoRefreshInterval: autoRefreshInterval)
             }
+        }
+    }
+}
+
+private struct ColumnSearchCommands: Commands {
+    @FocusedValue(\.columnSearchFocus)
+    private var columnSearchFocus
+
+    var body: some Commands {
+        CommandGroup(after: .pasteboard) {
+            Divider()
+
+            Button("Find") {
+                columnSearchFocus?.wrappedValue = true
+            }
+            .keyboardShortcut("f", modifiers: .command)
+            .disabled(columnSearchFocus == nil)
         }
     }
 }

--- a/Brewy/Views/DiscoverView.swift
+++ b/Brewy/Views/DiscoverView.swift
@@ -22,11 +22,17 @@ struct DiscoverView: View {
 
     var body: some View {
         let packages = displayedPackages
-        List(selection: $selectedPackage) {
-            if packages.isEmpty {
-                emptyContent
-            } else {
-                if searchText.isEmpty, let result = brewService.lastUpdateResult {
+        VStack(spacing: 0) {
+            ColumnSearchBar(
+                text: $searchText,
+                prompt: "Search all of Homebrew...",
+                accessibilityIdentifier: "discover-search-field"
+            )
+            Divider()
+            List(selection: $selectedPackage) {
+                if packages.isEmpty {
+                    emptyContent
+                } else if searchText.isEmpty, let result = brewService.lastUpdateResult {
                     Section {
                         packageRows(packages)
                     } header: {
@@ -36,9 +42,9 @@ struct DiscoverView: View {
                     packageRows(packages)
                 }
             }
+            .accessibilityIdentifier("discover-package-list")
+            .listStyle(.inset(alternatesRowBackgrounds: true))
         }
-        .listStyle(.inset(alternatesRowBackgrounds: true))
-        .searchable(text: $searchText, prompt: "Search all of Homebrew...")
         .onChange(of: searchText) {
             searchTask?.cancel()
             guard !searchText.isEmpty else {

--- a/Brewy/Views/PackageDetailView.swift
+++ b/Brewy/Views/PackageDetailView.swift
@@ -86,16 +86,23 @@ private struct PackageHeader: View {
             PackageSourceIcon(source: package.source, size: 44)
 
             VStack(alignment: .leading, spacing: 4) {
+                Text(package.name)
+                    .font(.title2)
+                    .bold()
+                    .help(package.name)
                 HStack(spacing: 8) {
-                    Text(package.name)
-                        .font(.title2)
-                        .bold()
                     PackageSourceBadge(source: package.source, style: .full)
+                        .fixedSize(horizontal: true, vertical: false)
+                        .accessibilityIdentifier("package-detail-source-badge")
                     if package.pinned {
                         BrewyStatusBadge("Pinned", systemImage: "pin.fill", color: .brewyAccent)
+                            .fixedSize(horizontal: true, vertical: false)
+                            .accessibilityIdentifier("package-detail-pinned-badge")
                     }
                     if package.isOutdated {
                         BrewyStatusBadge("Update Available", systemImage: "arrow.up.circle.fill", color: .brewyAccent)
+                            .fixedSize(horizontal: true, vertical: false)
+                            .accessibilityIdentifier("package-detail-outdated-badge")
                     }
                 }
                 if !package.description.isEmpty {

--- a/Brewy/Views/PackageListView.swift
+++ b/Brewy/Views/PackageListView.swift
@@ -13,7 +13,6 @@ struct PackageListView: View {
     @Binding var searchText: String
     @State private var searchScope: SearchScope = .installed
     @State private var searchTask: Task<Void, Never>?
-    @State private var isSearchPresented = false
     // periphery:ignore - Read and written through toolbar and row-selection bindings.
     @State private var selectedForUpgrade: Set<String> = []
     @State private var isSelectingForUpgrade = false
@@ -23,7 +22,7 @@ struct PackageListView: View {
     }
 
     private var isSearchingAll: Bool {
-        isSearchPresented && searchScope == .all
+        searchScope == .all && !searchText.isEmpty
     }
 
     private var displayedPackages: [BrewPackage] {
@@ -46,21 +45,20 @@ struct PackageListView: View {
 
     var body: some View {
         let packages = displayedPackages
-        return packageList(packages: packages)
-            .listStyle(.inset(alternatesRowBackgrounds: true))
-            .searchable(text: $searchText, isPresented: $isSearchPresented, prompt: searchPrompt)
-            .searchScopes($searchScope, activation: .onSearchPresentation) {
-                ForEach(SearchScope.allCases, id: \.self) { scope in
-                    Text(scope.rawValue).tag(scope)
-                }
-            }
+        return VStack(spacing: 0) {
+            searchControls
+            Divider()
+            packageList(packages: packages)
+                .accessibilityIdentifier("package-list")
+                .listStyle(.inset(alternatesRowBackgrounds: true))
+        }
             .onChange(of: searchText) {
                 searchTask?.cancel()
-                guard isSearchingAll else { return }
                 guard !searchText.isEmpty else {
                     brewService.searchResults = []
                     return
                 }
+                guard isSearchingAll else { return }
                 searchTask = Task {
                     try? await Task.sleep(for: .milliseconds(300))
                     guard !Task.isCancelled else { return }
@@ -68,21 +66,16 @@ struct PackageListView: View {
                 }
             }
             .onChange(of: searchScope) {
+                searchTask?.cancel()
                 guard isSearchingAll else {
                     brewService.searchResults = []
                     return
                 }
                 if !searchText.isEmpty {
-                    searchTask?.cancel()
                     searchTask = Task {
                         await brewService.search(query: searchText)
                     }
                 }
-            }
-            .onChange(of: isSearchPresented) {
-                guard !isSearchPresented else { return }
-                searchTask?.cancel()
-                brewService.searchResults = []
             }
             .onChange(of: selectedCategory) {
                 searchScope = .installed
@@ -106,6 +99,30 @@ struct PackageListView: View {
                     outdatedPackages: isOutdatedCategory ? packages.filter { !$0.isMas } : []
                 )
             }
+    }
+
+    private var searchControls: some View {
+        ColumnSearchBar(
+            text: $searchText,
+            prompt: searchPrompt,
+            accessibilityIdentifier: "package-search-field"
+        ) {
+            Menu {
+                Picker("Search Scope", selection: $searchScope) {
+                    ForEach(SearchScope.allCases, id: \.self) { scope in
+                        Text(scope.rawValue).tag(scope)
+                    }
+                }
+            } label: {
+                Label("Search Scope", systemImage: "line.3.horizontal.decrease.circle")
+                    .labelStyle(.iconOnly)
+            }
+            .menuStyle(.borderlessButton)
+            .fixedSize()
+            .help("Search scope: \(searchScope.rawValue)")
+            .accessibilityValue(searchScope.rawValue)
+            .accessibilityIdentifier("package-search-scope")
+        }
     }
 
     private func packageList(packages: [BrewPackage]) -> some View {
@@ -147,12 +164,6 @@ struct PackageListView: View {
     @ViewBuilder private var emptyContent: some View {
         if brewService.isLoading {
             EmptyView()
-        } else if isSearchingAll, searchText.isEmpty {
-            ContentUnavailableView(
-                "Search Homebrew",
-                systemImage: "magnifyingglass",
-                description: Text("Type a package name to search all of Homebrew.")
-            )
         } else if isSearchingAll {
             ContentUnavailableView.search(text: searchText)
         } else {
@@ -178,7 +189,7 @@ private struct PackageListToolbar: ToolbarContent {
     var body: some ToolbarContent {
         if isOutdated, !outdatedPackages.isEmpty {
             if isSelecting {
-                ToolbarItem(placement: .primaryAction) {
+                ToolbarItem(placement: .navigation) {
                     Button("Upgrade (\(selectedForUpgrade.count))") {
                         let toUpgrade = outdatedPackages.filter { selectedForUpgrade.contains($0.id) }
                         Task {
@@ -189,31 +200,38 @@ private struct PackageListToolbar: ToolbarContent {
                     }
                     .disabled(selectedForUpgrade.isEmpty)
                 }
-                ToolbarItem(placement: .cancellationAction) {
+                ToolbarItem(placement: .navigation) {
                     Button("Cancel") {
                         selectedForUpgrade.removeAll()
                         isSelecting = false
                     }
+                    .keyboardShortcut(.cancelAction)
                 }
             } else {
-                ToolbarItem(placement: .primaryAction) {
-                    Button("Upgrade All") {
-                        Task { await brewService.upgradeAll() }
-                    }
+                ToolbarItem(placement: .navigation) {
+                    upgradeAllButton
                 }
-                ToolbarItem(placement: .secondaryAction) {
+                ToolbarItem(placement: .navigation) {
                     Button("Select") {
                         isSelecting = true
                     }
                 }
             }
         } else if !brewService.homebrewOutdatedPackages.isEmpty {
-            ToolbarItem(placement: .primaryAction) {
-                Button("Upgrade All") {
-                    Task { await brewService.upgradeAll() }
-                }
+            ToolbarItem(placement: .navigation) {
+                upgradeAllButton
             }
         }
+    }
+
+    private var upgradeAllButton: some View {
+        Button {
+            Task { await brewService.upgradeAll() }
+        } label: {
+            Label("Upgrade All", systemImage: "square.and.arrow.up.on.square")
+        }
+        .labelStyle(.iconOnly)
+        .help("Upgrade all outdated packages")
     }
 }
 
@@ -248,15 +266,23 @@ private struct PackageRow: View {
     var onUpgrade: ((BrewPackage) async -> Void)?
 
     var body: some View {
-        HStack(spacing: 10) {
+        HStack(alignment: .top, spacing: 10) {
             PackageSourceIcon(source: package.source, size: 28)
 
-            VStack(alignment: .leading, spacing: 2) {
-                HStack(spacing: 6) {
+            VStack(alignment: .leading, spacing: 4) {
+                HStack(alignment: .firstTextBaseline, spacing: 8) {
                     Text(package.name)
                         .font(.body)
                         .fontWeight(.semibold)
+                        .lineLimit(1)
+                        .layoutPriority(1)
+                        .help(package.name)
                         .accessibilityIdentifier("package-row-\(package.name)")
+                    Spacer(minLength: 0)
+                    versionLabel
+                        .fixedSize(horizontal: true, vertical: false)
+                }
+                HStack(spacing: 6) {
                     if showInstalledBadge, package.isInstalled {
                         Image(systemName: "checkmark.circle.fill")
                             .font(.caption2)
@@ -264,8 +290,11 @@ private struct PackageRow: View {
                             .accessibilityLabel("Installed")
                     }
                     PackageSourceBadge(source: package.source)
+                        .fixedSize(horizontal: true, vertical: false)
                     if package.pinned {
                         BrewyStatusBadge("pinned", systemImage: "pin.fill", color: .brewyAccent)
+                            .fixedSize(horizontal: true, vertical: false)
+                            .accessibilityIdentifier("package-row-pinned-\(package.name)")
                     }
                 }
                 if !package.description.isEmpty {
@@ -275,8 +304,6 @@ private struct PackageRow: View {
                         .lineLimit(2)
                 }
             }
-            Spacer()
-            versionLabel
             if showUpgradeButton, package.isOutdated, !package.isMas {
                 Button {
                     Task { await onUpgrade?(package) }

--- a/Brewy/Views/SharedViews.swift
+++ b/Brewy/Views/SharedViews.swift
@@ -1,9 +1,131 @@
+import AppKit
 import SwiftUI
 
 // MARK: - Shared Visual Primitives
 
 extension Color {
     static var brewyAccent: Color { .orange }
+}
+
+extension FocusedValues {
+    @Entry var columnSearchFocus: Binding<Bool>?
+}
+
+struct ColumnSearchBar<Accessory: View>: View {
+    @Binding private var text: String
+    // periphery:ignore - Read through NSViewRepresentable and focused-scene projected bindings.
+    @State private var isSearchFocused = false
+    private let prompt: String
+    private let accessibilityIdentifier: String
+    private let accessory: Accessory
+
+    init(
+        text: Binding<String>,
+        prompt: String,
+        accessibilityIdentifier: String,
+        @ViewBuilder accessory: () -> Accessory
+    ) {
+        _text = text
+        self.prompt = prompt
+        self.accessibilityIdentifier = accessibilityIdentifier
+        self.accessory = accessory()
+    }
+
+    var body: some View {
+        HStack(spacing: 8) {
+            NativeSearchField(
+                text: $text,
+                isFocused: $isSearchFocused,
+                prompt: prompt,
+                accessibilityIdentifier: accessibilityIdentifier
+            )
+            accessory
+        }
+        .padding(.horizontal, 8)
+        .padding(.vertical, 6)
+        .background(.bar)
+        .focusedSceneValue(\.columnSearchFocus, $isSearchFocused)
+    }
+}
+
+extension ColumnSearchBar where Accessory == EmptyView {
+    init(text: Binding<String>, prompt: String, accessibilityIdentifier: String) {
+        self.init(text: text, prompt: prompt, accessibilityIdentifier: accessibilityIdentifier) {
+            EmptyView()
+        }
+    }
+}
+
+private struct NativeSearchField: NSViewRepresentable {
+    @Binding var text: String
+    @Binding var isFocused: Bool
+    let prompt: String
+    let accessibilityIdentifier: String
+
+    func makeCoordinator() -> Coordinator {
+        Coordinator(text: $text, isFocused: $isFocused)
+    }
+
+    func makeNSView(context: Context) -> NSSearchField {
+        let searchField = NSSearchField()
+        searchField.delegate = context.coordinator
+        searchField.placeholderString = prompt
+        searchField.identifier = NSUserInterfaceItemIdentifier(accessibilityIdentifier)
+        return searchField
+    }
+
+    func updateNSView(_ searchField: NSSearchField, context: Context) {
+        context.coordinator.text = $text
+        context.coordinator.isFocused = $isFocused
+        searchField.placeholderString = prompt
+
+        if searchField.stringValue != text {
+            searchField.stringValue = text
+        }
+
+        guard isFocused, searchField.currentEditor() == nil else { return }
+        DispatchQueue.main.async {
+            isFocused = false
+            searchField.window?.makeFirstResponder(searchField)
+        }
+    }
+
+    final class Coordinator: NSObject, NSSearchFieldDelegate {
+        var text: Binding<String>
+        var isFocused: Binding<Bool>
+
+        init(text: Binding<String>, isFocused: Binding<Bool>) {
+            self.text = text
+            self.isFocused = isFocused
+        }
+
+        func controlTextDidBeginEditing(_ notification: Notification) {
+            isFocused.wrappedValue = true
+        }
+
+        func controlTextDidChange(_ notification: Notification) {
+            guard let searchField = notification.object as? NSSearchField else { return }
+            text.wrappedValue = searchField.stringValue
+        }
+
+        func controlTextDidEndEditing(_ notification: Notification) {
+            isFocused.wrappedValue = false
+        }
+
+        func control(
+            _ control: NSControl,
+            textView: NSTextView,
+            doCommandBy commandSelector: Selector
+        ) -> Bool {
+            guard commandSelector == #selector(NSResponder.cancelOperation(_:)),
+                  let searchField = control as? NSSearchField else { return false }
+
+            guard !searchField.stringValue.isEmpty else { return false }
+            searchField.stringValue = ""
+            text.wrappedValue = ""
+            return true
+        }
+    }
 }
 
 extension PackageSource {

--- a/BrewyUITests/PackageListLayoutUITests.swift
+++ b/BrewyUITests/PackageListLayoutUITests.swift
@@ -1,0 +1,188 @@
+import XCTest
+
+extension SidebarNavigationUITests {
+    func testPackageSearchSupportsFindAndEscape() throws {
+        let searchField = packageSearchField()
+        assertExists(searchField, timeout: Self.launchTimeout, "Package search should appear")
+        let package = app.staticTexts["package-row-ripgrep"]
+        assertExists(package, timeout: Self.elementTimeout, "Fixture package should appear")
+        package.click()
+
+        app.typeKey("f", modifierFlags: .command)
+        app.typeText("wget")
+        assertSearchField(searchField, hasValue: "wget")
+
+        app.typeKey(XCUIKeyboardKey.escape, modifierFlags: [])
+        assertSearchField(searchField, hasValue: "")
+    }
+
+    func testClearingAllPackagesSearchRestoresInstalledList() throws {
+        let scope = app.descendants(matching: .any)["package-search-scope"].firstMatch
+        assertExists(scope, timeout: Self.launchTimeout, "Package search scope should appear")
+        scope.click()
+        let allPackages = app.menuItems["All Packages"]
+        assertExists(allPackages, timeout: Self.elementTimeout, "All Packages scope should appear")
+        allPackages.click()
+
+        let searchField = packageSearchField()
+        searchField.click()
+        searchField.typeText("wget")
+        searchField.typeKey("a", modifierFlags: .command)
+        searchField.typeKey(XCUIKeyboardKey.delete, modifierFlags: [])
+        assertSearchField(searchField, hasValue: "")
+
+        assertExists(
+            app.staticTexts["package-row-ripgrep"],
+            timeout: Self.elementTimeout,
+            "Clearing an all-package search should restore the selected category"
+        )
+    }
+
+    func testUpgradeSelectionCancelUsesEscape() throws {
+        let sidebar = app.outlines.firstMatch
+        assertExists(sidebar, timeout: Self.launchTimeout, "Sidebar should appear")
+        sidebar.staticTexts["Outdated"].click()
+
+        let searchField = packageSearchField()
+        assertExists(searchField, timeout: Self.elementTimeout, "Package search should appear")
+        searchField.click()
+        searchField.typeText("rip")
+
+        let select = app.buttons["Select"]
+        assertExists(select, timeout: Self.elementTimeout, "Select should appear")
+        select.click()
+
+        let cancel = app.buttons["Cancel"]
+        assertExists(cancel, timeout: Self.elementTimeout, "Cancel should appear")
+        app.typeKey(XCUIKeyboardKey.escape, modifierFlags: [])
+        assertSearchField(searchField, hasValue: "")
+        XCTAssertTrue(cancel.exists, "Clearing search should keep upgrade selection active")
+
+        app.typeKey(XCUIKeyboardKey.escape, modifierFlags: [])
+
+        XCTAssertTrue(
+            cancel.waitForNonExistence(timeout: Self.elementTimeout),
+            "Escape should cancel upgrade selection"
+        )
+        assertExists(select, timeout: Self.elementTimeout, "Select should reappear after cancelling")
+    }
+
+    func testDiscoverSearchRemainsInsideContentColumn() throws {
+        let sidebar = app.outlines.firstMatch
+        assertExists(sidebar, timeout: Self.launchTimeout, "Sidebar should appear")
+        sidebar.staticTexts["Discover"].click()
+
+        let packageList = app.outlines["discover-package-list"].firstMatch
+        assertExists(packageList, timeout: Self.elementTimeout, "Discover package list should appear")
+        let searchField = app.searchFields["discover-search-field"].firstMatch
+        assertExists(searchField, timeout: Self.elementTimeout, "Discover search should appear")
+
+        assertHorizontallyContained(searchField, named: "Discover search", in: packageList)
+    }
+
+    func testPackageRowMetadataRemainsReadableInNarrowContentColumn() throws {
+        let packageName = app.staticTexts["package-row-ripgrep"]
+        assertExists(packageName, timeout: Self.launchTimeout, "Fixture package should appear")
+        packageName.click()
+        resizeMainWindow(toWidth: 920)
+
+        let packageList = app.outlines["package-list"].firstMatch
+        assertExists(packageList, timeout: Self.launchTimeout, "Package list should appear")
+        XCTAssertLessThanOrEqual(
+            packageList.frame.width,
+            360,
+            "The fixture must exercise a narrow package-list column"
+        )
+
+        let pinnedBadge = app.staticTexts["package-row-pinned-ripgrep"].firstMatch
+        assertExists(pinnedBadge, timeout: Self.elementTimeout, "Pinned badge should appear")
+
+        for badgeID in [
+            "package-detail-source-badge",
+            "package-detail-pinned-badge",
+            "package-detail-outdated-badge"
+        ] {
+            let badge = app.descendants(matching: .any)[badgeID].firstMatch
+            assertExists(badge, timeout: Self.elementTimeout, "\(badgeID) should appear")
+            XCTAssertGreaterThan(
+                badge.frame.width,
+                badge.frame.height,
+                "\(badgeID) should remain horizontal in a narrow detail column"
+            )
+            XCTAssertLessThanOrEqual(
+                badge.frame.height,
+                20,
+                "\(badgeID) should remain compact in a narrow detail column"
+            )
+        }
+
+        let upgradeAllButton = app.buttons["Upgrade All"].firstMatch
+        assertExists(upgradeAllButton, timeout: Self.elementTimeout, "Upgrade All should appear")
+        let searchField = app.searchFields["package-search-field"].firstMatch
+        assertExists(searchField, timeout: Self.elementTimeout, "Package search should appear")
+        assertHorizontallyContained(
+            upgradeAllButton,
+            named: "Upgrade All",
+            in: packageList
+        )
+        assertHorizontallyContained(
+            searchField,
+            named: "Package search",
+            in: packageList
+        )
+
+        XCTAssertGreaterThan(
+            packageName.frame.width,
+            packageName.frame.height,
+            "Package names should remain on one line in a narrow content column"
+        )
+        XCTAssertGreaterThan(
+            pinnedBadge.frame.width,
+            pinnedBadge.frame.height,
+            "Status badges should remain horizontal in a narrow content column"
+        )
+    }
+
+    private func packageSearchField() -> XCUIElement {
+        app.searchFields["package-search-field"].firstMatch
+    }
+
+    private func assertSearchField(_ searchField: XCUIElement, hasValue expectedValue: String) {
+        let predicate = NSPredicate(format: "value == %@", expectedValue)
+        let expectation = XCTNSPredicateExpectation(predicate: predicate, object: searchField)
+        XCTAssertEqual(
+            XCTWaiter.wait(for: [expectation], timeout: Self.elementTimeout),
+            .completed,
+            "Search field should contain '\(expectedValue)'"
+        )
+    }
+
+    private func assertHorizontallyContained(
+        _ element: XCUIElement,
+        named name: String,
+        in column: XCUIElement
+    ) {
+        XCTAssertGreaterThanOrEqual(
+            element.frame.minX,
+            column.frame.minX,
+            "\(name) should remain inside its content column"
+        )
+        XCTAssertLessThanOrEqual(
+            element.frame.maxX,
+            column.frame.maxX,
+            "\(name) should not enter the detail column"
+        )
+    }
+
+    private func resizeMainWindow(toWidth width: CGFloat) {
+        let window = app.windows.firstMatch
+        assertExists(window, timeout: Self.launchTimeout, "Main window should appear")
+
+        let widthDelta = width - window.frame.width
+        guard abs(widthDelta) > 1 else { return }
+
+        let rightEdge = window.coordinate(withNormalizedOffset: CGVector(dx: 1, dy: 0.5))
+        let destination = rightEdge.withOffset(CGVector(dx: widthDelta, dy: 0))
+        rightEdge.press(forDuration: 0.1, thenDragTo: destination)
+    }
+}

--- a/BrewyUITests/SidebarNavigationUITests.swift
+++ b/BrewyUITests/SidebarNavigationUITests.swift
@@ -34,6 +34,7 @@ final class SidebarNavigationUITests: XCTestCase {
         app = XCUIApplication()
         app.terminate()
         app.launchArguments += [
+            "-ApplePersistenceIgnoreState", "YES",
             "-NSConstraintBasedLayoutVisualizeMutuallyExclusiveConstraints", "YES",
             "-autoRefreshInterval", "0",
             "-brewfilePath", "",


### PR DESCRIPTION
Package and Discover search move out of the toolbar into a column-width search bar built on `NSSearchField`, so neither spills into the detail pane. The field keeps the system magnifier, clear button, Find, and Escape-to-clear, with Find wired through a focused scene value so it fires only while a column publishes one.

Rows lay the package name and version on one line with badges below, replacing a single row that compressed a name to a few points wide and stacked badges vertically at narrow widths. Long names truncate to one line with the full name in a tooltip.

The "All Packages" scope now applies only while the query is non-empty, so clearing the field restores the selected category rather than leaving the list empty. Toolbar actions moved to the navigation placement to keep them over their own column, and Cancel responds to Escape.

Depends on #295.

AI disclosure: Claude Opus 5 with manual testing and review.
