### PR TITLE
fix(packages): keep long versions from displacing package names

### DIFF
--- a/Brewy/Models/UITestFixtures.swift
+++ b/Brewy/Models/UITestFixtures.swift
@@ -145,6 +145,9 @@ extension BrewService {
 
         installedFormulae = [ripgrep, pcre2]
         installedCasks = [firefox]
+        if ProcessInfo.processInfo.environment["BREWY_UI_LONG_PACKAGE_VERSION"] == "1" {
+            installedCasks.append(contentsOf: [makeClaudeFixture(), makeLongNameCaskFixture()])
+        }
         installedMasApps = [xcode]
         isMasAvailable = true
         outdatedPackages = ProcessInfo.processInfo.environment["BREWY_UI_NO_OUTDATED_PACKAGES"] == "1"
@@ -201,6 +204,42 @@ extension BrewService {
             isOutdated: true,
             installedVersion: "127.0",
             latestVersion: "128.0",
+            source: .cask,
+            pinned: false,
+            installedOnRequest: true,
+            dependencies: []
+        )
+    }
+
+    private func makeClaudeFixture() -> BrewPackage {
+        BrewPackage(
+            id: "cask-claude",
+            name: "claude",
+            version: "1.32352.1,6c6aa595ae38b202d9e00c026dc94d3a6a42c332",
+            description: "Anthropic's official Claude AI desktop app",
+            homepage: "https://claude.com/download",
+            isInstalled: true,
+            isOutdated: false,
+            installedVersion: "1.32352.1,6c6aa595ae38b202d9e00c026dc94d3a6a42c332",
+            latestVersion: nil,
+            source: .cask,
+            pinned: false,
+            installedOnRequest: true,
+            dependencies: []
+        )
+    }
+
+    private func makeLongNameCaskFixture() -> BrewPackage {
+        BrewPackage(
+            id: "cask-font-bitstream-vera-sans-mono-nerd-font",
+            name: "font-bitstream-vera-sans-mono-nerd-font",
+            version: "2.3.4",
+            description: "Long-name layout fixture",
+            homepage: "https://example.com/long-name-layout-fixture",
+            isInstalled: true,
+            isOutdated: false,
+            installedVersion: "2.3.4",
+            latestVersion: nil,
             source: .cask,
             pinned: false,
             installedOnRequest: true,

--- a/Brewy/Views/PackageListView.swift
+++ b/Brewy/Views/PackageListView.swift
@@ -280,7 +280,6 @@ private struct PackageRow: View {
                         .accessibilityIdentifier("package-row-\(package.name)")
                     Spacer(minLength: 0)
                     versionLabel
-                        .fixedSize(horizontal: true, vertical: false)
                 }
                 HStack(spacing: 6) {
                     if showInstalledBadge, package.isInstalled {
@@ -333,5 +332,10 @@ private struct PackageRow: View {
                     .monospacedDigit()
             }
         }
+        .lineLimit(1)
+        .truncationMode(.middle)
+        .help(package.displayVersion)
+        .accessibilityIdentifier("package-row-version-\(package.name)")
+        .layoutPriority(1)
     }
 }

--- a/BrewyUITests/PackageListLayoutUITests.swift
+++ b/BrewyUITests/PackageListLayoutUITests.swift
@@ -143,6 +143,74 @@ extension SidebarNavigationUITests {
         )
     }
 
+    func testLongPackageVersionDoesNotDisplacePackageName() throws {
+        app.terminate()
+        app.launchEnvironment["BREWY_UI_LONG_PACKAGE_VERSION"] = "1"
+        app.launch()
+        app.activate()
+
+        let sidebar = app.outlines.firstMatch
+        assertExists(sidebar, timeout: Self.launchTimeout, "Sidebar should appear")
+        sidebar.staticTexts["Casks"].click()
+
+        let stablePackage = app.staticTexts["package-row-firefox"]
+        assertExists(stablePackage, timeout: Self.elementTimeout, "Stable cask fixture should appear")
+        stablePackage.click()
+        resizeMainWindow(toWidth: 920)
+
+        let packageList = app.outlines["package-list"].firstMatch
+        assertExists(packageList, timeout: Self.elementTimeout, "Package list should appear")
+        let window = app.windows.firstMatch
+        assertExists(window, timeout: Self.elementTimeout, "Main window should appear")
+        XCTAssertLessThanOrEqual(
+            packageList.frame.width,
+            window.frame.width / 2,
+            "The fixture must exercise a constrained package-list column"
+        )
+        let packageName = app.staticTexts["package-row-claude"]
+        assertExists(packageName, timeout: Self.elementTimeout, "Long-version fixture should appear")
+        let version = app.staticTexts["package-row-version-claude"].firstMatch
+        assertExists(version, timeout: Self.elementTimeout, "Package version should appear")
+
+        assertHorizontallyContained(packageName, named: "Package name", in: packageList)
+        assertHorizontallyContained(version, named: "Package version", in: packageList)
+        XCTAssertGreaterThan(
+            packageName.frame.width,
+            packageName.frame.height,
+            "A long version should not squeeze the package name out of the row"
+        )
+        XCTAssertLessThanOrEqual(
+            packageName.frame.maxX,
+            version.frame.minX,
+            "The package name and version should not overlap"
+        )
+        XCTAssertEqual(
+            version.value as? String,
+            "1.32352.1,6c6aa595ae38b202d9e00c026dc94d3a6a42c332",
+            "Accessibility should expose the complete version"
+        )
+
+        let longName = app.staticTexts["package-row-font-bitstream-vera-sans-mono-nerd-font"]
+        assertExists(longName, timeout: Self.elementTimeout, "Long-name fixture should appear")
+        let regularVersion = app.staticTexts[
+            "package-row-version-font-bitstream-vera-sans-mono-nerd-font"
+        ].firstMatch
+        assertExists(regularVersion, timeout: Self.elementTimeout, "Regular version should appear")
+
+        assertHorizontallyContained(longName, named: "Long package name", in: packageList)
+        assertHorizontallyContained(regularVersion, named: "Regular version", in: packageList)
+        XCTAssertGreaterThan(
+            regularVersion.frame.width,
+            regularVersion.frame.height,
+            "A long package name should not reduce a regular version to one glyph"
+        )
+        XCTAssertLessThanOrEqual(
+            longName.frame.maxX,
+            regularVersion.frame.minX,
+            "The long package name and regular version should not overlap"
+        )
+    }
+
     private func packageSearchField() -> XCUIElement {
         app.searchFields["package-search-field"].firstMatch
     }


### PR DESCRIPTION
An unusually long cask version, such as Claude's `1.32352.1,6c6aa595ae38b202d9e00c026dc94d3a6a42c332`, consumed the width of its package row: the name was pushed out entirely and the version overflowed the package-list column. The version label now truncates in the middle on a single line and keeps the full string in its tooltip and accessibility value.

Both labels carry equal layout priority rather than giving the name priority alone. Priority on the name alone fixes the reported row but inverts the problem for long package names, where a token such as `font-bitstream-vera-sans-mono-nerd-font` reduces an ordinary `2.3.4` to a single clipped glyph. With equal priority each label takes only the width it needs, and whichever has to give way truncates visibly. UI tests cover both directions in a narrow content column.

AI disclosure: Claude Opus 5 with manual testing and review.
