### PR TITLE
feat(packages): show installed application icons

### DIFF
--- a/Brewy/Models/BrewError.swift
+++ b/Brewy/Models/BrewError.swift
@@ -1,0 +1,27 @@
+import Foundation
+
+enum BrewError: LocalizedError {
+    case commandFailed(command: String, output: String)
+
+    var errorDescription: String? {
+        switch self {
+        case .commandFailed(let command, let output):
+            return Self.summarize(command: command, output: output)
+        }
+    }
+
+    private static let maxOutputChars = 800
+
+    private static func summarize(command: String, output: String) -> String {
+        let trimmed = output.trimmingCharacters(in: .whitespacesAndNewlines)
+        guard !trimmed.isEmpty else { return "brew \(command) failed." }
+
+        let lines = trimmed.split(separator: "\n", omittingEmptySubsequences: false)
+        if let errorLine = lines.first(where: { $0.lowercased().hasPrefix("error:") }) {
+            return String(errorLine)
+        }
+        let tail = lines.suffix(6).joined(separator: "\n")
+        if tail.count <= maxOutputChars { return tail }
+        return "…" + String(tail.suffix(maxOutputChars))
+    }
+}

--- a/Brewy/Models/BrewJSONTypes.swift
+++ b/Brewy/Models/BrewJSONTypes.swift
@@ -59,9 +59,10 @@ struct CaskJSON: Decodable {
     let desc: String?
     let homepage: String?
     let dependencies: [String]
+    let artifacts: [CaskArtifactJSON]
 
     enum CodingKeys: String, CodingKey {
-        case token, version, installed, desc, homepage
+        case token, version, installed, desc, homepage, artifacts
         case dependsOn = "depends_on"
     }
 
@@ -77,10 +78,15 @@ struct CaskJSON: Decodable {
         installed = try container.decodeIfPresent(String.self, forKey: .installed)
         desc = try container.decodeIfPresent(String.self, forKey: .desc)
         homepage = try container.decodeIfPresent(String.self, forKey: .homepage)
+        artifacts = (try? container.decodeIfPresent([CaskArtifactJSON].self, forKey: .artifacts)) ?? []
         // `depends_on` is usually an object but brew sometimes emits an empty array; tolerate
         // either shape so a cask never fails to decode over its dependency field.
         let deps = try? container.decodeIfPresent(DependsOn.self, forKey: .dependsOn)
         dependencies = (deps?.formula ?? []) + (deps?.cask ?? [])
+    }
+
+    var applicationBundleURLs: [URL] {
+        artifacts.compactMap(\.applicationBundleURL)
     }
 
     func toPackage() -> BrewPackage {
@@ -101,6 +107,35 @@ struct CaskJSON: Decodable {
             installedOnRequest: true,
             dependencies: dependencies
         )
+    }
+}
+
+struct CaskArtifactJSON: Decodable {
+    let isApplication: Bool
+    let target: String?
+
+    private enum CodingKeys: String, CodingKey {
+        case app, target
+    }
+
+    init(from decoder: Decoder) throws {
+        guard let container = try? decoder.container(keyedBy: CodingKeys.self) else {
+            isApplication = false
+            target = nil
+            return
+        }
+        let containsApplication = container.contains(.app)
+        let applicationIsNil = containsApplication ? (try? container.decodeNil(forKey: .app)) ?? true : true
+        isApplication = containsApplication && !applicationIsNil
+        target = try? container.decodeIfPresent(String.self, forKey: .target)
+    }
+
+    var applicationBundleURL: URL? {
+        guard isApplication, let target else { return nil }
+        let path = (target as NSString).expandingTildeInPath
+        let url = URL(fileURLWithPath: path)
+        guard url.pathExtension.caseInsensitiveCompare("app") == .orderedSame else { return nil }
+        return url
     }
 }
 

--- a/Brewy/Models/BrewService+ApplicationIcons.swift
+++ b/Brewy/Models/BrewService+ApplicationIcons.swift
@@ -1,0 +1,30 @@
+import Foundation
+
+extension BrewService {
+
+    func installedApplicationURL(for package: BrewPackage) -> URL? {
+        if let url = installedApplicationURLs[package.id] {
+            return url
+        }
+        guard package.isInstalled, package.isCask else { return nil }
+        return installedApplicationURLs["cask-\(package.name)"]
+    }
+
+    nonisolated static func refreshedApplicationURLs(
+        existingURLs: [String: URL],
+        brewURLs: [String: URL]?,
+        masURLs: [String: URL]?,
+        installedIDs: Set<String>
+    ) -> [String: URL] {
+        var urls = existingURLs
+        if let brewURLs {
+            urls = urls.filter { !$0.key.hasPrefix("cask-") }
+            urls.merge(brewURLs, uniquingKeysWith: { _, latest in latest })
+        }
+        if let masURLs {
+            urls = urls.filter { !$0.key.hasPrefix("mas-") }
+            urls.merge(masURLs, uniquingKeysWith: { _, latest in latest })
+        }
+        return urls.filter { installedIDs.contains($0.key) }
+    }
+}

--- a/Brewy/Models/BrewService+Fetching.swift
+++ b/Brewy/Models/BrewService+Fetching.swift
@@ -3,7 +3,46 @@ import OSLog
 
 private let logger = Logger(subsystem: "io.linnane.brewy", category: "BrewService+Fetching")
 
+struct InstalledBrewPackages {
+    let formulae: [BrewPackage]
+    let casks: [BrewPackage]
+    let applicationURLs: [String: URL]
+}
+
+struct MergedRefreshPackages {
+    let formulae: [BrewPackage]
+    let casks: [BrewPackage]
+    let masApps: [BrewPackage]
+    let outdated: [BrewPackage]
+
+    var installedIDs: Set<String> {
+        Set((formulae + casks + masApps).map(\.id))
+    }
+}
+
 extension BrewService {
+
+    nonisolated static func mergeRefreshPackages(
+        formulae: [BrewPackage],
+        casks: [BrewPackage],
+        masApps: [BrewPackage],
+        outdated: [BrewPackage]
+    ) -> MergedRefreshPackages {
+        let outdatedByID = Dictionary(outdated.map { ($0.id, $0) }, uniquingKeysWith: { _, last in last })
+        let formulae = formulae.map { mergeOutdatedStatus($0, outdatedByID: outdatedByID) }
+        let casks = casks.map { mergeOutdatedStatus($0, outdatedByID: outdatedByID) }
+        let masApps = masApps.map { mergeOutdatedStatus($0, outdatedByID: outdatedByID) }
+        let mergedByID = Dictionary(
+            (formulae + casks + masApps).filter(\.isOutdated).map { ($0.id, $0) },
+            uniquingKeysWith: { _, last in last }
+        )
+        return MergedRefreshPackages(
+            formulae: formulae,
+            casks: casks,
+            masApps: masApps,
+            outdated: outdated.map { mergedByID[$0.id] ?? $0 }
+        )
+    }
 
     // MARK: - Fetch Installed Packages
 
@@ -11,21 +50,29 @@ extension BrewService {
     /// instead of clobbering them to empty; a successful-but-empty response still returns `[]`s.
     /// One `brew info --installed --json=v2` invocation carries both formulae and casks in the
     /// JSON v2 envelope, so a refresh needs a single pass over the installed set, not two.
-    func fetchInstalledPackages() async -> (formulae: [BrewPackage], casks: [BrewPackage])? {
+    func fetchInstalledPackages() async -> InstalledBrewPackages? {
         let result = await runBrewCommand(["info", "--installed", "--json=v2"])
         guard result.success, let data = result.output.data(using: .utf8) else {
             if !result.success {
                 reportFetchError(command: "info --installed", output: result.output)
             }
-            return result.success ? ([], []) : nil
+            return result.success ? InstalledBrewPackages(formulae: [], casks: [], applicationURLs: [:]) : nil
         }
 
-        let packages: (formulae: [BrewPackage], casks: [BrewPackage])? = await Task.detached(priority: .userInitiated) {
+        let packages: InstalledBrewPackages? = await Task.detached(priority: .userInitiated) {
             do {
                 let response = try JSONDecoder().decode(BrewInfoResponse.self, from: data)
-                return (
-                    (response.formulae ?? []).map { $0.toPackage() },
-                    (response.casks ?? []).map { $0.toPackage() }
+                let casks = response.casks ?? []
+                let applicationURLs = Dictionary(
+                    casks.compactMap { cask in
+                        cask.applicationBundleURLs.first.map { ("cask-\(cask.token)", $0) }
+                    },
+                    uniquingKeysWith: { _, latest in latest }
+                )
+                return InstalledBrewPackages(
+                    formulae: (response.formulae ?? []).map { $0.toPackage() },
+                    casks: casks.map { $0.toPackage() },
+                    applicationURLs: applicationURLs
                 )
             } catch {
                 logger.error("Failed to parse installed packages JSON: \(error.localizedDescription)")

--- a/Brewy/Models/BrewService.swift
+++ b/Brewy/Models/BrewService.swift
@@ -6,38 +6,12 @@ import SwiftUI
 
 private let logger = Logger(subsystem: "io.linnane.brewy", category: "BrewService")
 
-// MARK: - Error Types
-
-enum BrewError: LocalizedError {
-    case commandFailed(command: String, output: String)
-
-    var errorDescription: String? {
-        switch self {
-        case .commandFailed(let command, let output):
-            return Self.summarize(command: command, output: output)
-        }
-    }
-
-    private static let maxOutputChars = 800
-
-    private static func summarize(command: String, output: String) -> String {
-        let trimmed = output.trimmingCharacters(in: .whitespacesAndNewlines)
-        guard !trimmed.isEmpty else { return "brew \(command) failed." }
-
-        let lines = trimmed.split(separator: "\n", omittingEmptySubsequences: false)
-        if let errorLine = lines.first(where: { $0.lowercased().hasPrefix("error:") }) {
-            return String(errorLine)
-        }
-        let tail = lines.suffix(6).joined(separator: "\n")
-        if tail.count <= maxOutputChars { return tail }
-        return "…" + String(tail.suffix(maxOutputChars))
-    }
-}
-
 @Observable
 @MainActor
 final class BrewService {
     @ObservationIgnored let commandRunner: CommandRunning
+    @ObservationIgnored private let masExecutablePathOverride: String?
+    @ObservationIgnored private let masExecutablePathResolver: @Sendable () -> String
     @ObservationIgnored private let packageCacheURL: URL?
     @ObservationIgnored private let packageCacheWritesEnabled: Bool
 
@@ -55,10 +29,14 @@ final class BrewService {
 
     init(
         commandRunner: CommandRunning = DefaultCommandRunner(),
+        masExecutablePath: String? = nil,
+        masExecutablePathResolver: @escaping @Sendable () -> String = CommandRunner.resolvedMasPath,
         packageCacheURL: URL? = BrewService.runtimeDefaultPackageCacheURL,
         packageCacheWritesEnabled: Bool = !BrewyRuntime.isRunningTests
     ) {
         self.commandRunner = commandRunner
+        masExecutablePathOverride = masExecutablePath
+        self.masExecutablePathResolver = masExecutablePathResolver
         self.packageCacheURL = packageCacheURL
         self.packageCacheWritesEnabled = packageCacheWritesEnabled
     }
@@ -66,6 +44,10 @@ final class BrewService {
     deinit {
         initialRefreshTask?.cancel()
         autoRefreshTask?.cancel()
+    }
+
+    var masExecutablePath: String {
+        masExecutablePathOverride ?? masExecutablePathResolver()
     }
 
     var installedFormulae: [BrewPackage] = [] {
@@ -86,6 +68,7 @@ final class BrewService {
             invalidateDerivedState()
         }
     }
+    private(set) var installedApplicationURLs: [String: URL] = [:]
     var isMasAvailable = false
     var outdatedPackages: [BrewPackage] = []
     var installedTaps: [BrewTap] = []
@@ -152,13 +135,15 @@ final class BrewService {
         formulae: [BrewPackage],
         casks: [BrewPackage],
         masApps: [BrewPackage],
-        outdated: [BrewPackage]
+        outdated: [BrewPackage],
+        applicationURLs: [String: URL]
     ) {
         isBatchingUpdates = true
         installedFormulae = formulae
         installedCasks = casks
         installedMasApps = masApps
         outdatedPackages = outdated
+        installedApplicationURLs = applicationURLs
         isBatchingUpdates = false
         invalidateDerivedState()
     }
@@ -194,6 +179,7 @@ final class BrewService {
     func dependents(of name: String) -> [BrewPackage] {
         reverseDependencies[name] ?? []
     }
+
 }
 
 // MARK: - Cache
@@ -248,7 +234,7 @@ extension BrewService {
             outdatedPackages = cached.outdated
             installedTaps = cached.taps
             tapsLoaded = !cached.taps.isEmpty
-            isMasAvailable = !masApps.isEmpty || FileManager.default.isExecutableFile(atPath: CommandRunner.resolvedMasPath())
+            isMasAvailable = !masApps.isEmpty || FileManager.default.isExecutableFile(atPath: masExecutablePath)
             lastUpdated = cached.lastUpdated
             logger.info("Loaded \(cached.formulae.count) formulae and \(cached.casks.count) casks from cache")
         } catch {
@@ -357,34 +343,45 @@ extension BrewService {
         let fetchedFormulae = fetchedInstalled?.formulae ?? installedFormulae
         let fetchedCasks = fetchedInstalled?.casks ?? installedCasks
         let fetchedOutdated = await outdated ?? outdatedPackages.filter { $0.source != .mas }
-        let fetchedMasApps = await masApps ?? installedMasApps
+        let fetchedMas = await masApps
+        let fetchedMasApps = fetchedMas?.packages ?? installedMasApps
         let fetchedMasOutdated = await masOutdated ?? outdatedPackages.filter(\.isMas)
         let fetchedTaps = await taps ?? installedTaps
-        let allOutdated = fetchedOutdated + fetchedMasOutdated
-        let outdatedByID = Dictionary(allOutdated.map { ($0.id, $0) }, uniquingKeysWith: { _, last in last })
-        let mergedFormulae = fetchedFormulae.map { Self.mergeOutdatedStatus($0, outdatedByID: outdatedByID) }
-        let mergedCasks = fetchedCasks.map { Self.mergeOutdatedStatus($0, outdatedByID: outdatedByID) }
-        let mergedMasApps = fetchedMasApps.map { Self.mergeOutdatedStatus($0, outdatedByID: outdatedByID) }
-        let mergedByID = Dictionary(
-            (mergedFormulae + mergedCasks + mergedMasApps).filter(\.isOutdated).map { ($0.id, $0) },
-            uniquingKeysWith: { _, last in last }
+        let merged = Self.mergeRefreshPackages(
+            formulae: fetchedFormulae,
+            casks: fetchedCasks,
+            masApps: fetchedMasApps,
+            outdated: fetchedOutdated + fetchedMasOutdated
         )
-        let displayedOutdated = allOutdated.map { mergedByID[$0.id] ?? $0 }
+        let applicationURLs = Self.refreshedApplicationURLs(
+            existingURLs: installedApplicationURLs,
+            brewURLs: fetchedInstalled?.applicationURLs,
+            masURLs: fetchedMas?.applicationURLs,
+            installedIDs: merged.installedIDs
+        )
 
         applyRefreshResults(
-            formulae: mergedFormulae,
-            casks: mergedCasks,
-            masApps: mergedMasApps,
-            outdated: displayedOutdated
+            formulae: merged.formulae,
+            casks: merged.casks,
+            masApps: merged.masApps,
+            outdated: merged.outdated,
+            applicationURLs: applicationURLs
         )
         lastUpdated = Date()
 
+        let masCount = fetchedMasApps.count
+        let outdatedCount = merged.outdated.count
+        logger.info("Refresh complete: \(fetchedFormulae.count) formulae, \(fetchedCasks.count) casks, \(masCount) mas, \(outdatedCount) outdated")
+        await finishRefresh(previousVersions: previousVersions, taps: fetchedTaps)
+    }
+
+    private func finishRefresh(previousVersions: [String: String], taps: [BrewTap]) async {
         let currentVersions = Dictionary(allInstalled.map { ($0.id, $0.version) }, uniquingKeysWith: { _, last in last })
         for id in infoCache.keys where currentVersions[id] != previousVersions[id] {
             infoCache.removeValue(forKey: id)
         }
 
-        installedTaps = fetchedTaps
+        installedTaps = taps
         tapsLoaded = true
         updateBundleEntryStatuses()
 
@@ -392,9 +389,6 @@ extension BrewService {
             backgroundRefreshError = nil
         }
 
-        let masCount = fetchedMasApps.count
-        let outdatedCount = allOutdated.count
-        logger.info("Refresh complete: \(fetchedFormulae.count) formulae, \(fetchedCasks.count) casks, \(masCount) mas, \(outdatedCount) outdated")
         await saveToCache()
         // Cancel any in-flight check unconditionally so a prior refresh's task can't overwrite
         // tapHealthStatuses after the tap list has changed.

--- a/Brewy/Models/MasService.swift
+++ b/Brewy/Models/MasService.swift
@@ -3,9 +3,60 @@ import OSLog
 
 private let logger = Logger(subsystem: "io.linnane.brewy", category: "MasService")
 
+struct MasInstalledAppsResult {
+    let packages: [BrewPackage]
+    let applicationURLs: [String: URL]
+}
+
 // MARK: - Mas Output Parser
 
 enum MasParser {
+
+    private struct InstalledAppJSON: Decodable {
+        let adamID: Int
+        let name: String
+        let path: String
+        let version: String
+
+        private enum CodingKeys: String, CodingKey {
+            case adamID, name, path, version
+        }
+
+        init(from decoder: Decoder) throws {
+            let container = try decoder.container(keyedBy: CodingKeys.self)
+            adamID = try container.decode(Int.self, forKey: .adamID)
+            name = try container.decode(String.self, forKey: .name)
+            path = try container.decodeIfPresent(String.self, forKey: .path) ?? ""
+            version = try container.decodeIfPresent(String.self, forKey: .version) ?? ""
+        }
+    }
+
+    static func parseJSONList(_ output: String) -> MasInstalledAppsResult? {
+        let lines = output.split(whereSeparator: \.isNewline)
+        guard !lines.isEmpty else {
+            return MasInstalledAppsResult(packages: [], applicationURLs: [:])
+        }
+
+        let records = lines.compactMap { line in
+            try? JSONDecoder().decode(InstalledAppJSON.self, from: Data(line.utf8))
+        }
+        guard !records.isEmpty else { return nil }
+
+        let packages = records.map { record in
+            makePackage(appID: String(record.adamID), name: record.name, version: record.version)
+        }
+        let applicationURLPairs: [(String, URL)] = zip(packages, records).compactMap { pair in
+            let (package, record) = pair
+            let url = URL(fileURLWithPath: record.path)
+            guard url.pathExtension.caseInsensitiveCompare("app") == .orderedSame else { return nil }
+            return (package.id, url)
+        }
+        let applicationURLs = Dictionary(
+            applicationURLPairs,
+            uniquingKeysWith: { _, latest in latest }
+        )
+        return MasInstalledAppsResult(packages: packages, applicationURLs: applicationURLs)
+    }
 
     static func parseList(_ output: String) -> [BrewPackage] {
         var packages: [BrewPackage] = []
@@ -28,24 +79,28 @@ enum MasParser {
                 version = String(rest[rest.index(after: parenOpen)..<parenClose])
             }
 
-            let uniqueId = appId == "0" ? "mas-0-\(name)" : "mas-\(appId)"
-            packages.append(BrewPackage(
-                id: uniqueId,
-                name: name,
-                version: version,
-                description: "",
-                homepage: appId == "0" ? "" : "https://apps.apple.com/app/id\(appId)",
-                isInstalled: true,
-                isOutdated: false,
-                installedVersion: version,
-                latestVersion: nil,
-                source: .mas,
-                pinned: false,
-                installedOnRequest: true,
-                dependencies: []
-            ))
+            packages.append(makePackage(appID: appId, name: name, version: version))
         }
         return packages
+    }
+
+    private static func makePackage(appID: String, name: String, version: String) -> BrewPackage {
+        let uniqueId = appID == "0" ? "mas-0-\(name)" : "mas-\(appID)"
+        return BrewPackage(
+            id: uniqueId,
+            name: name,
+            version: version,
+            description: "",
+            homepage: appID == "0" ? "" : "https://apps.apple.com/app/id\(appID)",
+            isInstalled: true,
+            isOutdated: false,
+            installedVersion: version,
+            latestVersion: nil,
+            source: .mas,
+            pinned: false,
+            installedOnRequest: true,
+            dependencies: []
+        )
     }
 
     static func parseOutdated(_ output: String) -> [BrewPackage] {
@@ -105,27 +160,40 @@ enum MasParser {
 
 extension BrewService {
 
-    func fetchInstalledMasApps() async -> [BrewPackage]? {
-        let masPath = CommandRunner.resolvedMasPath()
-        guard FileManager.default.isExecutableFile(atPath: masPath) else {
+    func fetchInstalledMasApps() async -> MasInstalledAppsResult? {
+        let executablePath = masExecutablePath
+        guard FileManager.default.isExecutableFile(atPath: executablePath) else {
             isMasAvailable = false
-            return []
+            return MasInstalledAppsResult(packages: [], applicationURLs: [:])
         }
         isMasAvailable = true
 
-        let result = await commandRunner.runExecutable(masPath, arguments: ["list"])
+        let jsonResult = await commandRunner.runExecutable(executablePath, arguments: ["list", "--json"])
+        if jsonResult.success, let parsed = MasParser.parseJSONList(jsonResult.standardOutput) {
+            return parsed
+        }
+
+        let result = await commandRunner.runExecutable(executablePath, arguments: ["list"])
         guard result.success else {
             logger.warning("Failed to fetch installed mas apps")
             return nil
         }
-        return MasParser.parseList(result.output)
+        if let parsed = MasParser.parseJSONList(result.standardOutput) {
+            return parsed
+        }
+        let packages = MasParser.parseList(result.standardOutput)
+        guard !packages.isEmpty || result.standardOutput.trimmingCharacters(in: .whitespacesAndNewlines).isEmpty else {
+            logger.warning("Failed to parse installed mas apps")
+            return nil
+        }
+        return MasInstalledAppsResult(packages: packages, applicationURLs: [:])
     }
 
     func fetchOutdatedMasApps() async -> [BrewPackage]? {
-        let masPath = CommandRunner.resolvedMasPath()
-        guard FileManager.default.isExecutableFile(atPath: masPath) else { return [] }
+        let executablePath = masExecutablePath
+        guard FileManager.default.isExecutableFile(atPath: executablePath) else { return [] }
 
-        let result = await commandRunner.runExecutable(masPath, arguments: ["outdated"])
+        let result = await commandRunner.runExecutable(executablePath, arguments: ["outdated"])
         guard result.success else {
             logger.warning("Failed to fetch outdated mas apps")
             return nil

--- a/Brewy/Views/InstalledPackageIcon.swift
+++ b/Brewy/Views/InstalledPackageIcon.swift
@@ -1,0 +1,89 @@
+import AppKit
+import SwiftUI
+
+final class InstalledApplicationIconCache: @unchecked Sendable {
+    static let shared = InstalledApplicationIconCache()
+
+    private let cache = NSCache<NSString, NSImage>()
+    private let fileExists: @Sendable (String) -> Bool
+    private let iconProvider: @Sendable (String) -> NSImage
+
+    init(
+        countLimit: Int = 128,
+        fileExists: @escaping @Sendable (String) -> Bool = { FileManager.default.fileExists(atPath: $0) },
+        iconProvider: @escaping @Sendable (String) -> NSImage = { NSWorkspace.shared.icon(forFile: $0) }
+    ) {
+        cache.countLimit = countLimit
+        self.fileExists = fileExists
+        self.iconProvider = iconProvider
+    }
+
+    func image(for applicationURL: URL, version: String) async -> NSImage? {
+        guard applicationURL.pathExtension.caseInsensitiveCompare("app") == .orderedSame else { return nil }
+
+        let path = applicationURL.standardizedFileURL.path
+        let key = "\(path)\u{0}\(version)" as NSString
+        if let cached = cache.object(forKey: key) {
+            return cached
+        }
+
+        let fileExists = fileExists
+        let iconProvider = iconProvider
+        let loadTask = Task.detached(priority: .userInitiated) { () -> NSImage? in
+            guard fileExists(path) else { return nil }
+            return iconProvider(path)
+        }
+        let image = await loadTask.value
+        guard let image else { return nil }
+        cache.setObject(image, forKey: key)
+        return image
+    }
+}
+
+struct InstalledPackageIcon: View {
+    @Environment(BrewService.self)
+    private var brewService
+    let package: BrewPackage
+    var size: CGFloat = 28
+    @State private var applicationIcon: NSImage?
+
+    private var applicationURL: URL? {
+        brewService.installedApplicationURL(for: package)
+    }
+
+    private var request: InstalledApplicationIconRequest? {
+        applicationURL.map { InstalledApplicationIconRequest(url: $0, version: package.version) }
+    }
+
+    var body: some View {
+        ZStack {
+            if let applicationIcon {
+                Image(nsImage: applicationIcon)
+                    .resizable()
+                    .aspectRatio(contentMode: .fit)
+            } else {
+                PackageSourceIcon(source: package.source, size: size)
+            }
+        }
+        .frame(width: size, height: size)
+        .task(id: request) { @MainActor in
+            guard let request else {
+                applicationIcon = nil
+                return
+            }
+            applicationIcon = nil
+            let image = await InstalledApplicationIconCache.shared.image(
+                for: request.url,
+                version: request.version
+            )
+            guard !Task.isCancelled else { return }
+            applicationIcon = image
+        }
+        .accessibilityHidden(true)
+    }
+}
+
+private struct InstalledApplicationIconRequest: Hashable {
+    let url: URL
+    let version: String
+}

--- a/Brewy/Views/PackageDetailView.swift
+++ b/Brewy/Views/PackageDetailView.swift
@@ -83,7 +83,7 @@ private struct PackageHeader: View {
 
     var body: some View {
         HStack(alignment: .top, spacing: 12) {
-            PackageSourceIcon(source: package.source, size: 44)
+            InstalledPackageIcon(package: package, size: 44)
 
             VStack(alignment: .leading, spacing: 4) {
                 Text(package.name)

--- a/Brewy/Views/PackageListView.swift
+++ b/Brewy/Views/PackageListView.swift
@@ -267,7 +267,7 @@ private struct PackageRow: View {
 
     var body: some View {
         HStack(alignment: .top, spacing: 10) {
-            PackageSourceIcon(source: package.source, size: 28)
+            InstalledPackageIcon(package: package, size: 28)
 
             VStack(alignment: .leading, spacing: 4) {
                 HStack(alignment: .firstTextBaseline, spacing: 8) {

--- a/BrewyTests/ApplicationIconTests.swift
+++ b/BrewyTests/ApplicationIconTests.swift
@@ -1,0 +1,223 @@
+import AppKit
+@testable import Brewy
+import Foundation
+import Testing
+
+@Suite("Cask Application Artifacts")
+struct CaskApplicationArtifactTests {
+
+    @Test("CaskJSON exposes application artifact targets")
+    func applicationArtifactTargets() throws {
+        let json = """
+        {
+            "formulae": [],
+            "casks": [
+                {
+                    "token": "firefox",
+                    "version": "122.0",
+                    "artifacts": [
+                        { "uninstall": [{ "quit": "org.mozilla.firefox" }] },
+                        {
+                            "app": ["Firefox Source.app", { "target": "Firefox.app" }],
+                            "target": "/Applications/Firefox.app"
+                        },
+                        { "binary": ["firefox"], "target": "/opt/homebrew/bin/firefox" }
+                    ]
+                }
+            ]
+        }
+        """
+        let data = try #require(json.data(using: .utf8))
+        let response = try JSONDecoder().decode(BrewInfoResponse.self, from: data)
+        let cask = try #require(response.casks?.first)
+
+        #expect(cask.applicationBundleURLs.map(\.path) == ["/Applications/Firefox.app"])
+    }
+
+    @Test("Unexpected artifact shapes do not discard installed packages")
+    func unexpectedArtifactShapesAreIgnored() throws {
+        let json = """
+        {
+            "formulae": [{ "name": "wget", "installed": [{ "version": "1.0" }] }],
+            "casks": [
+                {
+                    "token": "firefox",
+                    "version": "122.0",
+                    "artifacts": [["Firefox.app"]]
+                },
+                {
+                    "token": "broken-artifacts",
+                    "version": "1.0",
+                    "artifacts": { "app": ["Broken.app"] }
+                },
+                {
+                    "token": "mixed-targets",
+                    "version": "1.0",
+                    "artifacts": [
+                        { "app": ["Broken.app"], "target": { "path": "/Applications/Broken.app" } },
+                        { "app": ["Working.app"], "target": "/Applications/Working.app" }
+                    ]
+                }
+            ]
+        }
+        """
+        let data = try #require(json.data(using: .utf8))
+        let response = try JSONDecoder().decode(BrewInfoResponse.self, from: data)
+
+        #expect(response.formulae?.count == 1)
+        #expect(response.casks?.count == 3)
+        #expect(response.casks?.first?.applicationBundleURLs.isEmpty == true)
+        #expect(response.casks?[1].applicationBundleURLs.isEmpty == true)
+        #expect(response.casks?[2].applicationBundleURLs.map(\.path) == ["/Applications/Working.app"])
+    }
+}
+
+@Suite("Installed Application URL Refreshing")
+struct InstalledApplicationURLRefreshTests {
+
+    @Test("A successful brew refresh preserves MAS URLs when MAS fails")
+    func brewSuccessPreservesMasFailure() {
+        let urls = BrewService.refreshedApplicationURLs(
+            existingURLs: [
+                "cask-firefox": URL(fileURLWithPath: "/Applications/Old Firefox.app"),
+                "mas-497799835": URL(fileURLWithPath: "/Applications/Xcode.app"),
+                "cask-removed": URL(fileURLWithPath: "/Applications/Removed.app")
+            ],
+            brewURLs: ["cask-firefox": URL(fileURLWithPath: "/Applications/Firefox.app")],
+            masURLs: nil,
+            installedIDs: ["cask-firefox", "mas-497799835"]
+        )
+
+        #expect(urls["cask-firefox"]?.path == "/Applications/Firefox.app")
+        #expect(urls["mas-497799835"]?.path == "/Applications/Xcode.app")
+        #expect(urls["cask-removed"] == nil)
+    }
+
+    @Test("A successful MAS refresh preserves cask URLs when brew fails")
+    func masSuccessPreservesBrewFailure() {
+        let urls = BrewService.refreshedApplicationURLs(
+            existingURLs: [
+                "cask-firefox": URL(fileURLWithPath: "/Applications/Firefox.app"),
+                "mas-497799835": URL(fileURLWithPath: "/Applications/Old Xcode.app")
+            ],
+            brewURLs: nil,
+            masURLs: ["mas-497799835": URL(fileURLWithPath: "/Applications/Xcode.app")],
+            installedIDs: ["cask-firefox", "mas-497799835"]
+        )
+
+        #expect(urls["cask-firefox"]?.path == "/Applications/Firefox.app")
+        #expect(urls["mas-497799835"]?.path == "/Applications/Xcode.app")
+    }
+}
+
+@Suite("Installed Application Icons")
+@MainActor
+struct InstalledApplicationIconTests {
+
+    @Test("Icon cache reuses a loaded application icon")
+    func cacheReusesLoadedIcon() async throws {
+        let url = URL(fileURLWithPath: "/Applications/Test.app")
+        let probe = IconLoadProbe(fileExists: true)
+        let cache = InstalledApplicationIconCache(
+            fileExists: probe.checkFileExists,
+            iconProvider: probe.loadIcon
+        )
+
+        let first = try #require(await cache.image(for: url, version: "1.0"))
+        let second = try #require(await cache.image(for: url, version: "1.0"))
+
+        #expect(first === probe.image)
+        #expect(second === probe.image)
+        #expect(probe.existenceCheckCount == 1)
+        #expect(probe.loadCount == 1)
+    }
+
+    @Test("Icon cache rejects missing and non-application paths")
+    func cacheRejectsInvalidPaths() async {
+        let probe = IconLoadProbe(fileExists: false)
+        let cache = InstalledApplicationIconCache(
+            fileExists: probe.checkFileExists,
+            iconProvider: probe.loadIcon
+        )
+
+        let missing = await cache.image(for: URL(fileURLWithPath: "/Applications/Missing.app"), version: "1.0")
+        let nonApplication = await cache.image(for: URL(fileURLWithPath: "/tmp/not-an-app"), version: "1.0")
+
+        #expect(missing == nil)
+        #expect(nonApplication == nil)
+        #expect(probe.loadCount == 0)
+    }
+
+    @Test("Cold icon loading does not run on the main thread")
+    func coldLoadRunsOffMainThread() async throws {
+        let probe = IconLoadProbe(fileExists: true)
+        let cache = InstalledApplicationIconCache(
+            fileExists: probe.checkFileExists,
+            iconProvider: probe.loadIcon
+        )
+
+        _ = try #require(await cache.image(
+            for: URL(fileURLWithPath: "/Applications/Test.app"),
+            version: "1.0"
+        ))
+
+        #expect(probe.loadedOnMainThread == false)
+    }
+
+    @Test("A new package version reloads an icon at the same path")
+    func versionChangeReloadsIcon() async throws {
+        let url = URL(fileURLWithPath: "/Applications/Test.app")
+        let probe = IconLoadProbe(fileExists: true)
+        let cache = InstalledApplicationIconCache(
+            fileExists: probe.checkFileExists,
+            iconProvider: probe.loadIcon
+        )
+
+        _ = try #require(await cache.image(for: url, version: "1.0"))
+        _ = try #require(await cache.image(for: url, version: "1.0"))
+        #expect(probe.loadCount == 1)
+
+        _ = try #require(await cache.image(for: url, version: "2.0"))
+        #expect(probe.loadCount == 2)
+    }
+}
+
+private final class IconLoadProbe: @unchecked Sendable {
+    private let lock = NSLock()
+    private let fileExists: Bool
+    let image = NSImage(size: NSSize(width: 16, height: 16))
+    private var _existenceCheckCount = 0
+    private var _loadCount = 0
+    private var _loadedOnMainThread: Bool?
+
+    init(fileExists: Bool) {
+        self.fileExists = fileExists
+    }
+
+    var existenceCheckCount: Int {
+        lock.withLock { _existenceCheckCount }
+    }
+
+    var loadCount: Int {
+        lock.withLock { _loadCount }
+    }
+
+    var loadedOnMainThread: Bool? {
+        lock.withLock { _loadedOnMainThread }
+    }
+
+    func checkFileExists(_: String) -> Bool {
+        lock.withLock {
+            _existenceCheckCount += 1
+            return fileExists
+        }
+    }
+
+    func loadIcon(_: String) -> NSImage {
+        lock.withLock {
+            _loadCount += 1
+            _loadedOnMainThread = Thread.isMainThread
+            return image
+        }
+    }
+}

--- a/BrewyTests/BrewServiceAsyncTests.swift
+++ b/BrewyTests/BrewServiceAsyncTests.swift
@@ -20,6 +20,23 @@ struct RefreshTests {
         #expect(service.installedFormulae[0].name == "wget")
         #expect(service.installedCasks.count == 1)
         #expect(service.installedCasks[0].name == "firefox")
+        #expect(service.installedApplicationURLs["cask-firefox"]?.path == "/Applications/Firefox.app")
+        let searchResult = BrewPackage(
+            id: "cask-search-firefox",
+            name: "firefox",
+            version: "",
+            description: "",
+            homepage: "",
+            isInstalled: true,
+            isOutdated: false,
+            installedVersion: nil,
+            latestVersion: nil,
+            source: .cask,
+            pinned: false,
+            installedOnRequest: false,
+            dependencies: []
+        )
+        #expect(service.installedApplicationURL(for: searchResult)?.path == "/Applications/Firefox.app")
         #expect(service.outdatedPackages.count == 1)
         #expect(service.installedTaps.count == 1)
         #expect(service.installedTaps[0].name == "homebrew/core")
@@ -111,9 +128,25 @@ struct RefreshTests {
 
         #expect(service.installedFormulae.count == 1)
         #expect(service.installedCasks.count == 1)
+        #expect(service.installedApplicationURLs["cask-firefox"]?.path == "/Applications/Firefox.app")
         #expect(service.outdatedPackages.count == 1)
         #expect(service.installedTaps.count == 1)
         #expect(service.lastError != nil)
+    }
+
+    @Test("refresh removes application URLs for uninstalled casks")
+    func refreshRemovesUninstalledApplicationURLs() async {
+        let mock = MockCommandRunner()
+        let (service, _) = makeService(mock: mock)
+        setupRefreshMock(mock)
+        await service.refresh()
+        #expect(service.installedApplicationURLs["cask-firefox"] != nil)
+
+        mock.setResult(for: ["info", "--installed", "--json=v2"], output: TestJSON.emptyFormulae)
+        mock.setResult(for: ["outdated", "--json=v2"], output: TestJSON.emptyOutdated)
+        await service.refresh()
+
+        #expect(service.installedApplicationURLs.isEmpty)
     }
 
     @Test("refresh invalidates info cache when versions change")

--- a/BrewyTests/GroupsAndMasTests.swift
+++ b/BrewyTests/GroupsAndMasTests.swift
@@ -181,6 +181,52 @@ struct BrewServicePackageGroupTests {
 @Suite("Mas Output Parsing")
 struct MasOutputParsingTests {
 
+    @Test("parseMasJSONList preserves application paths")
+    func parseMasJSONList() throws {
+        let output = """
+        {"adamID":497799835,"bundleID":"com.apple.dt.Xcode","name":"Xcode","path":"/Applications/Xcode.app","version":"16.4"}
+        {"adamID":0,"bundleID":"com.example.beta","name":"Beta App","path":"/Applications/Beta App.app","version":"2.0"}
+        """
+
+        let result = try #require(MasParser.parseJSONList(output))
+
+        #expect(result.packages.map(\.id) == ["mas-497799835", "mas-0-Beta App"])
+        #expect(result.applicationURLs["mas-497799835"]?.path == "/Applications/Xcode.app")
+        #expect(result.applicationURLs["mas-0-Beta App"]?.path == "/Applications/Beta App.app")
+    }
+
+    @Test("parseMasJSONList tolerates missing Spotlight fields")
+    func parseMasJSONListMissingFields() throws {
+        let output = """
+        {"adamID":497799835,"name":"Xcode","path":"/Applications/Xcode.app"}
+        {"adamID":640199958,"name":"Developer","version":"10.6.5"}
+        """
+
+        let result = try #require(MasParser.parseJSONList(output))
+
+        #expect(result.packages.map(\.id) == ["mas-497799835", "mas-640199958"])
+        #expect(result.packages.map(\.version) == ["", "10.6.5"])
+        #expect(result.applicationURLs["mas-497799835"]?.path == "/Applications/Xcode.app")
+        #expect(result.applicationURLs["mas-640199958"] == nil)
+    }
+
+    @Test("parseMasJSONList preserves valid records beside malformed records")
+    func parseMasJSONListPartialOutput() throws {
+        let output = """
+        {"adamID":497799835,"name":"Xcode","path":"/Applications/Xcode.app","version":"16.4"}
+        not-json
+        """
+
+        let result = try #require(MasParser.parseJSONList(output))
+
+        #expect(result.packages.map(\.id) == ["mas-497799835"])
+    }
+
+    @Test("parseMasJSONList rejects malformed output for legacy fallback")
+    func parseMasJSONListMalformed() {
+        #expect(MasParser.parseJSONList("497799835 Xcode (16.4)") == nil)
+    }
+
     @Test("parseMasList parses standard output")
     func parseMasListStandard() {
         let output = """
@@ -288,5 +334,113 @@ struct MasOutputParsingTests {
         #expect(packages[0].id == "mas-0-App Alpha")
         #expect(packages[1].id == "mas-0-App Beta")
         #expect(packages[0].id != packages[1].id)
+    }
+}
+
+@Suite("Mas Installed App Fetching")
+@MainActor
+struct MasInstalledAppFetchingTests {
+
+    @Test("fetchInstalledMasApps prefers JSON output with application paths")
+    func fetchInstalledMasAppsJSON() async throws {
+        let mock = MockCommandRunner()
+        let output = """
+        {"adamID":497799835,"name":"Xcode","path":"/Applications/Xcode.app","version":"16.4"}
+        """
+        mock.setResult(for: ["list", "--json"], output: output)
+        let service = BrewService(commandRunner: mock, masExecutablePath: "/usr/bin/true")
+
+        let result = try #require(await service.fetchInstalledMasApps())
+
+        #expect(result.packages.map(\.id) == ["mas-497799835"])
+        #expect(result.applicationURLs["mas-497799835"]?.path == "/Applications/Xcode.app")
+        #expect(mock.executedCommands == [["list", "--json"]])
+        #expect(mock.executedExecutables.map(\.path) == ["/usr/bin/true"])
+    }
+
+    @Test("fetchInstalledMasApps falls back for older mas versions")
+    func fetchInstalledMasAppsLegacyFallback() async throws {
+        let mock = MockCommandRunner()
+        mock.setResult(for: ["list", "--json"], output: "unknown option", success: false)
+        mock.setResult(for: ["list"], output: "497799835 Xcode (15.4)")
+        let service = BrewService(commandRunner: mock, masExecutablePath: "/usr/bin/true")
+
+        let result = try #require(await service.fetchInstalledMasApps())
+
+        #expect(result.packages.map(\.id) == ["mas-497799835"])
+        #expect(result.applicationURLs.isEmpty)
+        #expect(mock.executedCommands == [["list", "--json"], ["list"]])
+        #expect(mock.executedExecutables.map(\.path) == ["/usr/bin/true", "/usr/bin/true"])
+    }
+
+    @Test("fetchInstalledMasApps parses JSON emitted by the fallback command")
+    func fetchInstalledMasAppsJSONFallback() async throws {
+        let mock = MockCommandRunner()
+        mock.setResult(for: ["list", "--json"], output: "unknown option", success: false)
+        mock.setResult(
+            for: ["list"],
+            output: #"{"adamID":497799835,"name":"Xcode","path":"/Applications/Xcode.app","version":"16.4"}"#
+        )
+        let service = BrewService(commandRunner: mock, masExecutablePath: "/usr/bin/true")
+
+        let result = try #require(await service.fetchInstalledMasApps())
+
+        #expect(result.packages.map(\.id) == ["mas-497799835"])
+        #expect(result.applicationURLs["mas-497799835"]?.path == "/Applications/Xcode.app")
+    }
+
+    @Test("fetchInstalledMasApps treats empty standard output as an empty list")
+    func fetchInstalledMasAppsEmptyStandardOutput() async throws {
+        let mock = MockCommandRunner()
+        mock.setResult(
+            for: ["list", "--json"],
+            result: CommandResult(
+                output: "Warning: No installed apps found.",
+                success: true,
+                standardOutput: "",
+                standardError: "Warning: No installed apps found."
+            )
+        )
+        let service = BrewService(commandRunner: mock, masExecutablePath: "/usr/bin/true")
+
+        let result = try #require(await service.fetchInstalledMasApps())
+
+        #expect(result.packages.isEmpty)
+        #expect(mock.executedCommands == [["list", "--json"]])
+    }
+
+    @Test("fetchInstalledMasApps re-resolves the executable when no override is set")
+    func fetchInstalledMasAppsReresolvesExecutable() async throws {
+        let mock = MockCommandRunner()
+        let resolver = MasPathResolver(path: "/usr/bin/true")
+        mock.setResult(for: ["list", "--json"], output: "")
+        let service = BrewService(
+            commandRunner: mock,
+            masExecutablePathResolver: resolver.resolve
+        )
+
+        _ = try #require(await service.fetchInstalledMasApps())
+        resolver.path = "/usr/bin/false"
+        _ = try #require(await service.fetchInstalledMasApps())
+
+        #expect(mock.executedExecutables.map(\.path) == ["/usr/bin/true", "/usr/bin/false"])
+    }
+}
+
+private final class MasPathResolver: @unchecked Sendable {
+    private let lock = NSLock()
+    private var _path: String
+
+    init(path: String) {
+        _path = path
+    }
+
+    var path: String {
+        get { lock.withLock { _path } }
+        set { lock.withLock { _path = newValue } }
+    }
+
+    func resolve() -> String {
+        path
     }
 }

--- a/BrewyTests/TestHelpers.swift
+++ b/BrewyTests/TestHelpers.swift
@@ -83,7 +83,8 @@ enum TestJSON {
     "installed":[{"version":"1.24.5","installed_on_request":true}],\
     "dependencies":["openssl@3","libidn2"]}],\
     "casks":[{"token":"firefox","version":"122.0",\
-    "desc":"Web browser","homepage":"https://www.mozilla.org/firefox/"}]}
+    "desc":"Web browser","homepage":"https://www.mozilla.org/firefox/",\
+    "artifacts":[{"app":["Firefox.app"],"target":"/Applications/Firefox.app"}]}]}
     """
 
     static let outdated = """


### PR DESCRIPTION
Brewy rendered every package with the same generic source glyph, so a list of installed casks gave no visual handle on which app was which (#306). `brew info --installed --json=v2` already reports the resolved `target` path for each cask's app artifact, and `mas list --json` reports the installed path for each Mac App Store app, so both come from commands a refresh already runs and no per-package invocation is added. Package rows and the detail header now show the real application icon for GUI casks and Mac App Store apps, while formulae, terminal-only casks, and missing bundles keep the existing source icon.

Discovered paths are transient refresh state: they stay out of the versioned package cache, survive a failed refresh of the command that supplies them, and are pruned once an app is no longer installed. Icons load off the main thread through a bounded cache keyed on path and package version, so an upgraded app picks up its new icon and warm rows resolve without touching the filesystem. Cask artifact and `mas` JSON decoding tolerate missing, null, and unexpected field shapes so an unfamiliar payload degrades to the fallback icon instead of failing the response around it.

AI disclosure: Claude Opus 5 with manual testing and review.