### PR TITLE
fix(window): keep the app alive while the menu bar icon is visible

### DIFF
--- a/Brewy/Models/AppVisibilitySettings.swift
+++ b/Brewy/Models/AppVisibilitySettings.swift
@@ -71,6 +71,10 @@ enum AppVisibilitySettings {
         showDockIcon ? .regular : .accessory
     }
 
+    static func shouldTerminateAfterLastWindowClosed(showMenuBarIcon: Bool) -> Bool {
+        !showMenuBarIcon
+    }
+
     @MainActor
     static func applyDockIconVisibility(_ isVisible: Bool) {
         guard !BrewyRuntime.isUnitTesting else { return }
@@ -109,6 +113,14 @@ final class BrewyApplicationDelegate: NSObject, NSApplicationDelegate {
                 Self.repairVisibilityIfNeeded()
             }
         }
+    }
+
+    func applicationShouldTerminateAfterLastWindowClosed(_ sender: NSApplication) -> Bool {
+        // A primary SwiftUI Window requests termination when it closes. Keep the app alive
+        // only while MenuBarExtra remains available as another entry point.
+        AppVisibilitySettings.shouldTerminateAfterLastWindowClosed(
+            showMenuBarIcon: UserDefaults.standard.bool(forKey: AppVisibilitySettings.showMenuBarIconKey)
+        )
     }
 
     func applicationWillTerminate(_ notification: Notification) {

--- a/BrewyTests/AppVisibilitySettingsTests.swift
+++ b/BrewyTests/AppVisibilitySettingsTests.swift
@@ -11,6 +11,12 @@ struct AppVisibilitySettingsTests {
         #expect(AppVisibilitySettings.activationPolicy(showDockIcon: false) == .accessory)
     }
 
+    @Test("Last-window termination preserves a remaining menu bar entry point")
+    func lastWindowTermination() {
+        #expect(!AppVisibilitySettings.shouldTerminateAfterLastWindowClosed(showMenuBarIcon: true))
+        #expect(AppVisibilitySettings.shouldTerminateAfterLastWindowClosed(showMenuBarIcon: false))
+    }
+
     @Test("Defaults keep both app entry points visible")
     func registersVisibleDefaults() throws {
         let (defaults, suiteName) = try makeDefaults()

--- a/BrewyUITests/DockIconSettingsUITests.swift
+++ b/BrewyUITests/DockIconSettingsUITests.swift
@@ -93,6 +93,145 @@ final class DockIconSettingsUITests: XCTestCase {
         XCTAssertTrue(mainWindow.isHittable, "The main window should be in the foreground")
     }
 
+    func testClosingMainWindowKeepsMenuBarAppRunning() {
+        launch(showDockIcon: true)
+
+        let mainWindow = app.windows.firstMatch
+        XCTAssertTrue(
+            mainWindow.waitForExistence(timeout: Self.launchTimeout),
+            "The main window should open at launch when the Dock icon is visible"
+        )
+        let statusItem = app.menuBars.statusItems["brewy-menu-bar-icon"]
+        XCTAssertTrue(
+            statusItem.waitForExistence(timeout: Self.launchTimeout),
+            "The menu bar icon should be available before closing the main window"
+        )
+
+        mainWindow.buttons[XCUIIdentifierCloseWindow].click()
+
+        XCTAssertFalse(
+            mainWindow.waitForExistence(timeout: 2 * Self.timeoutScale),
+            "Closing the main window should dismiss it"
+        )
+        XCTAssertTrue(
+            statusItem.waitForExistence(timeout: Self.transitionTimeout),
+            "Closing the main window should keep the menu bar icon available"
+        )
+
+        statusItem.click()
+        let openBrewy = statusItem.menuItems["Open Brewy"]
+        XCTAssertTrue(
+            openBrewy.waitForExistence(timeout: Self.transitionTimeout),
+            "The menu bar should still offer an Open Brewy action"
+        )
+        openBrewy.click()
+
+        XCTAssertTrue(
+            app.wait(for: .runningForeground, timeout: Self.transitionTimeout),
+            "Open Brewy should reactivate the app"
+        )
+        XCTAssertTrue(
+            mainWindow.waitForExistence(timeout: Self.transitionTimeout),
+            "Open Brewy should reopen the main window"
+        )
+        XCTAssertEqual(app.windows.count, 1, "Reopening should present one main window")
+    }
+
+    func testClosingMainWindowWithoutMenuBarIconTerminatesApp() {
+        launch(showDockIcon: true, showMenuBarIcon: false)
+
+        let mainWindow = app.windows.firstMatch
+        XCTAssertTrue(
+            mainWindow.waitForExistence(timeout: Self.launchTimeout),
+            "The main window should open at launch when the Dock icon is visible"
+        )
+        XCTAssertFalse(
+            app.menuBars.statusItems["brewy-menu-bar-icon"].exists,
+            "The menu bar icon should be hidden for this configuration"
+        )
+
+        mainWindow.buttons[XCUIIdentifierCloseWindow].click()
+
+        XCTAssertTrue(
+            app.wait(for: .notRunning, timeout: Self.transitionTimeout),
+            "Closing the only entry point should terminate the app"
+        )
+    }
+
+    func testMenuBarOnlyRefreshKeepsAppRunning() {
+        XCTAssertFalse(
+            app.windows.firstMatch.waitForExistence(timeout: 2 * Self.timeoutScale),
+            "The main window should be suppressed when the Dock icon is hidden"
+        )
+
+        let statusItem = app.menuBars.statusItems["brewy-menu-bar-icon"]
+        XCTAssertTrue(
+            statusItem.waitForExistence(timeout: Self.launchTimeout),
+            "The menu bar icon should remain available"
+        )
+        statusItem.click()
+
+        XCTAssertTrue(
+            statusItem.menuItems["2 packages outdated"].waitForExistence(timeout: Self.transitionTimeout),
+            "The menu bar should load package state before refreshing"
+        )
+        let refresh = statusItem.menuItems["Refresh"]
+        XCTAssertTrue(
+            refresh.waitForExistence(timeout: Self.transitionTimeout),
+            "The menu bar should offer a Refresh action"
+        )
+        refresh.click()
+
+        XCTAssertTrue(
+            statusItem.waitForExistence(timeout: Self.transitionTimeout),
+            "Refreshing should keep the menu bar icon available"
+        )
+        XCTAssertFalse(
+            app.windows.firstMatch.waitForExistence(timeout: 2 * Self.timeoutScale),
+            "Refreshing should not open the main window"
+        )
+        statusItem.click()
+        XCTAssertTrue(
+            statusItem.menuItems["Open Brewy"].waitForExistence(timeout: Self.transitionTimeout),
+            "The menu bar should remain usable after refreshing"
+        )
+    }
+
+    func testQuitFromMenuBarTerminatesAppAfterClosingMainWindow() {
+        launch(showDockIcon: true)
+
+        let mainWindow = app.windows.firstMatch
+        XCTAssertTrue(
+            mainWindow.waitForExistence(timeout: Self.launchTimeout),
+            "The main window should open at launch when the Dock icon is visible"
+        )
+        let statusItem = app.menuBars.statusItems["brewy-menu-bar-icon"]
+        XCTAssertTrue(
+            statusItem.waitForExistence(timeout: Self.launchTimeout),
+            "The menu bar icon should remain available"
+        )
+
+        mainWindow.buttons[XCUIIdentifierCloseWindow].click()
+
+        XCTAssertTrue(
+            statusItem.waitForExistence(timeout: Self.transitionTimeout),
+            "Closing the main window should keep the menu bar icon available"
+        )
+        statusItem.click()
+
+        let quitBrewy = statusItem.menuItems["Quit Brewy"]
+        XCTAssertTrue(
+            quitBrewy.waitForExistence(timeout: Self.transitionTimeout),
+            "The menu bar should offer a Quit Brewy action"
+        )
+        quitBrewy.click()
+
+        XCTAssertTrue(
+            app.wait(for: .notRunning, timeout: Self.transitionTimeout),
+            "Quit Brewy should terminate the app"
+        )
+    }
+
     func testMenuBarOnlyLaunchCanOpenSettings() {
         XCTAssertFalse(
             app.windows.firstMatch.waitForExistence(timeout: 2 * Self.timeoutScale),
@@ -155,7 +294,7 @@ final class DockIconSettingsUITests: XCTestCase {
         )
     }
 
-    private func launch(showDockIcon: Bool) {
+    private func launch(showDockIcon: Bool, showMenuBarIcon: Bool = true) {
         app?.terminate()
         app = XCUIApplication()
         app.launchArguments += [
@@ -164,7 +303,7 @@ final class DockIconSettingsUITests: XCTestCase {
             "-brewfilePath", "",
             "-showCasksByDefault", "NO",
             "-showDockIcon", showDockIcon ? "YES" : "NO",
-            "-showMenuBarIcon", "YES"
+            "-showMenuBarIcon", showMenuBarIcon ? "YES" : "NO"
         ]
         app.launchEnvironment["BREWY_UI_TESTING"] = "1"
         app.launchEnvironment["XDG_CONFIG_HOME"] = fixtureDirectory.path


### PR DESCRIPTION
The singleton `Window` scene that replaced `WindowGroup` in #301 asks the app to terminate when it closes, so Brewy ended its session during ordinary menu bar use with the Dock icon hidden, and quit outright when the Dock icon was visible and the main window was closed. The app delegate now answers `applicationShouldTerminateAfterLastWindowClosed` rather than leaving it to the SwiftUI default.

The answer is conditional rather than a flat `false`, because the two icons are configured independently and the only guarantee is that they are not both hidden: a flat `false` would leave the Dock-icon-only configuration running with no window and no menu bar item to reopen from. Termination is declined only while the menu bar icon is visible, and UI tests cover all three legal configurations plus an explicit menu bar quit after a window close.

AI disclosure: Claude Opus 5 with manual testing and review.
