### PR TITLE
fix(commands): run the timeout watchdog at default QoS

### DIFF
--- a/Brewy/Models/CommandRunner.swift
+++ b/Brewy/Models/CommandRunner.swift
@@ -463,7 +463,7 @@ final class TimeoutWatchdog: @unchecked Sendable {
             action()
         }
         thread.name = "Brewy command timeout"
-        thread.qualityOfService = .userInitiated
+        thread.qualityOfService = .default
         thread.start()
     }
 

--- a/BrewyTests/CommandRunnerTests.swift
+++ b/BrewyTests/CommandRunnerTests.swift
@@ -195,15 +195,20 @@ struct CommandRunnerProcessTests {
         #expect(elapsed < .seconds(25))
     }
 
-    @Test("Timeout watchdog runs on its dedicated thread")
-    func timeoutWatchdogFires() {
-        let fired = DispatchSemaphore(value: 0)
+    @Test("Timeout watchdog runs on its dedicated thread at default QoS")
+    func timeoutWatchdogFires() async throws {
+        let qualityOfService = LockedQualityOfService()
         let watchdog = TimeoutWatchdog(deadline: .now() + .milliseconds(50)) {
-            fired.signal()
+            qualityOfService.store(Thread.current.qualityOfService)
+        }
+        defer { watchdog.cancel() }
+
+        let deadline = ContinuousClock.now.advanced(by: .seconds(10))
+        while qualityOfService.value == nil, ContinuousClock.now < deadline {
+            try await Task.sleep(for: .milliseconds(10))
         }
 
-        #expect(fired.wait(timeout: .now() + .seconds(10)) == .success)
-        withExtendedLifetime(watchdog) {}
+        #expect(qualityOfService.value == .default)
     }
 
     @Test("Timeout watchdog cancellation prevents its action")
@@ -345,6 +350,19 @@ struct CommandRunnerProcessTests {
 
         #expect(!result.success)
         #expect(chunks.joined().contains("err-line"))
+    }
+}
+
+private final class LockedQualityOfService: @unchecked Sendable {
+    private let lock = NSLock()
+    private var qualityOfService: QualityOfService?
+
+    var value: QualityOfService? {
+        lock.withLock { qualityOfService }
+    }
+
+    func store(_ qualityOfService: QualityOfService) {
+        lock.withLock { self.qualityOfService = qualityOfService }
     }
 }
 


### PR DESCRIPTION
Xcode's Thread Performance Checker flagged a priority inversion in `CommandRunner`: the timeout watchdog's dedicated thread waited at `.userInitiated` on a `DispatchSemaphore` that is only ever signalled from the default-QoS task running the child process. The watchdog thread now runs at `.default`, matching its signaller, which removes the inversion at its source rather than papering over the wait.

The SIGTERM and SIGKILL escalation thread in `ProcessTermination` deliberately stays `.userInitiated`. The watchdog does nothing latency-sensitive itself: it wakes from a semaphore timeout, sends SIGTERM inline, and hands the grace-period timer to that separate thread, so lowering it cannot delay teardown. Its test now polls a lock-protected observation against an explicit deadline instead of blocking the test runner on a semaphore, and asserts the QoS the watchdog actually runs at.

AI disclosure: Claude Opus 5 with manual testing and review.
