### PR TITLE
feat(menu-bar): show the outdated package count in the menu bar

### DIFF
--- a/Brewy/BrewyApp.swift
+++ b/Brewy/BrewyApp.swift
@@ -112,15 +112,11 @@ struct BrewyApp: App {
             MenuBarView()
                 .environment(brewService)
         } label: {
-            let count = brewService.outdatedPackages.count
-            Label(
-                count > 0 ? "\(count)" : "Brewy",
-                systemImage: count > 0 ? "shippingbox.fill" : "shippingbox"
-            )
-            .accessibilityIdentifier("brewy-menu-bar-icon")
-            .task(id: autoRefreshInterval) {
-                brewService.startPackageUpdates(autoRefreshInterval: autoRefreshInterval)
-            }
+            MenuBarStatusLabel(outdatedCount: brewService.outdatedPackages.count)
+                .accessibilityIdentifier("brewy-menu-bar-icon")
+                .task(id: autoRefreshInterval) {
+                    brewService.startPackageUpdates(autoRefreshInterval: autoRefreshInterval)
+                }
         }
     }
 }
@@ -190,6 +186,29 @@ private struct CheckForUpdatesView: View {
 }
 
 // MARK: - Menu Bar View
+
+private struct MenuBarStatusLabel: View {
+    let outdatedCount: Int
+
+    var body: some View {
+        Group {
+            if outdatedCount > 0 {
+                Label("\(outdatedCount)", systemImage: "shippingbox.fill")
+                    .labelStyle(.titleAndIcon)
+            } else {
+                Label("Brewy", systemImage: "shippingbox")
+                    .labelStyle(.iconOnly)
+            }
+        }
+        .accessibilityElement(children: .ignore)
+        .accessibilityLabel(accessibilityLabel)
+    }
+
+    private var accessibilityLabel: String {
+        guard outdatedCount > 0 else { return "Brewy, all packages up to date" }
+        return "Brewy, \(outdatedCount) package\(outdatedCount == 1 ? "" : "s") outdated"
+    }
+}
 
 private struct MenuBarView: View {
     @Environment(BrewService.self)

--- a/Brewy/Models/UITestFixtures.swift
+++ b/Brewy/Models/UITestFixtures.swift
@@ -147,7 +147,9 @@ extension BrewService {
         installedCasks = [firefox]
         installedMasApps = [xcode]
         isMasAvailable = true
-        outdatedPackages = [ripgrep, firefox]
+        outdatedPackages = ProcessInfo.processInfo.environment["BREWY_UI_NO_OUTDATED_PACKAGES"] == "1"
+            ? []
+            : [ripgrep, firefox]
 
         return (ripgrep, pcre2, firefox)
     }

--- a/BrewyUITests/DockIconSettingsUITests.swift
+++ b/BrewyUITests/DockIconSettingsUITests.swift
@@ -106,6 +106,36 @@ final class DockIconSettingsUITests: XCTestCase {
         XCTAssertTrue(settingsWindow.isHittable, "The Settings window should be in the foreground")
     }
 
+    func testMenuBarShowsCountOnlyWhenUpdatesAreAvailable() {
+        let statusItemWithUpdates = app.menuBars.statusItems["brewy-menu-bar-icon"]
+        XCTAssertTrue(
+            statusItemWithUpdates.waitForExistence(timeout: Self.launchTimeout),
+            "The menu bar icon should remain available"
+        )
+        statusItemWithUpdates.click()
+        XCTAssertTrue(
+            app.menuItems["2 packages outdated"].waitForExistence(timeout: Self.transitionTimeout),
+            "The fixture updates should load before measuring the menu bar item"
+        )
+        app.typeKey(.escape, modifierFlags: [])
+        let widthWithUpdates = statusItemWithUpdates.frame.width
+
+        app.terminate()
+        app.launchEnvironment["BREWY_UI_NO_OUTDATED_PACKAGES"] = "1"
+        app.launch()
+
+        let statusItemWithoutUpdates = app.menuBars.statusItems["brewy-menu-bar-icon"]
+        XCTAssertTrue(
+            statusItemWithoutUpdates.waitForExistence(timeout: Self.launchTimeout),
+            "The menu bar icon should remain available without updates"
+        )
+        XCTAssertGreaterThan(
+            widthWithUpdates,
+            statusItemWithoutUpdates.frame.width,
+            "The update count should add visible text next to the menu bar icon"
+        )
+    }
+
     private static var isThreadSanitizerActive: Bool {
         (0..<_dyld_image_count()).contains { index in
             guard let name = _dyld_get_image_name(index) else { return false }


### PR DESCRIPTION
The menu bar status item already supplied the outdated package count as its label title, but SwiftUI's automatic label style rendered the item icon-only, so the count was never visible. The label now selects title-and-icon while packages are outdated and icon-only at zero, so the count appears beside a filled icon when action is needed and the menu bar stays clean when it is not.

The label lives in its own view so the refresh task keeps a stable identity as the count crosses zero, and both states carry an explicit accessibility label rather than announcing a bare number.

A UI test compares the status item width across a launch with outdated fixtures and a launch with a debug-only fixture that reports none, gating the measurement on the loaded menu contents so it does not race fixture loading.

Closes #293.

AI disclosure: Claude Opus 5 with manual testing and review.
