### PR TITLE
fix(security): decode Homebrew's vulnerability findings envelope

### DIFF
--- a/Brewy/Models/BrewService+Vulnerabilities.swift
+++ b/Brewy/Models/BrewService+Vulnerabilities.swift
@@ -23,14 +23,15 @@ extension BrewService {
         }
 
         do {
-            let findings = try JSONDecoder().decode(
-                [FormulaVulnerabilityFinding].self,
+            let report = try JSONDecoder().decode(
+                BrewVulnerabilityReport.self,
                 from: Data(result.standardOutput.utf8)
             )
             vulnerabilityScan = FormulaVulnerabilityScan(
-                findings: findings,
+                findings: report.findings,
                 scannedAt: Date(),
-                warning: Self.nonemptyVulnerabilityMessage(result.standardError)
+                warning: Self.nonemptyVulnerabilityMessage(result.standardError),
+                skippedFormulae: report.skippedFormulae
             )
         } catch {
             vulnerabilityScanError = .commandFailed(command: "vulns --json", output: result.output)

--- a/Brewy/Models/UITestFixtures.swift
+++ b/Brewy/Models/UITestFixtures.swift
@@ -179,7 +179,7 @@ final class UITestCommandRunner: CommandRunning, @unchecked Sendable {
     Core cask tap last commit: 4 days ago
     """
 
-    private static let vulnerabilitiesJSON = """
+    private static let vulnerabilityFindingsJSON = """
     [
       {
         "formula": "ripgrep",
@@ -206,6 +206,13 @@ final class UITestCommandRunner: CommandRunning, @unchecked Sendable {
         ]
       }
     ]
+    """
+
+    private static let vulnerabilitiesJSON = """
+    {
+      "findings": \(vulnerabilityFindingsJSON),
+      "skipped_formulae": ["fixture-only"]
+    }
     """
 
     private static let vulnerabilityNotice = "Results reflect Homebrew's reported scan target."

--- a/Brewy/Models/VulnerabilityModel.swift
+++ b/Brewy/Models/VulnerabilityModel.swift
@@ -74,6 +74,32 @@ struct FormulaVulnerabilityFinding: Identifiable, Hashable, Decodable, Sendable 
     }
 }
 
+struct BrewVulnerabilityReport: Decodable, Sendable {
+    let findings: [FormulaVulnerabilityFinding]
+    let skippedFormulae: [String]?
+
+    enum CodingKeys: String, CodingKey {
+        case findings
+        case skippedFormulae = "skipped_formulae"
+    }
+
+    init(from decoder: Decoder) throws {
+        if var container = try? decoder.unkeyedContainer() {
+            var findings: [FormulaVulnerabilityFinding] = []
+            while !container.isAtEnd {
+                findings.append(try container.decode(FormulaVulnerabilityFinding.self))
+            }
+            self.findings = findings
+            self.skippedFormulae = nil
+            return
+        }
+
+        let container = try decoder.container(keyedBy: CodingKeys.self)
+        self.findings = try container.decode([FormulaVulnerabilityFinding].self, forKey: .findings)
+        self.skippedFormulae = try container.decodeIfPresent([String].self, forKey: .skippedFormulae)
+    }
+}
+
 struct FormulaVulnerabilityGroup: Identifiable, Equatable, Sendable {
     let id: String
     let formula: String
@@ -90,8 +116,14 @@ struct FormulaVulnerabilityScan: Equatable, Sendable {
     let patchedCount: Int
     let scannedAt: Date
     let warning: String?
+    let skippedFormulae: [String]?
 
-    init(findings: [FormulaVulnerabilityFinding], scannedAt: Date, warning: String?) {
+    init(
+        findings: [FormulaVulnerabilityFinding],
+        scannedAt: Date,
+        warning: String?,
+        skippedFormulae: [String]? = nil
+    ) {
         let openGroups = findings
             .filter { !$0.vulnerabilities.isEmpty }
             .sorted(by: Self.openFindingOrder)
@@ -124,6 +156,9 @@ struct FormulaVulnerabilityScan: Equatable, Sendable {
         self.patchedCount = patchedGroups.reduce(0) { $0 + $1.vulnerabilities.count }
         self.scannedAt = scannedAt
         self.warning = warning
+        self.skippedFormulae = skippedFormulae.map {
+            Array(Set($0)).sorted { $0.localizedStandardCompare($1) == .orderedAscending }
+        }
     }
 
     private static func normalized(_ vulnerabilities: [BrewVulnerability]) -> [BrewVulnerability] {

--- a/Brewy/Views/SecurityView.swift
+++ b/Brewy/Views/SecurityView.swift
@@ -185,7 +185,7 @@ private struct SecurityScanContent: View {
             )
         }
 
-        SecurityCoverageSection()
+        SecurityCoverageSection(skippedFormulae: scan.skippedFormulae)
     }
 }
 
@@ -397,17 +397,51 @@ private struct SecurityVulnerabilityRow: View {
 }
 
 private struct SecurityCoverageSection: View {
+    let skippedFormulae: [String]?
+
     var body: some View {
         Section("Coverage") {
-            Label(
-                "The JSON report does not include checked or skipped formula counts.",
-                systemImage: "info.circle"
-            )
+            if let skippedFormulae {
+                Label(
+                    "The JSON report does not include the number of formulae checked.",
+                    systemImage: "info.circle"
+                )
+                if skippedFormulae.isEmpty {
+                    Label(
+                        "Homebrew reported no formulae skipped for a missing or unsupported source URL.",
+                        systemImage: "checkmark.circle"
+                    )
+                } else {
+                    DisclosureGroup {
+                        Text(skippedFormulae.joined(separator: ", "))
+                            .font(.callout)
+                            .foregroundStyle(.secondary)
+                            .textSelection(.enabled)
+                    } label: {
+                        Label(
+                            skippedDescription(count: skippedFormulae.count),
+                            systemImage: "exclamationmark.triangle"
+                        )
+                    }
+                }
+            } else {
+                Label(
+                    "The JSON report does not include checked or skipped formula counts.",
+                    systemImage: "info.circle"
+                )
+            }
             Label(
                 "An empty report means Homebrew returned no findings, not that every installed formula was assessed.",
                 systemImage: "eye.trianglebadge.exclamationmark"
             )
         }
+    }
+
+    private func skippedDescription(count: Int) -> String {
+        if count == 1 {
+            return "1 installed formula was skipped because it has no supported source URL."
+        }
+        return "\(count) installed formulae were skipped because they have no supported source URL."
     }
 }
 

--- a/BrewyTests/VulnerabilityTests.swift
+++ b/BrewyTests/VulnerabilityTests.swift
@@ -34,6 +34,13 @@ struct VulnerabilityTests {
     ]
     """
 
+    private static let findingsEnvelopeJSON = """
+    {
+      "findings": \(findingsJSON),
+      "skipped_formulae": ["automake", "libev"]
+    }
+    """
+
     @Test("Decodes Homebrew open and formula-patched findings")
     func decodesFindings() throws {
         let findings = try JSONDecoder().decode(
@@ -47,6 +54,28 @@ struct VulnerabilityTests {
         #expect(finding.vulnerabilities.first?.fixedVersions == ["openssl-3.5.3"])
         #expect(finding.patched.first?.id == "CVE-2025-4321")
         #expect(finding.patched.first?.summary == nil)
+    }
+
+    @Test("Accepts Homebrew's findings envelope")
+    func acceptsFindingsEnvelope() async {
+        let mock = MockCommandRunner()
+        let (service, _) = makeService(mock: mock)
+        mock.setResult(
+            for: ["vulns", "--json"],
+            result: CommandResult(
+                output: Self.findingsEnvelopeJSON,
+                success: false,
+                standardOutput: Self.findingsEnvelopeJSON,
+                exitCode: 1
+            )
+        )
+
+        await service.scanVulnerabilities()
+
+        #expect(service.vulnerabilityScan?.openCount == 1)
+        #expect(service.vulnerabilityScan?.patchedCount == 1)
+        #expect(service.vulnerabilityScan?.skippedFormulae == ["automake", "libev"])
+        #expect(service.vulnerabilityScanError == nil)
     }
 
     @Test("Accepts valid JSON when brew exits one for open findings")
@@ -73,6 +102,7 @@ struct VulnerabilityTests {
         #expect(service.vulnerabilityScan?.openGroups.first?.tag == "openssl-3.5.2")
         #expect(service.vulnerabilityScan?.patchedGroups.first?.version == "3.5.2")
         #expect(service.vulnerabilityScan?.patchedGroups.first?.tag == "openssl-3.5.2")
+        #expect(service.vulnerabilityScan?.skippedFormulae == nil)
         #expect(service.vulnerabilityScan?.openGroups.first?.vulnerabilities.first?.id == "CVE-2026-1234")
         #expect(service.vulnerabilityScan?.patchedGroups.first?.vulnerabilities.first?.id == "CVE-2025-4321")
         #expect(service.vulnerabilityScan?.openGroups.first?.id != service.vulnerabilityScan?.patchedGroups.first?.id)


### PR DESCRIPTION
Brewy's Security screen reported every vulnerability scan as a command failure. `brew vulns --json` wraps its results in an object keyed by `findings` and `skipped_formulae`, and Brewy decoded the output as a bare top-level array, so the decode threw and the error path fired no matter what the scan found. `BrewVulnerabilityReport` now accepts both shapes: an unkeyed container decodes as the older array, anything else as the current envelope.

The skipped list is worth surfacing rather than discarding, because a formula Homebrew could not check is not a formula it cleared. Coverage now distinguishes three states that the previous single notice collapsed into one: output that carries no skipped list at all, a scan that skipped nothing, and a scan that skipped formulae, which names them behind a disclosure. Skipped names are deduplicated and sorted so the list stays stable between scans.

AI disclosure: Claude Opus 5 with manual testing and review.
