### PR TITLE
feat(settings): report and control Homebrew's analytics setting

### DIFF
--- a/Brewy/BrewyApp.swift
+++ b/Brewy/BrewyApp.swift
@@ -106,6 +106,7 @@ struct BrewyApp: App {
 
         Settings {
             SettingsView()
+                .environment(brewService)
         }
 
         MenuBarExtra(isInserted: $showMenuBarIcon) {

--- a/Brewy/Models/BrewService+Analytics.swift
+++ b/Brewy/Models/BrewService+Analytics.swift
@@ -1,0 +1,89 @@
+import Foundation
+
+enum HomebrewAnalyticsStatus: Equatable, Sendable {
+    case unknown
+    case enabled
+    case disabled
+
+    static func parse(_ output: String) -> Self? {
+        for line in output.split(whereSeparator: \.isNewline) {
+            switch line.trimmingCharacters(in: .whitespaces).lowercased() {
+            case "influxdb analytics are enabled.":
+                return .enabled
+            case "influxdb analytics are disabled.":
+                return .disabled
+            default:
+                continue
+            }
+        }
+        return nil
+    }
+}
+
+extension BrewService {
+    func refreshHomebrewAnalyticsStatus() async {
+        guard !isUpdatingHomebrewAnalytics else { return }
+        isUpdatingHomebrewAnalytics = true
+        homebrewAnalyticsError = nil
+        defer { isUpdatingHomebrewAnalytics = false }
+
+        _ = await loadHomebrewAnalyticsStatus()
+    }
+
+    func setHomebrewAnalyticsEnabled(_ enabled: Bool) async {
+        guard !isUpdatingHomebrewAnalytics else {
+            homebrewAnalyticsError = "Wait for the current analytics operation to finish."
+            return
+        }
+        isUpdatingHomebrewAnalytics = true
+        homebrewAnalyticsError = nil
+        defer { isUpdatingHomebrewAnalytics = false }
+
+        let action = enabled ? "on" : "off"
+        let result = await runBrewCommand(["analytics", action])
+        guard !result.cancelled else { return }
+        guard result.success else {
+            homebrewAnalyticsError = BrewError.commandFailed(
+                command: "analytics \(action)",
+                output: result.output
+            ).localizedDescription
+            return
+        }
+
+        guard let reportedStatus = await loadHomebrewAnalyticsStatus() else { return }
+        let expectedStatus: HomebrewAnalyticsStatus = enabled ? .enabled : .disabled
+        if reportedStatus != expectedStatus {
+            homebrewAnalyticsError = "Homebrew still reports analytics as \(reportedStatus.description). "
+                + "Check your Homebrew environment and configuration."
+        }
+    }
+
+    private func loadHomebrewAnalyticsStatus() async -> HomebrewAnalyticsStatus? {
+        let result = await runBrewCommand(["analytics", "state"])
+        guard !result.cancelled else { return nil }
+        guard result.success else {
+            homebrewAnalyticsError = BrewError.commandFailed(
+                command: "analytics state",
+                output: result.output
+            ).localizedDescription
+            return nil
+        }
+        guard let status = HomebrewAnalyticsStatus.parse(result.standardOutput) else {
+            homebrewAnalyticsError = "Homebrew returned an unrecognized analytics status."
+            return nil
+        }
+
+        homebrewAnalyticsStatus = status
+        return status
+    }
+}
+
+extension HomebrewAnalyticsStatus {
+    fileprivate var description: String {
+        switch self {
+        case .unknown: "unknown"
+        case .enabled: "enabled"
+        case .disabled: "disabled"
+        }
+    }
+}

--- a/Brewy/Models/BrewService.swift
+++ b/Brewy/Models/BrewService.swift
@@ -111,7 +111,9 @@ final class BrewService {
     var vulnerabilityScan: FormulaVulnerabilityScan?
     var vulnerabilityScanError: BrewError?
     var isScanningVulnerabilities = false
-
+    var homebrewAnalyticsStatus: HomebrewAnalyticsStatus = .unknown
+    var homebrewAnalyticsError: String?
+    var isUpdatingHomebrewAnalytics = false
     var tapsLoaded = false
     private var isRefreshing = false
     private var needsRefresh = false

--- a/Brewy/Models/UITestFixtures.swift
+++ b/Brewy/Models/UITestFixtures.swift
@@ -26,7 +26,17 @@ enum BrewyRuntime {
 }
 
 #if DEBUG
-struct UITestCommandRunner: CommandRunning {
+final class UITestCommandRunner: CommandRunning, @unchecked Sendable {
+    private let lock = NSLock()
+    private var analyticsEnabled = true
+    private var analyticsStateFailuresRemaining: Int
+
+    init() {
+        analyticsStateFailuresRemaining = ProcessInfo.processInfo.environment[
+            "BREWY_UI_ANALYTICS_STATE_FAILS_ONCE"
+        ] == "1" ? 1 : 0
+    }
+
     func run(_ arguments: [String], brewPath: String, timeout: Duration) async -> CommandResult {
         if arguments == ["services", "info", "--all", "--json"] {
             return CommandResult(output: Self.servicesJSON, success: true)
@@ -42,6 +52,9 @@ struct UITestCommandRunner: CommandRunning {
         }
         if arguments == ["config"] {
             return CommandResult(output: Self.configOutput, success: true)
+        }
+        if let analyticsResult = analyticsResult(arguments) {
+            return analyticsResult
         }
         if arguments == ["vulns", "--json"] {
             if ProcessInfo.processInfo.environment["BREWY_UI_VULNERABILITY_SCAN_FAILURE"] == "1" {
@@ -74,6 +87,31 @@ struct UITestCommandRunner: CommandRunning {
             return CommandResult(output: "jq needs to be installed or updated.\n", success: false)
         }
         return CommandResult(output: "Fixture command completed.\n", success: true)
+    }
+
+    private func analyticsResult(_ arguments: [String]) -> CommandResult? {
+        switch arguments {
+        case ["analytics", "state"]:
+            return lock.withLock {
+                if analyticsStateFailuresRemaining > 0 {
+                    analyticsStateFailuresRemaining -= 1
+                    return CommandResult(output: "Error: fixture analytics state failed", success: false)
+                }
+                let state = analyticsEnabled ? "enabled" : "disabled"
+                return CommandResult(
+                    output: "InfluxDB analytics are \(state).\nGoogle Analytics were destroyed.\n",
+                    success: true
+                )
+            }
+        case ["analytics", "on"]:
+            lock.withLock { analyticsEnabled = true }
+            return CommandResult(output: "Homebrew analytics have been enabled.\n", success: true)
+        case ["analytics", "off"]:
+            lock.withLock { analyticsEnabled = false }
+            return CommandResult(output: "Homebrew analytics have been disabled.\n", success: true)
+        default:
+            return nil
+        }
     }
 
     func runExecutable(

--- a/Brewy/Views/SettingsView.swift
+++ b/Brewy/Views/SettingsView.swift
@@ -1,5 +1,9 @@
 import SwiftUI
 
+private let homebrewAnalyticsDocumentationURL = ExternalURLPolicy.url(
+    from: "https://docs.brew.sh/Analytics"
+)
+
 enum AppTheme: String, CaseIterable, Identifiable {
     case system = "System"
     case light = "Light"
@@ -66,6 +70,8 @@ struct SettingsView: View {
             Toggle("Prevent Homebrew auto-update", isOn: $preventHomebrewAutoUpdate)
                 .help("Stops Homebrew from updating itself before installs and upgrades.")
 
+            HomebrewAnalyticsSetting()
+
             Picker("Appearance:", selection: $appTheme) {
                 ForEach(AppTheme.allCases) { theme in
                     Text(theme.rawValue).tag(theme.rawValue)
@@ -105,7 +111,7 @@ struct SettingsView: View {
         .onChange(of: showDockIcon, initial: true) {
             AppVisibilitySettings.applyDockIconVisibility(showDockIcon)
         }
-        .frame(width: 560, height: 470)
+        .frame(width: 560, height: 560)
     }
 
     private var appVisibilitySettings: some View {
@@ -156,6 +162,97 @@ struct SettingsView: View {
     private func chooseBrewfile() {
         guard let path = BrewfilePicker.choosePath() else { return }
         brewfilePath = path
+    }
+}
+
+private struct HomebrewAnalyticsSetting: View {
+    @Environment(BrewService.self)
+    private var brewService
+    @State private var requestedState: Bool?
+
+    private var isEnabled: Binding<Bool> {
+        Binding(
+            get: { requestedState ?? (brewService.homebrewAnalyticsStatus == .enabled) },
+            set: { enabled in requestStateChange(enabled) }
+        )
+    }
+
+    private var statusDescription: String {
+        switch brewService.homebrewAnalyticsStatus {
+        case .unknown:
+            brewService.isUpdatingHomebrewAnalytics ? "Checking…" : "Unavailable"
+        case .enabled:
+            "Enabled"
+        case .disabled:
+            "Disabled"
+        }
+    }
+
+    var body: some View {
+        Section("Homebrew Analytics") {
+            if brewService.homebrewAnalyticsStatus != .unknown {
+                Toggle("Share Homebrew analytics", isOn: isEnabled)
+                    .accessibilityIdentifier("homebrew-analytics-toggle")
+                    .help("Changes Homebrew's analytics setting.")
+                    .disabled(brewService.isUpdatingHomebrewAnalytics)
+            }
+
+            LabeledContent("Status:") {
+                HStack(spacing: 8) {
+                    Text(statusDescription)
+                    if brewService.isUpdatingHomebrewAnalytics {
+                        ProgressView()
+                            .controlSize(.small)
+                            .accessibilityHidden(true)
+                    }
+                }
+            }
+            .accessibilityElement(children: .ignore)
+            .accessibilityIdentifier("homebrew-analytics-status")
+            .accessibilityLabel("Homebrew analytics status: \(statusDescription)")
+
+            Text("Homebrew uses aggregate usage data to help maintainers prioritize work. This changes Homebrew's existing analytics setting.")
+                .font(.caption)
+                .foregroundStyle(.secondary)
+                .fixedSize(horizontal: false, vertical: true)
+
+            if let error = brewService.homebrewAnalyticsError {
+                HStack {
+                    Text(error)
+                        .font(.caption)
+                        .foregroundStyle(.red)
+                        .fixedSize(horizontal: false, vertical: true)
+                }
+                .accessibilityElement(children: .ignore)
+                .accessibilityLabel(error)
+                .accessibilityIdentifier("homebrew-analytics-error")
+            }
+
+            if brewService.homebrewAnalyticsStatus == .unknown,
+               !brewService.isUpdatingHomebrewAnalytics {
+                Button("Retry", systemImage: "arrow.clockwise") {
+                    Task { @MainActor in
+                        await brewService.refreshHomebrewAnalyticsStatus()
+                    }
+                }
+                .accessibilityIdentifier("homebrew-analytics-retry")
+            }
+
+            if let documentationURL = homebrewAnalyticsDocumentationURL {
+                Link("Learn more about Homebrew analytics", destination: documentationURL)
+            }
+        }
+        .task {
+            await brewService.refreshHomebrewAnalyticsStatus()
+        }
+    }
+
+    private func requestStateChange(_ enabled: Bool) {
+        requestedState = enabled
+        Task { @MainActor in
+            await brewService.setHomebrewAnalyticsEnabled(enabled)
+            requestedState = nil
+        }
     }
 }
 

--- a/BrewyTests/HomebrewAnalyticsTests.swift
+++ b/BrewyTests/HomebrewAnalyticsTests.swift
@@ -1,0 +1,223 @@
+@testable import Brewy
+import Testing
+
+@Suite("Homebrew Analytics Settings")
+@MainActor
+struct HomebrewAnalyticsTests {
+    @Test("Parses enabled analytics state while ignoring legacy analytics output")
+    func parsesEnabledState() {
+        let output = """
+        InfluxDB analytics are enabled.
+        Google Analytics were destroyed.
+        """
+
+        #expect(HomebrewAnalyticsStatus.parse(output) == .enabled)
+    }
+
+    @Test("Parses disabled analytics state")
+    func parsesDisabledState() {
+        #expect(HomebrewAnalyticsStatus.parse("InfluxDB analytics are disabled.") == .disabled)
+    }
+
+    @Test("Rejects unrecognized analytics state")
+    func rejectsUnrecognizedState() {
+        #expect(HomebrewAnalyticsStatus.parse("Google Analytics were destroyed.") == nil)
+    }
+
+    @Test("Loads the current analytics state")
+    func loadsCurrentState() async {
+        let mock = MockCommandRunner()
+        let (service, _) = makeService(mock: mock)
+        mock.setResult(
+            for: ["analytics", "state"],
+            output: "InfluxDB analytics are enabled.\nGoogle Analytics were destroyed.\n"
+        )
+
+        await service.refreshHomebrewAnalyticsStatus()
+
+        #expect(service.homebrewAnalyticsStatus == .enabled)
+        #expect(service.homebrewAnalyticsError == nil)
+        #expect(!service.isUpdatingHomebrewAnalytics)
+        #expect(mock.executedCommands == [["analytics", "state"]])
+    }
+
+    @Test("Reports an unrecognized successful state response")
+    func reportsUnrecognizedState() async {
+        let mock = MockCommandRunner()
+        let (service, _) = makeService(mock: mock)
+        mock.setResult(for: ["analytics", "state"], output: "Google Analytics were destroyed.\n")
+
+        await service.refreshHomebrewAnalyticsStatus()
+
+        #expect(service.homebrewAnalyticsStatus == .unknown)
+        #expect(service.homebrewAnalyticsError == "Homebrew returned an unrecognized analytics status.")
+    }
+
+    @Test("Cancellation does not surface an analytics error")
+    func cancellationIsSilent() async {
+        let mock = MockCommandRunner()
+        let (service, _) = makeService(mock: mock)
+        mock.setResult(
+            for: ["analytics", "state"],
+            result: CommandResult(output: "Command was cancelled.", success: false, cancelled: true)
+        )
+
+        await service.refreshHomebrewAnalyticsStatus()
+
+        #expect(service.homebrewAnalyticsStatus == .unknown)
+        #expect(service.homebrewAnalyticsError == nil)
+        #expect(!service.isUpdatingHomebrewAnalytics)
+    }
+
+    @Test("Disables analytics and reloads the reported state")
+    func disablesAnalytics() async {
+        let mock = MockCommandRunner()
+        let (service, _) = makeService(mock: mock)
+        service.homebrewAnalyticsStatus = .enabled
+        mock.setResult(for: ["analytics", "off"], output: "Homebrew analytics have been disabled.")
+        mock.setResult(for: ["analytics", "state"], output: "InfluxDB analytics are disabled.")
+
+        await service.setHomebrewAnalyticsEnabled(false)
+
+        #expect(service.homebrewAnalyticsStatus == .disabled)
+        #expect(service.homebrewAnalyticsError == nil)
+        #expect(mock.executedCommands == [["analytics", "off"], ["analytics", "state"]])
+    }
+
+    @Test("Uses the reported state instead of assuming analytics were enabled")
+    func reloadsStateAfterEnabling() async {
+        let mock = MockCommandRunner()
+        let (service, _) = makeService(mock: mock)
+        service.homebrewAnalyticsStatus = .disabled
+        mock.setResult(for: ["analytics", "on"], output: "Homebrew analytics have been enabled.")
+        mock.setResult(for: ["analytics", "state"], output: "InfluxDB analytics are disabled.")
+
+        await service.setHomebrewAnalyticsEnabled(true)
+
+        #expect(service.homebrewAnalyticsStatus == .disabled)
+        #expect(
+            service.homebrewAnalyticsError
+                == "Homebrew still reports analytics as disabled. Check your Homebrew environment and configuration."
+        )
+        #expect(mock.executedCommands == [["analytics", "on"], ["analytics", "state"]])
+    }
+
+    @Test("Enables analytics and reloads the reported state")
+    func enablesAnalytics() async {
+        let mock = MockCommandRunner()
+        let (service, _) = makeService(mock: mock)
+        service.homebrewAnalyticsStatus = .disabled
+        mock.setResult(for: ["analytics", "on"], output: "Homebrew analytics have been enabled.")
+        mock.setResult(for: ["analytics", "state"], output: "InfluxDB analytics are enabled.")
+
+        await service.setHomebrewAnalyticsEnabled(true)
+
+        #expect(service.homebrewAnalyticsStatus == .enabled)
+        #expect(service.homebrewAnalyticsError == nil)
+        #expect(mock.executedCommands == [["analytics", "on"], ["analytics", "state"]])
+    }
+
+    @Test("A failed follow-up query preserves the last known state")
+    func preservesStateWhenReloadFails() async {
+        let mock = MockCommandRunner()
+        let (service, _) = makeService(mock: mock)
+        service.homebrewAnalyticsStatus = .disabled
+        mock.setResult(for: ["analytics", "on"], output: "Homebrew analytics have been enabled.")
+        mock.setResult(
+            for: ["analytics", "state"],
+            result: CommandResult(output: "Error: unable to read configuration", success: false)
+        )
+
+        await service.setHomebrewAnalyticsEnabled(true)
+
+        #expect(service.homebrewAnalyticsStatus == .disabled)
+        #expect(service.homebrewAnalyticsError == "Error: unable to read configuration")
+        #expect(mock.executedCommands == [["analytics", "on"], ["analytics", "state"]])
+    }
+
+    @Test("A cancelled setting change preserves the last known state")
+    func preservesStateOnSettingCancellation() async {
+        let mock = MockCommandRunner()
+        let (service, _) = makeService(mock: mock)
+        service.homebrewAnalyticsStatus = .enabled
+        mock.setResult(
+            for: ["analytics", "off"],
+            result: CommandResult(output: "Command was cancelled.", success: false, cancelled: true)
+        )
+
+        await service.setHomebrewAnalyticsEnabled(false)
+
+        #expect(service.homebrewAnalyticsStatus == .enabled)
+        #expect(service.homebrewAnalyticsError == nil)
+        #expect(mock.executedCommands == [["analytics", "off"]])
+    }
+
+    @Test("A concurrent setting request is rejected visibly")
+    func reportsConcurrentSettingRequest() async {
+        let mock = MockCommandRunner()
+        let (service, _) = makeService(mock: mock)
+        service.homebrewAnalyticsStatus = .enabled
+        service.isUpdatingHomebrewAnalytics = true
+
+        await service.setHomebrewAnalyticsEnabled(false)
+
+        #expect(service.homebrewAnalyticsStatus == .enabled)
+        #expect(service.isUpdatingHomebrewAnalytics)
+        #expect(service.homebrewAnalyticsError == "Wait for the current analytics operation to finish.")
+        #expect(mock.executedCommands.isEmpty)
+    }
+
+    @Test("A concurrent refresh does not clear another operation's state")
+    func preservesConcurrentOperationDuringRefresh() async {
+        let mock = MockCommandRunner()
+        let (service, _) = makeService(mock: mock)
+        service.homebrewAnalyticsStatus = .enabled
+        service.isUpdatingHomebrewAnalytics = true
+
+        await service.refreshHomebrewAnalyticsStatus()
+
+        #expect(service.homebrewAnalyticsStatus == .enabled)
+        #expect(service.isUpdatingHomebrewAnalytics)
+        #expect(mock.executedCommands.isEmpty)
+    }
+
+    @Test("A completing refresh preserves a concurrent request warning")
+    func preservesConcurrentRequestWarningAfterRefresh() async {
+        let mock = MockCommandRunner()
+        let (service, _) = makeService(mock: mock)
+        service.homebrewAnalyticsStatus = .enabled
+        mock.setResult(for: ["analytics", "state"], output: "InfluxDB analytics are enabled.")
+        mock.setDelay(for: ["analytics", "state"], duration: .milliseconds(100))
+
+        let refresh = Task { await service.refreshHomebrewAnalyticsStatus() }
+        for _ in 0..<100 where mock.executedCommands.isEmpty {
+            await Task.yield()
+        }
+        #expect(mock.executedCommands == [["analytics", "state"]])
+
+        await service.setHomebrewAnalyticsEnabled(false)
+        #expect(service.homebrewAnalyticsError == "Wait for the current analytics operation to finish.")
+        await refresh.value
+
+        #expect(service.homebrewAnalyticsStatus == .enabled)
+        #expect(service.homebrewAnalyticsError == "Wait for the current analytics operation to finish.")
+        #expect(!service.isUpdatingHomebrewAnalytics)
+    }
+
+    @Test("A failed setting change preserves the last known state")
+    func preservesStateOnSettingFailure() async {
+        let mock = MockCommandRunner()
+        let (service, _) = makeService(mock: mock)
+        service.homebrewAnalyticsStatus = .enabled
+        mock.setResult(
+            for: ["analytics", "off"],
+            result: CommandResult(output: "Error: configuration is read-only", success: false)
+        )
+
+        await service.setHomebrewAnalyticsEnabled(false)
+
+        #expect(service.homebrewAnalyticsStatus == .enabled)
+        #expect(service.homebrewAnalyticsError == "Error: configuration is read-only")
+        #expect(mock.executedCommands == [["analytics", "off"]])
+    }
+}

--- a/BrewyUITests/HomebrewAnalyticsUITests.swift
+++ b/BrewyUITests/HomebrewAnalyticsUITests.swift
@@ -1,0 +1,173 @@
+import XCTest
+
+@MainActor
+final class HomebrewAnalyticsUITests: XCTestCase {
+    private static let launchTimeout: TimeInterval = 30
+    private static let transitionTimeout: TimeInterval = 10
+
+    private var app: XCUIApplication!
+    private var fixtureDirectory: URL!
+
+    override func setUp() async throws {
+        continueAfterFailure = false
+        fixtureDirectory = FileManager.default.temporaryDirectory
+            .appendingPathComponent("brewy-analytics-ui-tests-\(ProcessInfo.processInfo.globallyUniqueString)")
+        try FileManager.default.createDirectory(at: fixtureDirectory, withIntermediateDirectories: true)
+    }
+
+    override func tearDown() async throws {
+        app?.terminate()
+        app = nil
+        try? FileManager.default.removeItem(at: fixtureDirectory)
+        fixtureDirectory = nil
+    }
+
+    func testSettingTogglesReportedState() {
+        launch()
+        XCTAssertTrue(
+            app.windows.firstMatch.waitForExistence(timeout: Self.launchTimeout),
+            "The main window should open before presenting Settings"
+        )
+        app.typeKey(",", modifierFlags: .command)
+
+        let settingsWindow = app.windows["Brewy Settings"]
+        XCTAssertTrue(
+            settingsWindow.waitForExistence(timeout: Self.transitionTimeout),
+            "The Settings window should open from its keyboard shortcut"
+        )
+
+        let analyticsToggle = settingsWindow.switches["homebrew-analytics-toggle"]
+        XCTAssertTrue(
+            analyticsToggle.waitForExistence(timeout: Self.transitionTimeout),
+            "Settings should expose Homebrew's analytics control"
+        )
+        let analyticsStatus = settingsWindow.descendants(matching: .any)["homebrew-analytics-status"]
+        XCTAssertTrue(
+            analyticsStatus.waitForExistence(timeout: Self.transitionTimeout),
+            "Settings should report Homebrew's current analytics state"
+        )
+        assertLabel("Homebrew analytics status: Enabled", for: analyticsStatus)
+
+        let editableToggle = XCTNSPredicateExpectation(
+            predicate: NSPredicate(format: "enabled == true"),
+            object: analyticsToggle
+        )
+        XCTAssertEqual(
+            XCTWaiter.wait(for: [editableToggle], timeout: Self.transitionTimeout),
+            .completed,
+            "The loaded analytics setting should be editable"
+        )
+        assertCheckedValue(true, for: analyticsToggle)
+
+        analyticsToggle.click()
+
+        assertCheckedValue(false, for: analyticsToggle)
+        assertLabel("Homebrew analytics status: Disabled", for: analyticsStatus)
+    }
+
+    func testUnavailableStateDoesNotRenderAsDisabledAndCanRetry() {
+        launch(analyticsStateFailsOnce: true)
+        XCTAssertTrue(
+            app.windows.firstMatch.waitForExistence(timeout: Self.launchTimeout),
+            "The main window should open before presenting Settings"
+        )
+        app.typeKey(",", modifierFlags: .command)
+
+        let settingsWindow = app.windows["Brewy Settings"]
+        XCTAssertTrue(
+            settingsWindow.waitForExistence(timeout: Self.transitionTimeout),
+            "The Settings window should open from its keyboard shortcut"
+        )
+        let analyticsStatus = settingsWindow.descendants(matching: .any)["homebrew-analytics-status"]
+        XCTAssertTrue(
+            analyticsStatus.waitForExistence(timeout: Self.transitionTimeout),
+            "Settings should expose the analytics status"
+        )
+        assertLabel("Homebrew analytics status: Unavailable", for: analyticsStatus)
+        XCTAssertFalse(
+            settingsWindow.switches["homebrew-analytics-toggle"].exists,
+            "An unknown analytics state must not render as an off switch"
+        )
+
+        let analyticsError = settingsWindow.descendants(matching: .any)["homebrew-analytics-error"]
+        XCTAssertTrue(
+            analyticsError.waitForExistence(timeout: Self.transitionTimeout),
+            "Settings should explain why the analytics state is unavailable"
+        )
+        let retry = settingsWindow.buttons["homebrew-analytics-retry"]
+        XCTAssertTrue(
+            retry.waitForExistence(timeout: Self.transitionTimeout),
+            "Settings should allow a failed analytics query to be retried"
+        )
+        retry.click()
+
+        XCTAssertTrue(
+            settingsWindow.switches["homebrew-analytics-toggle"].waitForExistence(
+                timeout: Self.transitionTimeout
+            ),
+            "A successful retry should reveal the analytics toggle"
+        )
+        assertLabel("Homebrew analytics status: Enabled", for: analyticsStatus)
+    }
+
+    private func launch(analyticsStateFailsOnce: Bool = false) {
+        app = XCUIApplication()
+        app.launchArguments += [
+            "-ApplePersistenceIgnoreState", "YES",
+            "-autoRefreshInterval", "0",
+            "-brewfilePath", "",
+            "-showCasksByDefault", "NO",
+            "-showDockIcon", "YES",
+            "-showMenuBarIcon", "YES"
+        ]
+        app.launchEnvironment["BREWY_UI_TESTING"] = "1"
+        app.launchEnvironment["XDG_CONFIG_HOME"] = fixtureDirectory.path
+        if analyticsStateFailsOnce {
+            app.launchEnvironment["BREWY_UI_ANALYTICS_STATE_FAILS_ONCE"] = "1"
+        }
+        app.launch()
+        app.activate()
+    }
+
+    private func assertLabel(_ label: String, for element: XCUIElement) {
+        let expectation = XCTNSPredicateExpectation(
+            predicate: NSPredicate(format: "label == %@ OR value == %@", label, label),
+            object: element
+        )
+        let result = XCTWaiter.wait(for: [expectation], timeout: Self.transitionTimeout)
+        XCTAssertEqual(
+            result,
+            .completed,
+            "Expected accessibility label or value '\(label)'; got label '\(element.label)' "
+                + "and value '\(String(describing: element.value))'"
+        )
+    }
+
+    private func assertCheckedValue(_ expectedValue: Bool, for toggle: XCUIElement) {
+        let expectation = XCTNSPredicateExpectation(
+            predicate: NSPredicate { [self] object, _ in
+                guard let toggle = object as? XCUIElement else { return false }
+                return checkedValue(of: toggle) == expectedValue
+            },
+            object: toggle
+        )
+        XCTAssertEqual(
+            XCTWaiter.wait(for: [expectation], timeout: Self.transitionTimeout),
+            .completed,
+            "Expected toggle value '\(expectedValue)'"
+        )
+    }
+
+    private func checkedValue(of toggle: XCUIElement) -> Bool? {
+        if let number = toggle.value as? NSNumber {
+            return number.boolValue
+        }
+
+        guard let string = toggle.value as? String else { return nil }
+        switch string.lowercased() {
+        case "1", "true", "on": return true
+        case "0", "false", "off": return false
+        default: return nil
+        }
+    }
+}


### PR DESCRIPTION
Brewy gave no indication of whether Homebrew's anonymous analytics were on, and changing them meant dropping to a terminal. Settings now reads `brew analytics state` when the pane opens and exposes a switch that runs `brew analytics on` or `off`. Every mutation is followed by a fresh `state` query, so the reported value comes from Homebrew rather than from an assumption that the command did what it said.

That re-read matters because the two can genuinely disagree: `Utils::Analytics.disabled?` short-circuits on `HOMEBREW_NO_ANALYTICS`, while `brew analytics on` only clears the `analyticsdisabled` setting, so an enable can succeed and leave analytics off. Brewy detects the mismatch and points at the environment instead of showing a switch that lies. Parsing reads only Homebrew's `InfluxDB analytics are enabled.` and `disabled.` lines from standard output and ignores the legacy Google Analytics line. A state Brewy cannot determine is never drawn as an off switch: the control is withheld, the failure is explained, and a Retry action re-runs the query. Failed mutations and cancelled commands leave the last known state intact.

AI disclosure: Claude Opus 5 with manual testing and review.
