### PR TITLE
feat(security): scan installed formulae for known vulnerabilities

### DIFF
--- a/Brewy/Models/BrewService+Vulnerabilities.swift
+++ b/Brewy/Models/BrewService+Vulnerabilities.swift
@@ -1,0 +1,44 @@
+import Foundation
+
+extension BrewService {
+    func scanVulnerabilities() async {
+        guard !isScanningVulnerabilities else { return }
+        isScanningVulnerabilities = true
+        vulnerabilityScanError = nil
+        defer { isScanningVulnerabilities = false }
+        var formulaFingerprint = installedFormulaFingerprint
+
+        var result = await runBrewCommand(["vulns", "--json"])
+        guard !result.cancelled else { return }
+        if formulaFingerprint != installedFormulaFingerprint {
+            formulaFingerprint = installedFormulaFingerprint
+            result = await runBrewCommand(["vulns", "--json"])
+            guard !result.cancelled else { return }
+        }
+        guard formulaFingerprint == installedFormulaFingerprint else { return }
+
+        guard result.exitCode == nil || result.exitCode == 0 || result.exitCode == 1 else {
+            vulnerabilityScanError = .commandFailed(command: "vulns --json", output: result.output)
+            return
+        }
+
+        do {
+            let findings = try JSONDecoder().decode(
+                [FormulaVulnerabilityFinding].self,
+                from: Data(result.standardOutput.utf8)
+            )
+            vulnerabilityScan = FormulaVulnerabilityScan(
+                findings: findings,
+                scannedAt: Date(),
+                warning: Self.nonemptyVulnerabilityMessage(result.standardError)
+            )
+        } catch {
+            vulnerabilityScanError = .commandFailed(command: "vulns --json", output: result.output)
+        }
+    }
+
+    private static func nonemptyVulnerabilityMessage(_ output: String) -> String? {
+        let message = output.trimmingCharacters(in: .whitespacesAndNewlines)
+        return message.isEmpty ? nil : message
+    }
+}

--- a/Brewy/Models/BrewService.swift
+++ b/Brewy/Models/BrewService.swift
@@ -108,6 +108,9 @@ final class BrewService {
     var bundleEntries: [BrewBundleEntry] = []
     var bundleCheckStatus: BrewBundleCheckStatus = .unknown
     var isBundleLoading = false
+    var vulnerabilityScan: FormulaVulnerabilityScan?
+    var vulnerabilityScanError: BrewError?
+    var isScanningVulnerabilities = false
 
     var tapsLoaded = false
     private var isRefreshing = false
@@ -116,6 +119,7 @@ final class BrewService {
     @ObservationIgnored private var isBackgroundRefresh = false
     @ObservationIgnored private var refreshReportedError = false
     @ObservationIgnored private var isBatchingUpdates = false
+    @ObservationIgnored private(set) var installedFormulaFingerprint: [String: String] = [:]
     @ObservationIgnored var infoCache: [String: String] = [:]
     @ObservationIgnored private var tapHealthTask: Task<Void, Never>?
     @ObservationIgnored var actionCommandTask: Task<CommandResult, Never>?
@@ -158,6 +162,16 @@ final class BrewService {
     }
 
     private func invalidateDerivedState() {
+        let formulaFingerprint = Dictionary(
+            installedFormulae.map { ($0.id, $0.version) },
+            uniquingKeysWith: { _, latest in latest }
+        )
+        if formulaFingerprint != installedFormulaFingerprint {
+            installedFormulaFingerprint = formulaFingerprint
+            vulnerabilityScan = nil
+            vulnerabilityScanError = nil
+        }
+
         let all = installedFormulae + installedCasks + installedMasApps
         allInstalled = all
         installedNames = Set(all.map(\.name))
@@ -473,6 +487,7 @@ extension BrewService {
         case .bundle: []
         case .history: []
         case .discover: searchResults
+        case .security: []
         case .maintenance: []
         }
     }

--- a/Brewy/Models/CommandRunner.swift
+++ b/Brewy/Models/CommandRunner.swift
@@ -12,11 +12,26 @@ struct CommandResult: Sendable {
     /// True when the process was terminated because the awaiting task was cancelled,
     /// so callers can skip failure alerts for user-requested cancellation.
     let cancelled: Bool
+    /// Raw standard output, kept separate so structured output remains parseable when
+    /// a command intentionally exits nonzero or also emits a warning on standard error.
+    let standardOutput: String
+    let standardError: String
+    let exitCode: Int32?
 
-    init(output: String, success: Bool, cancelled: Bool = false) {
+    init(
+        output: String,
+        success: Bool,
+        cancelled: Bool = false,
+        standardOutput: String? = nil,
+        standardError: String = "",
+        exitCode: Int32? = nil
+    ) {
         self.output = output
         self.success = success
         self.cancelled = cancelled
+        self.standardOutput = standardOutput ?? output
+        self.standardError = standardError
+        self.exitCode = exitCode
     }
 }
 
@@ -187,8 +202,11 @@ enum CommandRunner {
         }
         return paths[0]
     }
+}
 
-    // MARK: - Environment
+// MARK: - Environment and Process Execution
+
+extension CommandRunner {
 
     static func buildEnvironment(
         brewPath: String,
@@ -246,7 +264,12 @@ enum CommandRunner {
         onOutput: (@Sendable (String) -> Void)?
     ) -> CommandResult {
         guard !handle.wasCancelled else {
-            return CommandResult(output: "Command was cancelled.", success: false, cancelled: true)
+            return CommandResult(
+                output: "Command was cancelled.",
+                success: false,
+                cancelled: true,
+                standardOutput: ""
+            )
         }
         let (process, stdoutPipe, stderrPipe) = configuredProcess(for: execution)
 
@@ -254,9 +277,12 @@ enum CommandRunner {
             try process.run()
         } catch {
             logger.error("Failed to launch process: \(error.localizedDescription)")
+            let output = "Failed to run \(execution.commandDescription): \(error.localizedDescription)"
             return CommandResult(
-                output: "Failed to run \(execution.commandDescription): \(error.localizedDescription)",
-                success: false
+                output: output,
+                success: false,
+                standardOutput: "",
+                standardError: output
             )
         }
 
@@ -315,7 +341,10 @@ enum CommandRunner {
                     terminationSucceeded: interruption.terminationSucceeded
                 ),
                 success: false,
-                cancelled: true
+                cancelled: true,
+                standardOutput: stdout,
+                standardError: stderr,
+                exitCode: process.terminationStatus
             )
         }
         if interruption.timedOut {
@@ -326,12 +355,18 @@ enum CommandRunner {
                     timeout: execution.timeout,
                     terminationSucceeded: interruption.terminationSucceeded
                 ),
-                success: false
+                success: false,
+                standardOutput: stdout,
+                standardError: stderr,
+                exitCode: process.terminationStatus
             )
         }
         return CommandResult(
             output: commandOutput(stdout: stdout, stderr: stderr, terminationStatus: process.terminationStatus),
-            success: process.terminationStatus == 0
+            success: process.terminationStatus == 0,
+            standardOutput: stdout,
+            standardError: stderr,
+            exitCode: process.terminationStatus
         )
     }
 

--- a/Brewy/Models/PackageModel.swift
+++ b/Brewy/Models/PackageModel.swift
@@ -113,50 +113,6 @@ struct TapHealthStatus: Codable, Equatable {
     }
 }
 
-enum SidebarCategory: String, CaseIterable, Identifiable {
-    case installed = "Installed"
-    case formulae = "Formulae"
-    case casks = "Casks"
-    case masApps = "Mac App Store"
-    case outdated = "Outdated"
-    case pinned = "Pinned"
-    case leaves = "Leaves"
-    case taps = "Taps"
-    case services = "Services"
-    case groups = "Groups"
-    case bundle = "Bundle"
-    case history = "History"
-    case discover = "Discover"
-    case maintenance = "Maintenance"
-
-    var id: String { rawValue }
-
-    var systemImage: String {
-        switch self {
-        case .installed: "shippingbox.fill"
-        case .formulae: "terminal.fill"
-        case .casks: "macwindow"
-        case .masApps: "app.badge.fill"
-        case .outdated: "arrow.triangle.2.circlepath"
-        case .pinned: "pin.fill"
-        case .leaves: "leaf.fill"
-        case .taps: "spigot.fill"
-        case .services: "gearshape.2"
-        case .groups: "folder.fill"
-        case .bundle: "doc.text.fill"
-        case .history: "clock.arrow.circlepath"
-        case .discover: "magnifyingglass"
-        case .maintenance: "wrench.and.screwdriver.fill"
-        }
-    }
-
-    static let packageCategories: [Self] = [
-        .installed, .formulae, .casks, .masApps, .outdated, .pinned, .leaves
-    ]
-    static let managementCategories: [Self] = [.taps, .services, .groups, .bundle]
-    static let toolCategories: [Self] = [.history, .discover, .maintenance]
-}
-
 // MARK: - Package Group
 
 struct PackageGroup: Identifiable, Codable, Hashable {

--- a/Brewy/Models/SidebarCategory.swift
+++ b/Brewy/Models/SidebarCategory.swift
@@ -1,0 +1,45 @@
+enum SidebarCategory: String, CaseIterable, Identifiable {
+    case installed = "Installed"
+    case formulae = "Formulae"
+    case casks = "Casks"
+    case masApps = "Mac App Store"
+    case outdated = "Outdated"
+    case pinned = "Pinned"
+    case leaves = "Leaves"
+    case taps = "Taps"
+    case services = "Services"
+    case groups = "Groups"
+    case bundle = "Bundle"
+    case history = "History"
+    case discover = "Discover"
+    case security = "Security"
+    case maintenance = "Maintenance"
+
+    var id: String { rawValue }
+
+    var systemImage: String {
+        switch self {
+        case .installed: "shippingbox.fill"
+        case .formulae: "terminal.fill"
+        case .casks: "macwindow"
+        case .masApps: "app.badge.fill"
+        case .outdated: "arrow.triangle.2.circlepath"
+        case .pinned: "pin.fill"
+        case .leaves: "leaf.fill"
+        case .taps: "spigot.fill"
+        case .services: "gearshape.2"
+        case .groups: "folder.fill"
+        case .bundle: "doc.text.fill"
+        case .history: "clock.arrow.circlepath"
+        case .discover: "magnifyingglass"
+        case .security: "shield.checkered"
+        case .maintenance: "wrench.and.screwdriver.fill"
+        }
+    }
+
+    static let packageCategories: [Self] = [
+        .installed, .formulae, .casks, .masApps, .outdated, .pinned, .leaves
+    ]
+    static let managementCategories: [Self] = [.taps, .services, .groups, .bundle]
+    static let toolCategories: [Self] = [.history, .discover, .security, .maintenance]
+}

--- a/Brewy/Models/UITestFixtures.swift
+++ b/Brewy/Models/UITestFixtures.swift
@@ -43,6 +43,24 @@ struct UITestCommandRunner: CommandRunning {
         if arguments == ["config"] {
             return CommandResult(output: Self.configOutput, success: true)
         }
+        if arguments == ["vulns", "--json"] {
+            if ProcessInfo.processInfo.environment["BREWY_UI_VULNERABILITY_SCAN_FAILURE"] == "1" {
+                return CommandResult(
+                    output: "Error: fixture vulnerability scan failed",
+                    success: false,
+                    standardOutput: "",
+                    standardError: "Error: fixture vulnerability scan failed",
+                    exitCode: 2
+                )
+            }
+            return CommandResult(
+                output: Self.vulnerabilitiesJSON + "\n" + Self.vulnerabilityNotice,
+                success: false,
+                standardOutput: Self.vulnerabilitiesJSON,
+                standardError: Self.vulnerabilityNotice,
+                exitCode: 1
+            )
+        }
         if arguments == ["cleanup", "--prune=all", "-s", "--dry-run"] {
             if ProcessInfo.processInfo.environment["BREWY_UI_CLEANUP_PREVIEW_FAILURE"] == "1" {
                 return CommandResult(output: "Fixture cleanup preview failed", success: false)
@@ -122,6 +140,37 @@ struct UITestCommandRunner: CommandRunning {
     Core tap last commit: 3 days ago
     Core cask tap last commit: 4 days ago
     """
+
+    private static let vulnerabilitiesJSON = """
+    [
+      {
+        "formula": "ripgrep",
+        "version": "14.1.0",
+        "tag": "14.1.1",
+        "repo_url": "https://github.com/BurntSushi/ripgrep.git",
+        "vulnerabilities": [
+          {
+            "id": "CVE-2026-1234",
+            "severity": "HIGH",
+            "summary": "Fixture open vulnerability",
+            "aliases": [],
+            "fixed_versions": ["14.1.2"]
+          }
+        ],
+        "patched": [
+          {
+            "id": "CVE-2025-4321",
+            "severity": "MEDIUM",
+            "summary": "Fixture formula-patched vulnerability",
+            "aliases": [],
+            "fixed_versions": []
+          }
+        ]
+      }
+    ]
+    """
+
+    private static let vulnerabilityNotice = "Results reflect Homebrew's reported scan target."
 }
 
 extension BrewService {

--- a/Brewy/Models/VulnerabilityModel.swift
+++ b/Brewy/Models/VulnerabilityModel.swift
@@ -1,0 +1,148 @@
+import Foundation
+
+enum VulnerabilitySeverity: Int, Comparable, Decodable, Sendable {
+    case unknown
+    case low
+    case medium
+    case high
+    case critical
+
+    init(from decoder: Decoder) throws {
+        let value = try decoder.singleValueContainer().decode(String.self)
+        self = switch value.uppercased() {
+        case "LOW": .low
+        case "MEDIUM": .medium
+        case "HIGH": .high
+        case "CRITICAL": .critical
+        default: .unknown
+        }
+    }
+
+    static func < (lhs: Self, rhs: Self) -> Bool {
+        lhs.rawValue < rhs.rawValue
+    }
+
+    var title: String {
+        switch self {
+        case .unknown: "Unknown"
+        case .low: "Low"
+        case .medium: "Medium"
+        case .high: "High"
+        case .critical: "Critical"
+        }
+    }
+}
+
+struct BrewVulnerability: Identifiable, Hashable, Decodable, Sendable {
+    let id: String
+    let severity: VulnerabilitySeverity
+    let summary: String?
+    let aliases: [String]
+    let fixedVersions: [String]
+
+    enum CodingKeys: String, CodingKey {
+        case id
+        case severity
+        case summary
+        case aliases
+        case fixedVersions = "fixed_versions"
+    }
+
+    var advisoryURL: URL? {
+        let baseURL = URL(string: "https://osv.dev/vulnerability/")
+        return ExternalURLPolicy.url(from: baseURL?.appendingPathComponent(id))
+    }
+}
+
+struct FormulaVulnerabilityFinding: Identifiable, Hashable, Decodable, Sendable {
+    let formula: String
+    let version: String
+    let tag: String
+    let repoURL: String
+    let vulnerabilities: [BrewVulnerability]
+    let patched: [BrewVulnerability]
+
+    var id: String { "\(formula)|\(tag)" }
+
+    enum CodingKeys: String, CodingKey {
+        case formula
+        case version
+        case tag
+        case repoURL = "repo_url"
+        case vulnerabilities
+        case patched
+    }
+}
+
+struct FormulaVulnerabilityGroup: Identifiable, Equatable, Sendable {
+    let id: String
+    let formula: String
+    let version: String
+    let tag: String
+    let repoURL: String
+    let vulnerabilities: [BrewVulnerability]
+}
+
+struct FormulaVulnerabilityScan: Equatable, Sendable {
+    let openGroups: [FormulaVulnerabilityGroup]
+    let patchedGroups: [FormulaVulnerabilityGroup]
+    let openCount: Int
+    let patchedCount: Int
+    let scannedAt: Date
+    let warning: String?
+
+    init(findings: [FormulaVulnerabilityFinding], scannedAt: Date, warning: String?) {
+        let openGroups = findings
+            .filter { !$0.vulnerabilities.isEmpty }
+            .sorted(by: Self.openFindingOrder)
+            .map {
+                FormulaVulnerabilityGroup(
+                    id: "open|\($0.id)",
+                    formula: $0.formula,
+                    version: $0.version,
+                    tag: $0.tag,
+                    repoURL: $0.repoURL,
+                    vulnerabilities: Self.normalized($0.vulnerabilities)
+                )
+            }
+        let patchedGroups = findings
+            .filter { !$0.patched.isEmpty }
+            .sorted { $0.formula.localizedStandardCompare($1.formula) == .orderedAscending }
+            .map {
+                FormulaVulnerabilityGroup(
+                    id: "patched|\($0.id)",
+                    formula: $0.formula,
+                    version: $0.version,
+                    tag: $0.tag,
+                    repoURL: $0.repoURL,
+                    vulnerabilities: Self.normalized($0.patched)
+                )
+            }
+        self.openGroups = openGroups
+        self.patchedGroups = patchedGroups
+        self.openCount = openGroups.reduce(0) { $0 + $1.vulnerabilities.count }
+        self.patchedCount = patchedGroups.reduce(0) { $0 + $1.vulnerabilities.count }
+        self.scannedAt = scannedAt
+        self.warning = warning
+    }
+
+    private static func normalized(_ vulnerabilities: [BrewVulnerability]) -> [BrewVulnerability] {
+        var seenIDs = Set<String>()
+        return vulnerabilities
+            .sorted {
+                if $0.severity != $1.severity { return $0.severity > $1.severity }
+                return $0.id.localizedStandardCompare($1.id) == .orderedAscending
+            }
+            .filter { seenIDs.insert($0.id).inserted }
+    }
+
+    private static func openFindingOrder(
+        _ lhs: FormulaVulnerabilityFinding,
+        _ rhs: FormulaVulnerabilityFinding
+    ) -> Bool {
+        let lhsSeverity = lhs.vulnerabilities.map(\.severity).max() ?? .unknown
+        let rhsSeverity = rhs.vulnerabilities.map(\.severity).max() ?? .unknown
+        if lhsSeverity != rhsSeverity { return lhsSeverity > rhsSeverity }
+        return lhs.formula.localizedStandardCompare(rhs.formula) == .orderedAscending
+    }
+}

--- a/Brewy/Views/ContentView.swift
+++ b/Brewy/Views/ContentView.swift
@@ -70,6 +70,9 @@ struct ContentView: View {
             } else if selectedCategory == .discover {
                 DiscoverView(selectedPackage: $selectedPackage)
                     .navigationSplitViewColumnWidth(min: 300, ideal: 350, max: 500)
+            } else if selectedCategory == .security {
+                SecurityView()
+                    .navigationSplitViewColumnWidth(min: 400, ideal: 600, max: .infinity)
             } else if selectedCategory == .maintenance {
                 MaintenanceView()
                     .navigationSplitViewColumnWidth(min: 400, ideal: 600, max: .infinity)
@@ -161,7 +164,7 @@ struct ContentView: View {
     }
 
     @ViewBuilder private var detailView: some View {
-        if selectedCategory == .maintenance || selectedCategory == .bundle
+        if selectedCategory == .maintenance || selectedCategory == .bundle || selectedCategory == .security
             || (selectedCategory == .masApps && !brewService.isMasAvailable) {
             Color.clear
                 .navigationSplitViewColumnWidth(0)

--- a/Brewy/Views/SecurityView.swift
+++ b/Brewy/Views/SecurityView.swift
@@ -1,0 +1,424 @@
+import SwiftUI
+
+private let securityScopeDescription =
+    "Casks, Mac App Store apps, and apps installed outside Homebrew are not assessed."
+
+struct SecurityView: View {
+    @Environment(BrewService.self)
+    private var brewService
+
+    var body: some View {
+        ZStack {
+            if let scan = brewService.vulnerabilityScan {
+                SecurityResultsList(scan: scan, error: brewService.vulnerabilityScanError)
+            } else if brewService.isScanningVulnerabilities {
+                SecurityScanningState()
+            } else {
+                SecurityUnavailableState(error: brewService.vulnerabilityScanError)
+            }
+        }
+        .frame(maxWidth: .infinity, maxHeight: .infinity)
+        .accessibilityElement(children: .contain)
+        .accessibilityIdentifier("security-pane")
+        .navigationTitle("Security")
+        .navigationSubtitle(navigationSubtitle)
+        .toolbar {
+            ToolbarItem(placement: .primaryAction) {
+                Button(toolbarButtonTitle, systemImage: "arrow.clockwise") {
+                    Task { await brewService.scanVulnerabilities() }
+                }
+                .labelStyle(.titleAndIcon)
+                .accessibilityIdentifier("security-scan-button")
+                .disabled(brewService.isScanningVulnerabilities)
+                .help("Check installed Homebrew formulae for known vulnerabilities")
+            }
+        }
+    }
+
+    private var navigationSubtitle: String {
+        if brewService.isScanningVulnerabilities { return "Scanning installed formulae" }
+        guard let scan = brewService.vulnerabilityScan else { return "Not scanned" }
+        if scan.openCount == 0 { return "No open findings returned" }
+        return scan.openCount == 1 ? "1 open vulnerability" : "\(scan.openCount) open vulnerabilities"
+    }
+
+    private var toolbarButtonTitle: String {
+        if brewService.isScanningVulnerabilities { return "Scanning..." }
+        if brewService.vulnerabilityScan != nil { return "Scan Again" }
+        if brewService.vulnerabilityScanError != nil { return "Retry Scan" }
+        return "Run Scan"
+    }
+}
+
+private struct SecurityResultsList: View {
+    let scan: FormulaVulnerabilityScan
+    let error: BrewError?
+
+    var body: some View {
+        List {
+            SecurityScopeSection()
+
+            if let error {
+                SecurityMessageSection(
+                    title: "Scan Failed",
+                    message: error.localizedDescription,
+                    systemImage: "xmark.octagon.fill",
+                    color: .red
+                )
+            }
+
+            SecurityScanContent(scan: scan)
+        }
+        .listStyle(.inset(alternatesRowBackgrounds: true))
+    }
+}
+
+private struct SecurityScopeSection: View {
+    var body: some View {
+        Section {
+            Label {
+                VStack(alignment: .leading, spacing: 3) {
+                    Text("Installed Homebrew Formulae")
+                        .font(.headline)
+                    Text("Uses Homebrew’s vulnerability scanner and OSV data.")
+                        .font(.callout)
+                        .foregroundStyle(.secondary)
+                }
+            } icon: {
+                Image(systemName: "terminal.fill")
+                    .foregroundStyle(.green)
+            }
+        } footer: {
+            Text(securityScopeDescription)
+                .frame(maxWidth: .infinity, alignment: .leading)
+        }
+    }
+}
+
+private struct SecurityScanningState: View {
+    var body: some View {
+        VStack(spacing: 12) {
+            ProgressView()
+                .controlSize(.large)
+            Text("Scanning Installed Formulae")
+                .font(.headline)
+            Text("Checking Homebrew formulae against known vulnerabilities.")
+                .font(.callout)
+                .foregroundStyle(.secondary)
+        }
+        .accessibilityElement(children: .combine)
+        .accessibilityIdentifier("security-scanning-state")
+    }
+}
+
+private struct SecurityUnavailableState: View {
+    @Environment(BrewService.self)
+    private var brewService
+
+    let error: BrewError?
+
+    var body: some View {
+        ContentUnavailableView {
+            Label(title, systemImage: systemImage)
+        } description: {
+            VStack(spacing: 6) {
+                Text(description)
+                    .textSelection(.enabled)
+                Text(securityScopeDescription)
+            }
+        } actions: {
+            Button(actionTitle) {
+                Task { await brewService.scanVulnerabilities() }
+            }
+        }
+        .frame(maxWidth: .infinity, maxHeight: .infinity)
+    }
+
+    private var title: String {
+        error == nil ? "No Scan Yet" : "Scan Failed"
+    }
+
+    private var systemImage: String {
+        error == nil ? "magnifyingglass" : "xmark.octagon"
+    }
+
+    private var description: String {
+        error?.localizedDescription
+            ?? "Homebrew queries OSV with upstream repository URLs and release tags when you run a scan."
+    }
+
+    private var actionTitle: String {
+        error == nil ? "Run Vulnerability Scan" : "Retry Vulnerability Scan"
+    }
+}
+
+private struct SecurityScanContent: View {
+    let scan: FormulaVulnerabilityScan
+
+    var body: some View {
+        SecuritySummarySection(scan: scan)
+
+        if let warning = scan.warning {
+            SecurityMessageSection(
+                title: "Homebrew Notice",
+                message: warning,
+                systemImage: "exclamationmark.triangle.fill",
+                color: .orange
+            )
+        }
+
+        if scan.openGroups.isEmpty {
+            SecurityNoOpenFindingsSection()
+        } else {
+            SecurityFindingsSection(
+                title: "Open Vulnerabilities",
+                groups: scan.openGroups,
+                resolution: .open
+            )
+        }
+
+        if !scan.patchedGroups.isEmpty {
+            SecurityFindingsSection(
+                title: "Resolved by Formula Patches",
+                groups: scan.patchedGroups,
+                resolution: .patched
+            )
+        }
+
+        SecurityCoverageSection()
+    }
+}
+
+private struct SecuritySummarySection: View {
+    let scan: FormulaVulnerabilityScan
+
+    var body: some View {
+        Section("Latest Scan") {
+            HStack(spacing: 28) {
+                SecurityMetric(
+                    title: "Open",
+                    count: scan.openCount,
+                    systemImage: "exclamationmark.shield.fill",
+                    color: scan.openCount == 0 ? .green : .red
+                )
+                SecurityMetric(
+                    title: "Formula-patched",
+                    count: scan.patchedCount,
+                    systemImage: "checkmark.shield.fill",
+                    color: .green
+                )
+                Spacer()
+                Text(scan.scannedAt, format: .relative(presentation: .named))
+                    .font(.callout)
+                    .foregroundStyle(.secondary)
+            }
+        }
+    }
+}
+
+private struct SecurityMetric: View {
+    let title: String
+    let count: Int
+    let systemImage: String
+    let color: Color
+
+    var body: some View {
+        Label {
+            VStack(alignment: .leading, spacing: 1) {
+                Text("\(count)")
+                    .font(.title2)
+                    .fontWeight(.semibold)
+                    .monospacedDigit()
+                Text(title)
+                    .font(.caption)
+                    .foregroundStyle(.secondary)
+            }
+        } icon: {
+            Image(systemName: systemImage)
+                .font(.title2)
+                .foregroundStyle(color)
+        }
+        .accessibilityElement(children: .combine)
+    }
+}
+
+private struct SecurityMessageSection: View {
+    let title: String
+    let message: String
+    let systemImage: String
+    let color: Color
+
+    var body: some View {
+        Section {
+            Label {
+                VStack(alignment: .leading, spacing: 4) {
+                    Text(title)
+                        .fontWeight(.medium)
+                    Text(message)
+                        .font(.callout)
+                        .foregroundStyle(.secondary)
+                        .textSelection(.enabled)
+                }
+            } icon: {
+                Image(systemName: systemImage)
+                    .foregroundStyle(color)
+            }
+        }
+    }
+}
+
+private struct SecurityNoOpenFindingsSection: View {
+    var body: some View {
+        Section {
+            ContentUnavailableView(
+                "No Open Vulnerabilities Returned",
+                systemImage: "checkmark.shield",
+                description: Text("Homebrew did not return any open findings in this scan.")
+            )
+        }
+    }
+}
+
+private enum VulnerabilityResolution: Equatable {
+    case open
+    case patched
+}
+
+private struct SecurityFindingsSection: View {
+    let title: String
+    let groups: [FormulaVulnerabilityGroup]
+    let resolution: VulnerabilityResolution
+
+    var body: some View {
+        Section(title) {
+            ForEach(groups) { group in
+                SecurityFormulaFindingRow(
+                    group: group,
+                    resolution: resolution
+                )
+            }
+        }
+    }
+}
+
+private struct SecurityFormulaFindingRow: View {
+    let group: FormulaVulnerabilityGroup
+    let resolution: VulnerabilityResolution
+
+    var body: some View {
+        VStack(alignment: .leading, spacing: 10) {
+            HStack(spacing: 8) {
+                VStack(alignment: .leading, spacing: 2) {
+                    Text(group.formula)
+                        .font(.headline)
+                        .textSelection(.enabled)
+                    HStack(spacing: 12) {
+                        Text("Installed version: \(group.version)")
+                        Text("Scanned target: \(group.tag)")
+                    }
+                    .font(.caption)
+                    .foregroundStyle(.secondary)
+                    .textSelection(.enabled)
+                }
+                Spacer()
+                if let url = ExternalURLPolicy.url(from: group.repoURL) {
+                    Link("Source", destination: url)
+                        .font(.caption)
+                }
+                BrewyCountBadge(count: group.vulnerabilities.count)
+            }
+
+            ForEach(group.vulnerabilities) { vulnerability in
+                SecurityVulnerabilityRow(
+                    vulnerability: vulnerability,
+                    resolution: resolution,
+                    groupID: group.id
+                )
+            }
+        }
+        .padding(.vertical, 4)
+    }
+}
+
+private struct SecurityVulnerabilityRow: View {
+    let vulnerability: BrewVulnerability
+    let resolution: VulnerabilityResolution
+    let groupID: String
+
+    var body: some View {
+        HStack(alignment: .top, spacing: 10) {
+            BrewyStatusBadge(vulnerability.severity.title, color: vulnerability.severity.color)
+            VStack(alignment: .leading, spacing: 4) {
+                if let url = vulnerability.advisoryURL {
+                    Link(destination: url) {
+                        HStack(spacing: 4) {
+                            Text(vulnerability.id)
+                                .fontWeight(.medium)
+                            Image(systemName: "arrow.up.right")
+                                .font(.caption2)
+                        }
+                    }
+                } else {
+                    Text(vulnerability.id)
+                        .fontWeight(.medium)
+                }
+
+                if let summary = vulnerability.summary, !summary.isEmpty {
+                    Text(summary)
+                        .font(.callout)
+                        .foregroundStyle(.secondary)
+                        .textSelection(.enabled)
+                }
+
+                if !vulnerability.aliases.isEmpty {
+                    Text("Also known as: \(vulnerability.aliases.joined(separator: ", "))")
+                        .font(.caption)
+                        .foregroundStyle(.tertiary)
+                        .textSelection(.enabled)
+                }
+
+                if !vulnerability.fixedVersions.isEmpty {
+                    Text("Upstream fix boundary: \(vulnerability.fixedVersions.joined(separator: ", "))")
+                        .font(.caption)
+                        .foregroundStyle(.tertiary)
+                        .textSelection(.enabled)
+                }
+
+                if resolution == .patched {
+                    Text("Resolved by a Homebrew formula patch")
+                        .font(.caption)
+                        .foregroundStyle(.green)
+                }
+            }
+        }
+        .accessibilityElement(children: .combine)
+        .accessibilityIdentifier("security-vulnerability-\(groupID)|\(vulnerability.id)")
+    }
+}
+
+private struct SecurityCoverageSection: View {
+    var body: some View {
+        Section("Coverage") {
+            Label(
+                "The JSON report does not include checked or skipped formula counts.",
+                systemImage: "info.circle"
+            )
+            Label(
+                "An empty report means Homebrew returned no findings, not that every installed formula was assessed.",
+                systemImage: "eye.trianglebadge.exclamationmark"
+            )
+        }
+    }
+}
+
+extension VulnerabilitySeverity {
+    var color: Color {
+        switch self {
+        case .critical: .red
+        case .high: .orange
+        case .medium: .yellow
+        case .low: .blue
+        case .unknown: .secondary
+        }
+    }
+}

--- a/Brewy/Views/SidebarView.swift
+++ b/Brewy/Views/SidebarView.swift
@@ -63,6 +63,8 @@ private struct SidebarRow: View {
         case .bundle: brewService.bundleEntryCount
         case .history: brewService.actionHistory.isEmpty ? nil : brewService.actionHistory.count
         case .discover: nil
+        case .security:
+            if let count = brewService.vulnerabilityScan?.openCount, count > 0 { count } else { nil }
         case .maintenance: nil
         default: brewService.packages(for: category).count
         }
@@ -83,6 +85,7 @@ private struct SidebarRow: View {
         case .bundle: .brewyAccent
         case .history: .secondary
         case .discover: .cyan
+        case .security: .red
         case .maintenance: .purple
         }
     }

--- a/BrewyTests/BrewServiceTests.swift
+++ b/BrewyTests/BrewServiceTests.swift
@@ -143,6 +143,7 @@ struct BrewServiceDerivedStateTests {
         #expect(service.packages(for: .outdated)[0].name == "node")
         #expect(service.packages(for: .taps).isEmpty)
         #expect(service.packages(for: .discover).isEmpty)
+        #expect(service.packages(for: .security).isEmpty)
         #expect(service.packages(for: .maintenance).isEmpty)
     }
 

--- a/BrewyTests/CommandRunnerTests.swift
+++ b/BrewyTests/CommandRunnerTests.swift
@@ -6,11 +6,14 @@ import Testing
 @Suite("CommandResult")
 struct CommandResultTests {
 
-    @Test("CommandResult is Sendable and stores output + success")
+    @Test("CommandResult defaults structured output to the legacy output")
     func basicFields() {
         let result = CommandResult(output: "hi", success: true)
         #expect(result.output == "hi")
         #expect(result.success)
+        #expect(result.standardOutput == "hi")
+        #expect(result.standardError.isEmpty)
+        #expect(result.exitCode == nil)
     }
 }
 
@@ -161,6 +164,9 @@ struct CommandRunnerProcessTests {
         #expect(!result.success)
         #expect(result.output.contains("stdout-line"))
         #expect(result.output.contains("stderr-line"))
+        #expect(result.standardOutput == "stdout-line\n")
+        #expect(result.standardError == "stderr-line\n")
+        #expect(result.exitCode == 2)
     }
 
     @Test("runExecutable reports the exit code when failure has no output")

--- a/BrewyTests/TestHelpers.swift
+++ b/BrewyTests/TestHelpers.swift
@@ -28,6 +28,12 @@ final class MockCommandRunner: CommandRunning, @unchecked Sendable {
         }
     }
 
+    func setResult(for arguments: [String], result: CommandResult) {
+        lock.withLock {
+            _results[arguments] = result
+        }
+    }
+
     func setDelay(for arguments: [String], duration: Duration) {
         lock.withLock {
             _delays[arguments] = duration

--- a/BrewyTests/VulnerabilityTests.swift
+++ b/BrewyTests/VulnerabilityTests.swift
@@ -1,0 +1,247 @@
+@testable import Brewy
+import Foundation
+import Testing
+
+@Suite("Homebrew Vulnerability Scanning")
+@MainActor
+struct VulnerabilityTests {
+    private static let findingsJSON = """
+    [
+      {
+        "formula": "openssl@3",
+        "version": "3.5.2",
+        "tag": "openssl-3.5.2",
+        "repo_url": "https://github.com/openssl/openssl.git",
+        "vulnerabilities": [
+          {
+            "id": "CVE-2026-1234",
+            "severity": "HIGH",
+            "summary": "Open vulnerability",
+            "aliases": ["GHSA-abcd-1234-5678"],
+            "fixed_versions": ["openssl-3.5.3"]
+          }
+        ],
+        "patched": [
+          {
+            "id": "CVE-2025-4321",
+            "severity": "MEDIUM",
+            "summary": null,
+            "aliases": [],
+            "fixed_versions": ["abc123"]
+          }
+        ]
+      }
+    ]
+    """
+
+    @Test("Decodes Homebrew open and formula-patched findings")
+    func decodesFindings() throws {
+        let findings = try JSONDecoder().decode(
+            [FormulaVulnerabilityFinding].self,
+            from: Data(Self.findingsJSON.utf8)
+        )
+
+        let finding = try #require(findings.first)
+        #expect(finding.formula == "openssl@3")
+        #expect(finding.vulnerabilities.first?.severity == .high)
+        #expect(finding.vulnerabilities.first?.fixedVersions == ["openssl-3.5.3"])
+        #expect(finding.patched.first?.id == "CVE-2025-4321")
+        #expect(finding.patched.first?.summary == nil)
+    }
+
+    @Test("Accepts valid JSON when brew exits one for open findings")
+    func acceptsFindingExitStatus() async {
+        let mock = MockCommandRunner()
+        let (service, _) = makeService(mock: mock)
+        mock.setResult(
+            for: ["vulns", "--json"],
+            result: CommandResult(
+                output: Self.findingsJSON + "\nSome formulae were skipped.",
+                success: false,
+                standardOutput: Self.findingsJSON,
+                standardError: "Some formulae were skipped.",
+                exitCode: 1
+            )
+        )
+
+        await service.scanVulnerabilities()
+
+        #expect(service.vulnerabilityScan?.openCount == 1)
+        #expect(service.vulnerabilityScan?.patchedCount == 1)
+        #expect(service.vulnerabilityScan?.warning == "Some formulae were skipped.")
+        #expect(service.vulnerabilityScan?.openGroups.first?.version == "3.5.2")
+        #expect(service.vulnerabilityScan?.openGroups.first?.tag == "openssl-3.5.2")
+        #expect(service.vulnerabilityScan?.patchedGroups.first?.version == "3.5.2")
+        #expect(service.vulnerabilityScan?.patchedGroups.first?.tag == "openssl-3.5.2")
+        #expect(service.vulnerabilityScan?.openGroups.first?.vulnerabilities.first?.id == "CVE-2026-1234")
+        #expect(service.vulnerabilityScan?.patchedGroups.first?.vulnerabilities.first?.id == "CVE-2025-4321")
+        #expect(service.vulnerabilityScan?.openGroups.first?.id != service.vulnerabilityScan?.patchedGroups.first?.id)
+        #expect(service.vulnerabilityScanError == nil)
+        #expect(mock.executedCommands == [["vulns", "--json"]])
+    }
+
+    @Test("Keeps prior findings when a later scan cannot be decoded")
+    func preservesPriorScanOnFailure() async {
+        let mock = MockCommandRunner()
+        let (service, _) = makeService(mock: mock)
+        mock.setResult(
+            for: ["vulns", "--json"],
+            result: CommandResult(
+                output: Self.findingsJSON,
+                success: false,
+                standardOutput: Self.findingsJSON,
+                exitCode: 1
+            )
+        )
+        await service.scanVulnerabilities()
+
+        mock.setResult(
+            for: ["vulns", "--json"],
+            result: CommandResult(
+                output: "Error: OSV request failed",
+                success: false,
+                standardOutput: "",
+                standardError: "Error: OSV request failed",
+                exitCode: 1
+            )
+        )
+        await service.scanVulnerabilities()
+
+        #expect(service.vulnerabilityScan?.openCount == 1)
+        #expect(service.vulnerabilityScanError?.localizedDescription == "Error: OSV request failed")
+    }
+
+    @Test("Cancellation does not replace results or surface an error")
+    func cancellationIsSilent() async {
+        let mock = MockCommandRunner()
+        let (service, _) = makeService(mock: mock)
+        mock.setResult(
+            for: ["vulns", "--json"],
+            result: CommandResult(output: "Command was cancelled.", success: false, cancelled: true)
+        )
+
+        await service.scanVulnerabilities()
+
+        #expect(service.vulnerabilityScan == nil)
+        #expect(service.vulnerabilityScanError == nil)
+        #expect(!service.isScanningVulnerabilities)
+    }
+
+    @Test("Installed formula version changes invalidate prior results")
+    func formulaVersionChangeInvalidatesScan() async {
+        let mock = MockCommandRunner()
+        let (service, _) = makeService(mock: mock)
+        service.installedFormulae = [makePackage(name: "openssl@3", installedVersion: "3.5.2")]
+        mock.setResult(
+            for: ["vulns", "--json"],
+            result: CommandResult(
+                output: Self.findingsJSON,
+                success: false,
+                standardOutput: Self.findingsJSON,
+                exitCode: 1
+            )
+        )
+        await service.scanVulnerabilities()
+
+        service.installedFormulae = [makePackage(name: "openssl@3", installedVersion: "3.5.2")]
+        #expect(service.vulnerabilityScan != nil)
+
+        service.installedFormulae = [makePackage(name: "openssl@3", installedVersion: "3.5.3")]
+        #expect(service.vulnerabilityScan == nil)
+    }
+
+    @Test("Groups sort worst severity first and deduplicate vulnerability IDs")
+    func normalizesGroupVulnerabilities() {
+        let duplicateLow = BrewVulnerability(
+            id: "CVE-duplicate",
+            severity: .low,
+            summary: nil,
+            aliases: [],
+            fixedVersions: []
+        )
+        let duplicateCritical = BrewVulnerability(
+            id: "CVE-duplicate",
+            severity: .critical,
+            summary: nil,
+            aliases: [],
+            fixedVersions: []
+        )
+        let high = BrewVulnerability(
+            id: "CVE-high",
+            severity: .high,
+            summary: nil,
+            aliases: [],
+            fixedVersions: []
+        )
+        let finding = FormulaVulnerabilityFinding(
+            formula: "openssl@3",
+            version: "3.5.2",
+            tag: "openssl-3.5.2",
+            repoURL: "https://github.com/openssl/openssl.git",
+            vulnerabilities: [duplicateLow, high, duplicateCritical],
+            patched: []
+        )
+
+        let scan = FormulaVulnerabilityScan(findings: [finding], scannedAt: Date(), warning: nil)
+
+        #expect(scan.openGroups.first?.vulnerabilities.map(\.id) == ["CVE-duplicate", "CVE-high"])
+        #expect(scan.openGroups.first?.vulnerabilities.first?.severity == .critical)
+        #expect(scan.openCount == 2)
+    }
+
+    @Test("Unexpected exit status preserves prior results")
+    func unexpectedExitStatusPreservesPriorScan() async {
+        let mock = MockCommandRunner()
+        let (service, _) = makeService(mock: mock)
+        mock.setResult(
+            for: ["vulns", "--json"],
+            result: CommandResult(
+                output: Self.findingsJSON,
+                success: false,
+                standardOutput: Self.findingsJSON,
+                exitCode: 1
+            )
+        )
+        await service.scanVulnerabilities()
+
+        mock.setResult(
+            for: ["vulns", "--json"],
+            result: CommandResult(
+                output: "brew vulns terminated unexpectedly",
+                success: false,
+                standardOutput: "",
+                standardError: "brew vulns terminated unexpectedly",
+                exitCode: 2
+            )
+        )
+        await service.scanVulnerabilities()
+
+        #expect(service.vulnerabilityScan?.openCount == 1)
+        #expect(service.vulnerabilityScanError?.localizedDescription == "brew vulns terminated unexpectedly")
+    }
+
+    @Test("Scan retries when the formula inventory changes in flight")
+    func retriesAfterConcurrentFormulaChange() async {
+        let mock = MockCommandRunner()
+        let (service, _) = makeService(mock: mock)
+        service.installedFormulae = [makePackage(name: "openssl@3", installedVersion: "3.5.2")]
+        mock.setResult(
+            for: ["vulns", "--json"],
+            result: CommandResult(
+                output: Self.findingsJSON,
+                success: false,
+                standardOutput: Self.findingsJSON,
+                exitCode: 1
+            )
+        )
+        mock.setDelay(for: ["vulns", "--json"], duration: .milliseconds(50))
+
+        async let scan: Void = service.scanVulnerabilities()
+        try? await Task.sleep(for: .milliseconds(10))
+        service.installedFormulae = [makePackage(name: "openssl@3", installedVersion: "3.5.3")]
+        await scan
+
+        #expect(service.vulnerabilityScan?.openCount == 1)
+        #expect(mock.executedCommands == [["vulns", "--json"], ["vulns", "--json"]])
+    }
+}

--- a/BrewyUITests/SecurityUITests.swift
+++ b/BrewyUITests/SecurityUITests.swift
@@ -1,0 +1,203 @@
+import XCTest
+
+@MainActor
+final class SecurityUITests: XCTestCase {
+    private static let timeoutScale: TimeInterval = isThreadSanitizerActive ? 4 : 1
+    private static let launchTimeout: TimeInterval = 30 * timeoutScale
+    private static let elementTimeout: TimeInterval = 10 * timeoutScale
+    private static let securityScopeDescription =
+        "Casks, Mac App Store apps, and apps installed outside Homebrew are not assessed."
+
+    private var app: XCUIApplication!
+    private var fixtureDirectory: URL!
+
+    override func setUp() async throws {
+        continueAfterFailure = false
+        fixtureDirectory = FileManager.default.temporaryDirectory
+            .appendingPathComponent("brewy-security-ui-tests-\(ProcessInfo.processInfo.globallyUniqueString)")
+        try FileManager.default.createDirectory(at: fixtureDirectory, withIntermediateDirectories: true)
+
+        app = XCUIApplication()
+        app.terminate()
+        app.launchArguments += [
+            "-ApplePersistenceIgnoreState", "YES",
+            "-NSConstraintBasedLayoutVisualizeMutuallyExclusiveConstraints", "YES",
+            "-autoRefreshInterval", "0",
+            "-brewfilePath", "",
+            "-showCasksByDefault", "NO",
+            "-showDockIcon", "YES",
+            "-showMenuBarIcon", "YES"
+        ]
+        app.launchEnvironment["BREWY_UI_TESTING"] = "1"
+        app.launchEnvironment["XDG_CONFIG_HOME"] = fixtureDirectory.path
+        app.launch()
+        app.activate()
+    }
+
+    override func tearDown() async throws {
+        app?.terminate()
+        app = nil
+        try? FileManager.default.removeItem(at: fixtureDirectory)
+        fixtureDirectory = nil
+    }
+
+    func testScanRequiresExplicitRequest() throws {
+        openSecurity()
+
+        let pane = app.descendants(matching: .any)["security-pane"]
+        let scanButton = app.buttons["security-scan-button"]
+        assertExists(pane, timeout: Self.elementTimeout, "Security pane should appear")
+        assertExists(app.staticTexts["No Scan Yet"], timeout: Self.elementTimeout, "Initial state should appear")
+        assertExists(scanButton, timeout: Self.elementTimeout, "Security scan button should appear")
+        XCTAssertEqual(scanButton.label, "Run Scan")
+        assertDoesNotExist(
+            app.descendants(matching: .any)[
+                "security-vulnerability-open|ripgrep|14.1.1|CVE-2026-1234"
+            ],
+            timeout: 1 * Self.timeoutScale,
+            "No findings should appear before the user requests a scan"
+        )
+    }
+
+    func testScanRendersOpenAndPatchedFindings() throws {
+        openSecurity()
+
+        let scanButton = app.buttons["security-scan-button"]
+        assertExists(scanButton, timeout: Self.elementTimeout, "Security scan button should appear")
+        XCTAssertEqual(scanButton.label, "Run Scan")
+        scanButton.click()
+        assertLabel(scanButton, equals: "Scan Again", "Security scan should complete")
+
+        let openFinding = app.descendants(matching: .any)[
+            "security-vulnerability-open|ripgrep|14.1.1|CVE-2026-1234"
+        ]
+        assertExists(openFinding, timeout: Self.elementTimeout, "An explicit scan should render the open finding")
+        assertExists(
+            app.staticTexts["Installed version: 14.1.0"],
+            timeout: Self.elementTimeout,
+            "The installed version should be labeled"
+        )
+        assertExists(
+            app.staticTexts["Scanned target: 14.1.1"],
+            timeout: Self.elementTimeout,
+            "The queried release tag should be labeled"
+        )
+        assertExists(
+            app.staticTexts["Homebrew Notice"],
+            timeout: Self.elementTimeout,
+            "Homebrew's warning should use a neutral heading"
+        )
+
+        let pane = app.descendants(matching: .any)["security-pane"]
+        assertExists(pane, timeout: Self.elementTimeout, "Security results pane should appear")
+        let scrollContainer = securityResultsScrollContainer(in: pane)
+        assertExists(scrollContainer, timeout: Self.elementTimeout, "Security results should be scrollable")
+        let initialOpenFindingY = openFinding.frame.midY
+        scrollContainer.scroll(byDeltaX: 0, deltaY: -600)
+        settle()
+        XCTAssertLessThan(openFinding.frame.midY, initialOpenFindingY, "The results content should actually scroll")
+
+        let patchedFinding = app.descendants(matching: .any)[
+            "security-vulnerability-patched|ripgrep|14.1.1|CVE-2025-4321"
+        ]
+        assertExists(patchedFinding, timeout: Self.elementTimeout, "Formula-patched vulnerability should render")
+        XCTAssertTrue(
+            scrollContainer.frame.intersects(patchedFinding.frame),
+            "The patched finding should be visible after scrolling the results container"
+        )
+    }
+
+    func testFailureStateIsCenteredAndOffersRetry() throws {
+        app.terminate()
+        app.launchEnvironment["BREWY_UI_VULNERABILITY_SCAN_FAILURE"] = "1"
+        app.launch()
+        app.activate()
+        openSecurity()
+
+        let pane = app.descendants(matching: .any)["security-pane"]
+        let scanButton = app.buttons["security-scan-button"]
+        let failureTitle = app.staticTexts["Scan Failed"]
+        assertExists(pane, timeout: Self.elementTimeout, "Security pane should appear")
+        assertExists(scanButton, timeout: Self.elementTimeout, "Security scan button should appear")
+        XCTAssertEqual(scanButton.label, "Run Scan")
+        scanButton.click()
+        assertLabel(scanButton, equals: "Retry Scan", "Failed scan should offer a retry")
+        assertExists(failureTitle, timeout: Self.elementTimeout, "Failure state should appear")
+        XCTAssertEqual(failureTitle.frame.midX, pane.frame.midX, accuracy: 30)
+        XCTAssertEqual(failureTitle.frame.midY, pane.frame.midY, accuracy: 80)
+        assertExists(
+            app.staticTexts[Self.securityScopeDescription],
+            timeout: Self.elementTimeout,
+            "Failure state should retain the formula-only coverage disclaimer"
+        )
+        assertExists(
+            app.buttons["Retry Vulnerability Scan"],
+            timeout: Self.elementTimeout,
+            "Failure state should offer an explicit retry action"
+        )
+    }
+
+    private func openSecurity() {
+        let sidebar = app.outlines.firstMatch
+        assertExists(sidebar, timeout: Self.launchTimeout, "Sidebar should exist")
+        sidebar.staticTexts["Security"].click()
+    }
+
+    private func assertExists(
+        _ element: XCUIElement,
+        timeout: TimeInterval,
+        _ message: @autoclosure () -> String,
+        file: StaticString = #filePath,
+        line: UInt = #line
+    ) {
+        XCTAssertTrue(element.waitForExistence(timeout: timeout), message(), file: file, line: line)
+    }
+
+    private func assertDoesNotExist(
+        _ element: XCUIElement,
+        timeout: TimeInterval,
+        _ message: @autoclosure () -> String,
+        file: StaticString = #filePath,
+        line: UInt = #line
+    ) {
+        XCTAssertFalse(element.waitForExistence(timeout: timeout), message(), file: file, line: line)
+    }
+
+    private func assertLabel(
+        _ element: XCUIElement,
+        equals label: String,
+        _ message: @autoclosure () -> String,
+        file: StaticString = #filePath,
+        line: UInt = #line
+    ) {
+        let expectation = XCTNSPredicateExpectation(
+            predicate: NSPredicate(format: "label == %@", label),
+            object: element
+        )
+        let outcome = XCTWaiter().wait(for: [expectation], timeout: Self.elementTimeout)
+        XCTAssertEqual(outcome, .completed, message(), file: file, line: line)
+    }
+
+    private func securityResultsScrollContainer(in pane: XCUIElement) -> XCUIElement {
+        if pane.elementType == .outline || pane.elementType == .scrollView {
+            return pane
+        }
+
+        let outline = pane.outlines.firstMatch
+        if outline.exists {
+            return outline
+        }
+        return pane.scrollViews.firstMatch
+    }
+
+    private func settle(_ seconds: TimeInterval = 0.5) {
+        RunLoop.current.run(until: Date(timeIntervalSinceNow: seconds * Self.timeoutScale))
+    }
+
+    private static var isThreadSanitizerActive: Bool {
+        (0..<_dyld_image_count()).contains { index in
+            guard let name = _dyld_get_image_name(index) else { return false }
+            return String(cString: name).contains("libclang_rt.tsan")
+        }
+    }
+}

--- a/BrewyUITests/SidebarNavigationUITests.swift
+++ b/BrewyUITests/SidebarNavigationUITests.swift
@@ -63,7 +63,7 @@ final class SidebarNavigationUITests: XCTestCase {
         let categories = [
             "Installed", "Formulae", "Casks", "Mac App Store", "Outdated",
             "Pinned", "Leaves", "Taps", "Services", "Groups", "Bundle",
-            "History", "Discover", "Maintenance"
+            "History", "Discover", "Security", "Maintenance"
         ]
 
         let sidebar = app.outlines.firstMatch
@@ -84,7 +84,7 @@ final class SidebarNavigationUITests: XCTestCase {
         let expectedCategories = [
             "Installed", "Formulae", "Casks", "Mac App Store", "Outdated",
             "Pinned", "Leaves", "Taps", "Services", "Groups", "Bundle",
-            "History", "Discover", "Maintenance"
+            "History", "Discover", "Security", "Maintenance"
         ]
 
         for category in expectedCategories {


### PR DESCRIPTION
Brewy had no way to tell whether an installed formula carries a known vulnerability. A new Security screen runs `brew vulns --json` on request and lists open findings alongside the ones Homebrew already resolves with a formula patch, worst severity first, each linking to its OSV advisory and upstream source. Casks, Mac App Store apps, and anything installed outside Homebrew are out of scope, and the screen says so rather than letting an empty report read as a clean bill of health.

`brew vulns` exits 1 when it successfully reports open findings and writes coverage warnings to standard error, so `CommandResult` now carries raw stdout, stderr, and exit status separately and the report is decoded from stdout alone; the combined `output` string is unchanged for existing callers. Scanning stays manual because it sends every queryable formula's upstream repository URL and release tag to OSV, which merely selecting a sidebar row should not trigger. Rows label the installed version and the scanned target separately, since Homebrew reports both and they diverge for an outdated formula with no SBOM. Results are discarded as soon as the installed formula set or any of its versions changes, so a stale finding count never outlives the packages it described.

AI disclosure: Claude Opus 5 with manual testing and review.
