### PR TITLE
feat(packages): show code signing and Gatekeeper details for installed apps

### DIFF
--- a/Brewy/BrewyApp.swift
+++ b/Brewy/BrewyApp.swift
@@ -46,7 +46,13 @@ struct BrewyApp: App {
     private static func makeBrewService() -> BrewService {
 #if DEBUG
         if BrewyRuntime.isUITesting {
-            return BrewService(commandRunner: UITestCommandRunner())
+            return BrewService(
+                commandRunner: UITestCommandRunner(),
+                installedApplicationURLs: [
+                    "cask-firefox": URL(fileURLWithPath: "/Applications/Firefox.app"),
+                    "mas-497799835": URL(fileURLWithPath: "/Applications/Xcode.app")
+                ]
+            )
         }
 #endif
         return BrewService()

--- a/Brewy/Models/ApplicationSecurityModel.swift
+++ b/Brewy/Models/ApplicationSecurityModel.swift
@@ -1,0 +1,229 @@
+import Foundation
+
+struct ApplicationSecurityDetails: Equatable, Sendable {
+    enum SigningStatus: Equatable, Sendable {
+        case valid
+        case unsigned
+        case invalid
+        case unavailable
+    }
+
+    enum GatekeeperStatus: Equatable, Sendable {
+        case accepted
+        case rejected
+        case unavailable
+    }
+
+    enum NotarizationStatus: Equatable, Sendable {
+        case stapledTicket
+        case acceptedByGatekeeper
+        case notReported
+    }
+
+    let applicationURL: URL
+    let signingStatus: SigningStatus
+    let signingMessage: String?
+    let signer: String?
+    let teamIdentifier: String?
+    let gatekeeperStatus: GatekeeperStatus
+    let gatekeeperSource: String?
+    let gatekeeperMessage: String?
+    let notarizationStatus: NotarizationStatus
+}
+
+enum ApplicationSecurityParser {
+    static func parse(
+        applicationURL: URL,
+        signingMetadata: CommandResult,
+        signingVerification: CommandResult,
+        gatekeeperAssessment: CommandResult
+    ) -> ApplicationSecurityDetails {
+        let metadataOutput = rawOutput(for: signingMetadata)
+        let verificationOutput = rawOutput(for: signingVerification)
+        let gatekeeperOutput = rawOutput(for: gatekeeperAssessment)
+        let signingStatus = signingStatus(
+            verification: signingVerification,
+            output: verificationOutput
+        )
+        let gatekeeperStatus = gatekeeperStatus(
+            assessment: gatekeeperAssessment,
+            output: gatekeeperOutput
+        )
+        let gatekeeperSource = value(for: "source", in: gatekeeperOutput)
+        let hasValidSignature = signingStatus == .valid
+        let signer = hasValidSignature ? signingIdentity(in: metadataOutput, gatekeeperOutput: gatekeeperOutput) : nil
+        let teamIdentifier = hasValidSignature ? normalizedTeamIdentifier(in: metadataOutput) : nil
+
+        return ApplicationSecurityDetails(
+            applicationURL: applicationURL,
+            signingStatus: signingStatus,
+            signingMessage: signingMessage(
+                for: signingStatus,
+                output: verificationOutput,
+                applicationPath: applicationURL.path
+            ),
+            signer: signer,
+            teamIdentifier: teamIdentifier,
+            gatekeeperStatus: gatekeeperStatus,
+            gatekeeperSource: gatekeeperSource,
+            gatekeeperMessage: gatekeeperMessage(
+                for: gatekeeperStatus,
+                output: gatekeeperOutput,
+                applicationPath: applicationURL.path
+            ),
+            notarizationStatus: notarizationStatus(
+                signingStatus: signingStatus,
+                metadataOutput: metadataOutput,
+                gatekeeperStatus: gatekeeperStatus,
+                gatekeeperSource: gatekeeperSource
+            )
+        )
+    }
+
+    private static func signingStatus(
+        verification: CommandResult,
+        output: String
+    ) -> ApplicationSecurityDetails.SigningStatus {
+        if verification.success {
+            return .valid
+        }
+        let lowercaseOutput = output.lowercased()
+        if lowercaseOutput.contains("not signed at all") {
+            return .unsigned
+        }
+        if verification.cancelled
+            || lowercaseOutput.contains("timed out")
+            || lowercaseOutput.contains("failed to run")
+            || lowercaseOutput.contains("no such file")
+            || lowercaseOutput.contains("does not exist")
+            || lowercaseOutput.contains("failed to launch process") {
+            return .unavailable
+        }
+        return .invalid
+    }
+
+    private static func gatekeeperStatus(
+        assessment: CommandResult,
+        output: String
+    ) -> ApplicationSecurityDetails.GatekeeperStatus {
+        if assessment.success {
+            return .accepted
+        }
+        if assessment.cancelled {
+            return .unavailable
+        }
+        if assessment.exitCode == 3 || output.localizedCaseInsensitiveContains("rejected") {
+            return .rejected
+        }
+        return .unavailable
+    }
+
+    private static func signingIdentity(in metadataOutput: String, gatekeeperOutput: String) -> String? {
+        if let authority = value(for: "Authority", in: metadataOutput) {
+            return authority
+        }
+        if value(for: "Signature", in: metadataOutput)?.lowercased() == "adhoc" {
+            return "Ad Hoc"
+        }
+        return value(for: "origin", in: gatekeeperOutput)
+    }
+
+    private static func normalizedTeamIdentifier(in output: String) -> String? {
+        guard let identifier = value(for: "TeamIdentifier", in: output),
+              !identifier.isEmpty,
+              identifier.lowercased() != "not set" else {
+            return nil
+        }
+        return identifier
+    }
+
+    private static func notarizationStatus(
+        signingStatus: ApplicationSecurityDetails.SigningStatus,
+        metadataOutput: String,
+        gatekeeperStatus: ApplicationSecurityDetails.GatekeeperStatus,
+        gatekeeperSource: String?
+    ) -> ApplicationSecurityDetails.NotarizationStatus {
+        if signingStatus == .valid,
+           value(for: "Notarization Ticket", in: metadataOutput)?.lowercased() == "stapled" {
+            return .stapledTicket
+        }
+        if gatekeeperStatus == .accepted,
+           gatekeeperSource?.lowercased().hasPrefix("notarized ") == true {
+            return .acceptedByGatekeeper
+        }
+        return .notReported
+    }
+
+    private static func signingMessage(
+        for status: ApplicationSecurityDetails.SigningStatus,
+        output: String,
+        applicationPath: String
+    ) -> String? {
+        switch status {
+        case .invalid, .unavailable:
+            diagnostic(from: output, applicationPath: applicationPath)
+        case .valid, .unsigned:
+            nil
+        }
+    }
+
+    private static func gatekeeperMessage(
+        for status: ApplicationSecurityDetails.GatekeeperStatus,
+        output: String,
+        applicationPath: String
+    ) -> String? {
+        switch status {
+        case .rejected, .unavailable:
+            guard let message = diagnostic(from: output, applicationPath: applicationPath) else { return nil }
+            let statusWord = status == .rejected ? "Rejected" : "Unavailable"
+            return message.localizedCaseInsensitiveCompare(statusWord) == .orderedSame ? nil : message
+        case .accepted:
+            return nil
+        }
+    }
+
+    private static func rawOutput(for result: CommandResult) -> String {
+        let rawStreams = [result.standardOutput, result.standardError]
+            .filter { !$0.isEmpty }
+            .joined(separator: "\n")
+        if !result.success, !result.output.isEmpty {
+            return result.output
+        }
+        return rawStreams.isEmpty ? result.output : rawStreams
+    }
+
+    private static func value(for key: String, in output: String) -> String? {
+        let prefix = "\(key)="
+        return output.split(whereSeparator: \.isNewline).lazy
+            .map { $0.trimmingCharacters(in: .whitespaces) }
+            .first { $0.hasPrefix(prefix) }
+            .map { String($0.dropFirst(prefix.count)) }
+    }
+
+    private static func diagnostic(from output: String, applicationPath: String) -> String? {
+        let candidates = output.split(whereSeparator: \.isNewline)
+            .map { $0.trimmingCharacters(in: .whitespacesAndNewlines) }
+            .filter { line in
+                let lowercaseLine = line.lowercased()
+                return !line.isEmpty
+                    && !lowercaseLine.hasPrefix("source=")
+                    && !lowercaseLine.hasPrefix("origin=")
+                    && !lowercaseLine.hasPrefix("--prepared:")
+                    && !lowercaseLine.hasPrefix("--validated:")
+                    && !lowercaseLine.hasPrefix("file modified:")
+                    && !lowercaseLine.hasPrefix("in subcomponent:")
+            }
+        let verdictPrefix = "\(applicationPath):"
+        guard var diagnostic = candidates.first(where: { $0.hasPrefix(verdictPrefix) })
+            ?? candidates.first else { return nil }
+        if diagnostic.hasPrefix(verdictPrefix) {
+            diagnostic = String(diagnostic.dropFirst(verdictPrefix.count))
+                .trimmingCharacters(in: .whitespaces)
+        } else if let separator = diagnostic.firstIndex(of: ":") {
+            diagnostic = diagnostic[diagnostic.index(after: separator)...]
+                .trimmingCharacters(in: .whitespaces)
+        }
+        guard let first = diagnostic.first else { return nil }
+        return first.uppercased() + diagnostic.dropFirst()
+    }
+}

--- a/Brewy/Models/BrewService+ApplicationSecurity.swift
+++ b/Brewy/Models/BrewService+ApplicationSecurity.swift
@@ -1,0 +1,53 @@
+import Foundation
+
+struct ApplicationSecurityInspector: Sendable {
+    private static let inspectionTimeout: Duration = .seconds(30)
+    private let commandRunner: CommandRunning
+
+    init(commandRunner: CommandRunning) {
+        self.commandRunner = commandRunner
+    }
+
+    func inspect(applicationURL: URL) async -> ApplicationSecurityDetails {
+        let applicationURL = applicationURL.standardizedFileURL
+        let path = applicationURL.path
+        let metadataArguments = ["--display", "--verbose=4", "--", path]
+        let verificationArguments = ["--verify", "--deep", "--strict", "--verbose=2", "--", path]
+        let gatekeeperArguments = ["--assess", "--type", "execute", "--verbose=4", "--", path]
+
+        async let signingMetadata = commandRunner.runExecutable(
+            "/usr/bin/codesign",
+            arguments: metadataArguments,
+            timeout: Self.inspectionTimeout
+        )
+        async let signingVerification = commandRunner.runExecutable(
+            "/usr/bin/codesign",
+            arguments: verificationArguments,
+            timeout: Self.inspectionTimeout
+        )
+        async let gatekeeperAssessment = commandRunner.runExecutable(
+            "/usr/sbin/spctl",
+            arguments: gatekeeperArguments,
+            timeout: Self.inspectionTimeout
+        )
+
+        return await ApplicationSecurityParser.parse(
+            applicationURL: applicationURL,
+            signingMetadata: signingMetadata,
+            signingVerification: signingVerification,
+            gatekeeperAssessment: gatekeeperAssessment
+        )
+    }
+}
+
+extension BrewService {
+    func applicationSecurityDetails(for package: BrewPackage) async -> ApplicationSecurityDetails? {
+        guard package.isInstalled,
+              !package.isFormula,
+              let applicationURL = installedApplicationURL(for: package) else {
+            return nil
+        }
+        return await ApplicationSecurityInspector(commandRunner: commandRunner)
+            .inspect(applicationURL: applicationURL)
+    }
+}

--- a/Brewy/Models/BrewService.swift
+++ b/Brewy/Models/BrewService.swift
@@ -31,12 +31,14 @@ final class BrewService {
         commandRunner: CommandRunning = DefaultCommandRunner(),
         masExecutablePath: String? = nil,
         masExecutablePathResolver: @escaping @Sendable () -> String = CommandRunner.resolvedMasPath,
+        installedApplicationURLs: [String: URL] = [:],
         packageCacheURL: URL? = BrewService.runtimeDefaultPackageCacheURL,
         packageCacheWritesEnabled: Bool = !BrewyRuntime.isRunningTests
     ) {
         self.commandRunner = commandRunner
         masExecutablePathOverride = masExecutablePath
         self.masExecutablePathResolver = masExecutablePathResolver
+        self.installedApplicationURLs = installedApplicationURLs
         self.packageCacheURL = packageCacheURL
         self.packageCacheWritesEnabled = packageCacheWritesEnabled
     }

--- a/Brewy/Models/UITestFixtures.swift
+++ b/Brewy/Models/UITestFixtures.swift
@@ -119,11 +119,54 @@ final class UITestCommandRunner: CommandRunning, @unchecked Sendable {
         arguments: [String],
         timeout: Duration
     ) async -> CommandResult {
+        if executablePath == "/usr/bin/codesign" {
+            let output = arguments.contains("--display")
+                ? Self.codeSigningMetadata
+                : "/Applications/Firefox.app: valid on disk"
+            return CommandResult(
+                output: output,
+                success: true,
+                standardOutput: "",
+                standardError: output
+            )
+        }
+        if executablePath == "/usr/sbin/spctl" {
+            if ProcessInfo.processInfo.environment["BREWY_UI_GATEKEEPER_FAILURE"] == "1" {
+                let output = "/Applications/Firefox.app: internal error in Code Signing subsystem"
+                return CommandResult(
+                    output: output,
+                    success: false,
+                    standardOutput: "",
+                    standardError: output,
+                    exitCode: 1
+                )
+            }
+            return CommandResult(
+                output: Self.gatekeeperAssessment,
+                success: true,
+                standardOutput: "",
+                standardError: Self.gatekeeperAssessment
+            )
+        }
         if executablePath == "/usr/bin/du" {
             return CommandResult(output: "2048\t/private/tmp/brewy-ui-cache\n", success: true)
         }
         return CommandResult(output: "Fixture command completed.\n", success: true)
     }
+
+    private static let codeSigningMetadata = """
+    Authority=Developer ID Application: Mozilla Corporation (43AQ936H96)
+    Authority=Developer ID Certification Authority
+    Authority=Apple Root CA
+    Notarization Ticket=stapled
+    TeamIdentifier=43AQ936H96
+    """
+
+    private static let gatekeeperAssessment = """
+    /Applications/Firefox.app: accepted
+    source=Notarized Developer ID
+    origin=Developer ID Application: Mozilla Corporation (43AQ936H96)
+    """
 
     private static func bundleListResult(_ arguments: [String]) -> CommandResult {
         let output: String

--- a/Brewy/Views/ApplicationSecurityView.swift
+++ b/Brewy/Views/ApplicationSecurityView.swift
@@ -1,0 +1,269 @@
+import SwiftUI
+
+struct ApplicationSecuritySection: View {
+    @Environment(BrewService.self)
+    private var brewService
+    let package: BrewPackage
+    @State private var loadState: LoadState = .idle
+    @State private var refreshID = 0
+
+    private var requestID: String {
+        let applicationPath = brewService.installedApplicationURL(for: package)?.path ?? ""
+        return "\(package.id)\u{0}\(package.version)\u{0}\(applicationPath)\u{0}\(refreshID)"
+    }
+
+    var body: some View {
+        VStack(alignment: .leading, spacing: 12) {
+            HStack {
+                Text("Security Details")
+                    .font(.headline)
+                Spacer()
+                if loadState != .idle, loadState != .loading {
+                    Button("Check Again", systemImage: "arrow.clockwise") {
+                        refreshID += 1
+                    }
+                    .controlSize(.small)
+                    .accessibilityIdentifier("application-security-retry")
+                }
+            }
+
+            switch loadState {
+            case .idle:
+                VStack(alignment: .leading, spacing: 8) {
+                    Text("Check this app’s signature, Gatekeeper assessment, and notarization evidence.")
+                        .font(.callout)
+                        .foregroundStyle(.secondary)
+                    Button("Check Security", systemImage: "checkmark.shield") {
+                        refreshID += 1
+                    }
+                    .buttonStyle(.bordered)
+                    .accessibilityIdentifier("application-security-check")
+                }
+            case .loading:
+                HStack(spacing: 8) {
+                    ProgressView()
+                        .controlSize(.small)
+                        .accessibilityHidden(true)
+                    Text("Checking this application…")
+                        .font(.callout)
+                        .foregroundStyle(.secondary)
+                }
+                .accessibilityElement(children: .ignore)
+                .accessibilityLabel("Checking application security")
+                .accessibilityIdentifier("application-security-loading")
+            case .unavailable:
+                Text("Brewy could not locate this application bundle. Refresh packages, then try again.")
+                    .font(.callout)
+                    .foregroundStyle(.secondary)
+                    .accessibilityIdentifier("application-security-unavailable")
+            case .loaded(let details):
+                ApplicationSecurityDetailsGrid(details: details)
+            }
+        }
+        .padding(.horizontal)
+        .padding(.vertical, 12)
+        .accessibilityElement(children: .contain)
+        .accessibilityLabel("Security Details")
+        .accessibilityIdentifier("application-security-section")
+        .task(id: requestID) {
+            guard refreshID > 0 else { return }
+            loadState = .loading
+            let details = await brewService.applicationSecurityDetails(for: package)
+            guard !Task.isCancelled else { return }
+            loadState = details.map(LoadState.loaded) ?? .unavailable
+        }
+    }
+}
+
+extension ApplicationSecuritySection {
+    private enum LoadState: Equatable {
+        case idle
+        case loading
+        case unavailable
+        case loaded(ApplicationSecurityDetails)
+    }
+}
+
+private struct ApplicationSecurityDetailsGrid: View {
+    let details: ApplicationSecurityDetails
+
+    var body: some View {
+        LazyVGrid(columns: [
+            GridItem(.flexible(), alignment: .topLeading),
+            GridItem(.flexible(), alignment: .topLeading)
+        ], spacing: 10) {
+            SecurityDetailField(
+                label: "Code Signing",
+                value: details.signingStatus.title,
+                message: details.signingMessage,
+                systemImage: details.signingStatus.systemImage,
+                color: details.signingStatus.color,
+                identifier: "application-security-signing"
+            )
+            SecurityDetailField(
+                label: "Gatekeeper",
+                value: details.gatekeeperStatus.title,
+                message: details.gatekeeperMessage,
+                systemImage: details.gatekeeperStatus.systemImage,
+                color: details.gatekeeperStatus.color,
+                identifier: "application-security-gatekeeper"
+            )
+            SecurityDetailField(
+                label: "Notarization",
+                value: details.notarizationStatus.title,
+                systemImage: details.notarizationStatus.systemImage,
+                color: details.notarizationStatus.color,
+                identifier: "application-security-notarization"
+            )
+            if let source = details.gatekeeperSource {
+                SecurityDetailField(
+                    label: "Assessment Source",
+                    value: source,
+                    identifier: "application-security-source"
+                )
+            }
+            if let signer = details.signer {
+                SecurityDetailField(
+                    label: "Signed By",
+                    value: signer,
+                    identifier: "application-security-signer"
+                )
+            }
+            if let teamIdentifier = details.teamIdentifier {
+                SecurityDetailField(
+                    label: "Team ID",
+                    value: teamIdentifier,
+                    identifier: "application-security-team-id"
+                )
+            }
+            SecurityDetailField(
+                label: "Application",
+                value: details.applicationURL.path,
+                identifier: "application-security-path"
+            )
+        }
+    }
+}
+
+private struct SecurityDetailField: View {
+    let label: String
+    let value: String
+    var message: String?
+    var systemImage: String?
+    var color: Color = .primary
+    let identifier: String
+
+    private var accessibilityDescription: String {
+        if let message {
+            return "\(label): \(value). \(message)"
+        }
+        return "\(label): \(value)"
+    }
+
+    var body: some View {
+        VStack(alignment: .leading, spacing: 2) {
+            Text(label)
+                .font(.caption)
+                .fontWeight(.medium)
+                .textCase(.uppercase)
+                .foregroundStyle(.secondary)
+            HStack(spacing: 5) {
+                if let systemImage {
+                    Image(systemName: systemImage)
+                        .accessibilityHidden(true)
+                }
+                Text(value)
+                    .textSelection(.enabled)
+            }
+            .font(.callout)
+            .foregroundStyle(color)
+            if let message {
+                Text(message)
+                    .font(.caption)
+                    .foregroundStyle(.secondary)
+                    .textSelection(.enabled)
+            }
+        }
+        .accessibilityElement(children: .ignore)
+        .accessibilityLabel(accessibilityDescription)
+        .accessibilityIdentifier(identifier)
+    }
+}
+
+extension ApplicationSecurityDetails.SigningStatus {
+    fileprivate var title: String {
+        switch self {
+        case .valid: "Signature Valid"
+        case .unsigned: "Unsigned"
+        case .invalid: "Signature Invalid"
+        case .unavailable: "Unavailable"
+        }
+    }
+
+    fileprivate var systemImage: String {
+        switch self {
+        case .valid: "checkmark.seal.fill"
+        case .unsigned: "exclamationmark.triangle.fill"
+        case .invalid: "xmark.seal.fill"
+        case .unavailable: "questionmark.circle.fill"
+        }
+    }
+
+    fileprivate var color: Color {
+        switch self {
+        case .valid: .green
+        case .unsigned, .unavailable: .orange
+        case .invalid: .red
+        }
+    }
+}
+
+extension ApplicationSecurityDetails.GatekeeperStatus {
+    fileprivate var title: String {
+        switch self {
+        case .accepted: "Accepted"
+        case .rejected: "Rejected"
+        case .unavailable: "Unavailable"
+        }
+    }
+
+    fileprivate var systemImage: String {
+        switch self {
+        case .accepted: "checkmark.shield.fill"
+        case .rejected: "xmark.shield.fill"
+        case .unavailable: "questionmark.circle.fill"
+        }
+    }
+
+    fileprivate var color: Color {
+        switch self {
+        case .accepted: .green
+        case .rejected: .red
+        case .unavailable: .orange
+        }
+    }
+}
+
+extension ApplicationSecurityDetails.NotarizationStatus {
+    fileprivate var title: String {
+        switch self {
+        case .stapledTicket: "Stapled Ticket"
+        case .acceptedByGatekeeper: "Accepted by Gatekeeper"
+        case .notReported: "Not Reported"
+        }
+    }
+
+    fileprivate var systemImage: String {
+        switch self {
+        case .stapledTicket, .acceptedByGatekeeper: "checkmark.seal.fill"
+        case .notReported: "minus.circle.fill"
+        }
+    }
+
+    fileprivate var color: Color {
+        switch self {
+        case .stapledTicket, .acceptedByGatekeeper: .green
+        case .notReported: .secondary
+        }
+    }
+}

--- a/Brewy/Views/InstalledPackageIcon.swift
+++ b/Brewy/Views/InstalledPackageIcon.swift
@@ -60,7 +60,7 @@ struct InstalledPackageIcon: View {
             if let applicationIcon {
                 Image(nsImage: applicationIcon)
                     .resizable()
-                    .aspectRatio(contentMode: .fit)
+                    .scaledToFit()
             } else {
                 PackageSourceIcon(source: package.source, size: size)
             }

--- a/Brewy/Views/PackageDetailView.swift
+++ b/Brewy/Views/PackageDetailView.swift
@@ -27,6 +27,14 @@ struct PackageDetailView: View {
                 Divider()
                     .padding(.horizontal)
                 PackageInfoSection(package: displayPackage)
+                if package.isInstalled,
+                   !package.isFormula,
+                   let applicationURL = brewService.installedApplicationURL(for: package) {
+                    Divider()
+                        .padding(.horizontal)
+                    ApplicationSecuritySection(package: package)
+                        .id(applicationURL)
+                }
                 if !package.isMas {
                     Divider()
                         .padding(.horizontal)

--- a/Brewy/Views/SettingsView.swift
+++ b/Brewy/Views/SettingsView.swift
@@ -307,7 +307,7 @@ private struct AppIconPreviewTile: View {
 
             Image(nsImage: icon.previewImage)
                 .resizable()
-                .aspectRatio(contentMode: .fit)
+                .scaledToFit()
                 .padding(imageInset)
         }
         .frame(width: 54, height: 54)

--- a/BrewyTests/ApplicationSecurityTests.swift
+++ b/BrewyTests/ApplicationSecurityTests.swift
@@ -1,0 +1,375 @@
+@testable import Brewy
+import Foundation
+import Testing
+
+@Suite("Application Security Parsing")
+struct ApplicationSecurityParsingTests {
+
+    @Test("Parses a valid Developer ID signature and notarization evidence")
+    func validDeveloperIDSignature() {
+        let details = ApplicationSecurityParser.parse(
+            applicationURL: URL(fileURLWithPath: "/Applications/Example.app"),
+            signingMetadata: CommandResult(
+                output: """
+                Authority=Developer ID Application: Example Corp (ABCDE12345)
+                Authority=Developer ID Certification Authority
+                Authority=Apple Root CA
+                Notarization Ticket=stapled
+                TeamIdentifier=ABCDE12345
+                """,
+                success: true
+            ),
+            signingVerification: CommandResult(
+                output: "/Applications/Example.app: valid on disk",
+                success: true
+            ),
+            gatekeeperAssessment: CommandResult(
+                output: """
+                /Applications/Example.app: accepted
+                source=Notarized Developer ID
+                origin=Developer ID Application: Example Corp (ABCDE12345)
+                """,
+                success: true
+            )
+        )
+
+        #expect(details.applicationURL.path == "/Applications/Example.app")
+        #expect(details.signingStatus == .valid)
+        #expect(details.signer == "Developer ID Application: Example Corp (ABCDE12345)")
+        #expect(details.teamIdentifier == "ABCDE12345")
+        #expect(details.gatekeeperStatus == .accepted)
+        #expect(details.gatekeeperSource == "Notarized Developer ID")
+        #expect(details.notarizationStatus == .stapledTicket)
+    }
+
+    @Test("Uses Gatekeeper as notarization evidence when no ticket is stapled")
+    func gatekeeperNotarizationEvidence() {
+        let details = ApplicationSecurityParser.parse(
+            applicationURL: URL(fileURLWithPath: "/Applications/Example.app"),
+            signingMetadata: CommandResult(
+                output: """
+                Authority=Developer ID Application: Example Corp (ABCDE12345)
+                TeamIdentifier=ABCDE12345
+                """,
+                success: true
+            ),
+            signingVerification: CommandResult(output: "valid on disk", success: true),
+            gatekeeperAssessment: CommandResult(
+                output: "source=Notarized Developer ID",
+                success: true
+            )
+        )
+
+        #expect(details.notarizationStatus == .acceptedByGatekeeper)
+    }
+
+    @Test("Distinguishes an unsigned app from a rejected Gatekeeper assessment")
+    func unsignedAndRejected() {
+        let unsignedOutput = "/Applications/Unsigned.app: code object is not signed at all"
+        let details = ApplicationSecurityParser.parse(
+            applicationURL: URL(fileURLWithPath: "/Applications/Unsigned.app"),
+            signingMetadata: CommandResult(output: unsignedOutput, success: false),
+            signingVerification: CommandResult(output: unsignedOutput, success: false),
+            gatekeeperAssessment: CommandResult(
+                output: """
+                /Applications/Unsigned.app: rejected
+                source=no usable signature
+                """,
+                success: false
+            )
+        )
+
+        #expect(details.signingStatus == .unsigned)
+        #expect(details.signer == nil)
+        #expect(details.teamIdentifier == nil)
+        #expect(details.gatekeeperStatus == .rejected)
+        #expect(details.gatekeeperSource == "no usable signature")
+        #expect(details.notarizationStatus == .notReported)
+    }
+
+    @Test("Does not report a Gatekeeper subsystem error as rejection")
+    func gatekeeperUnavailable() {
+        let details = ApplicationSecurityParser.parse(
+            applicationURL: URL(fileURLWithPath: "/Applications/Example.app"),
+            signingMetadata: CommandResult(
+                output: """
+                Authority=Developer ID Application: Example Corp (ABCDE12345)
+                TeamIdentifier=ABCDE12345
+                """,
+                success: true
+            ),
+            signingVerification: CommandResult(
+                output: "a sealed resource is missing or invalid",
+                success: false
+            ),
+            gatekeeperAssessment: CommandResult(
+                output: "/Applications/Example.app: internal error in Code Signing subsystem",
+                success: false
+            )
+        )
+
+        #expect(details.signingStatus == .invalid)
+        #expect(details.signer == nil)
+        #expect(details.teamIdentifier == nil)
+        #expect(details.gatekeeperStatus == .unavailable)
+        #expect(details.gatekeeperMessage == "Internal error in Code Signing subsystem")
+        #expect(details.notarizationStatus == .notReported)
+    }
+
+    @Test("Uses Gatekeeper's policy-denial exit status without relying on wording")
+    func gatekeeperPolicyDenialExitStatus() {
+        let details = ApplicationSecurityParser.parse(
+            applicationURL: URL(fileURLWithPath: "/Applications/Denied.app"),
+            signingMetadata: CommandResult(output: "", success: true),
+            signingVerification: CommandResult(output: "valid on disk", success: true),
+            gatekeeperAssessment: CommandResult(
+                output: "/Applications/Denied.app: assessment denied by policy",
+                success: false,
+                exitCode: 3
+            )
+        )
+
+        #expect(details.gatekeeperStatus == .rejected)
+        #expect(details.gatekeeperMessage == "Assessment denied by policy")
+    }
+
+    @Test("Keeps an assessment operation failure distinct from policy rejection")
+    func gatekeeperOperationFailure() {
+        let failure = "/Applications/Broken.app: a sealed resource is missing or invalid"
+        let details = ApplicationSecurityParser.parse(
+            applicationURL: URL(fileURLWithPath: "/Applications/Broken.app"),
+            signingMetadata: CommandResult(output: "", success: false),
+            signingVerification: CommandResult(output: failure, success: false, exitCode: 1),
+            gatekeeperAssessment: CommandResult(output: failure, success: false, exitCode: 1)
+        )
+
+        #expect(details.signingStatus == .invalid)
+        #expect(details.gatekeeperStatus == .unavailable)
+    }
+
+    @Test("Reports a signing timeout with partial output as unavailable")
+    func signingTimeout() {
+        let timeout = "Command timed out after 30 seconds.\n--prepared:/Applications/Slow.app/Contents/MacOS/Slow"
+        let details = ApplicationSecurityParser.parse(
+            applicationURL: URL(fileURLWithPath: "/Applications/Slow.app"),
+            signingMetadata: CommandResult(output: "", success: false),
+            signingVerification: CommandResult(
+                output: timeout,
+                success: false,
+                standardOutput: "",
+                standardError: "--prepared:/Applications/Slow.app/Contents/MacOS/Slow",
+                exitCode: 15
+            ),
+            gatekeeperAssessment: CommandResult(
+                output: "internal error in Code Signing subsystem",
+                success: false,
+                exitCode: 1
+            )
+        )
+
+        #expect(details.signingStatus == .unavailable)
+        #expect(details.signingMessage == "Command timed out after 30 seconds.")
+    }
+
+    @Test("Reports a codesign launch failure as unavailable")
+    func signingLaunchFailure() {
+        let failure = "Failed to run codesign --verify: Permission denied"
+        let details = ApplicationSecurityParser.parse(
+            applicationURL: URL(fileURLWithPath: "/Applications/Example.app"),
+            signingMetadata: CommandResult(output: "", success: false),
+            signingVerification: CommandResult(
+                output: failure,
+                success: false,
+                standardOutput: "",
+                standardError: failure
+            ),
+            gatekeeperAssessment: CommandResult(
+                output: "internal error in Code Signing subsystem",
+                success: false,
+                exitCode: 1
+            )
+        )
+
+        #expect(details.signingStatus == .unavailable)
+        #expect(details.signingMessage == "Permission denied")
+    }
+
+    @Test("Keeps cancelled security tools unavailable")
+    func cancelledTools() {
+        let cancellation = CommandResult(
+            output: "Command was cancelled.",
+            success: false,
+            cancelled: true,
+            standardOutput: ""
+        )
+        let details = ApplicationSecurityParser.parse(
+            applicationURL: URL(fileURLWithPath: "/Applications/Example.app"),
+            signingMetadata: cancellation,
+            signingVerification: cancellation,
+            gatekeeperAssessment: cancellation
+        )
+
+        #expect(details.signingStatus == .unavailable)
+        #expect(details.gatekeeperStatus == .unavailable)
+    }
+
+    @Test("Does not treat an unnotarized source as notarization evidence")
+    func unnotarizedSource() {
+        let details = ApplicationSecurityParser.parse(
+            applicationURL: URL(fileURLWithPath: "/Applications/Example.app"),
+            signingMetadata: CommandResult(output: "", success: true),
+            signingVerification: CommandResult(output: "valid on disk", success: true),
+            gatekeeperAssessment: CommandResult(
+                output: "source=Unnotarized Developer ID",
+                success: true
+            )
+        )
+
+        #expect(details.notarizationStatus == .notReported)
+    }
+
+    @Test("Does not repeat a bare Gatekeeper status as its message")
+    func duplicateGatekeeperMessage() {
+        let details = ApplicationSecurityParser.parse(
+            applicationURL: URL(fileURLWithPath: "/Applications/Denied.app"),
+            signingMetadata: CommandResult(output: "", success: false),
+            signingVerification: CommandResult(output: "not signed at all", success: false),
+            gatekeeperAssessment: CommandResult(
+                output: "/Applications/Denied.app: rejected",
+                success: false,
+                standardOutput: "",
+                standardError: "/Applications/Denied.app: rejected",
+                exitCode: 3
+            )
+        )
+
+        #expect(details.gatekeeperStatus == .rejected)
+        #expect(details.gatekeeperMessage == nil)
+    }
+
+    @Test("Parses real tool output from standard error")
+    func standardErrorOutput() {
+        let metadata = "Authority=Developer ID Application: Example Corp (ABCDE12345)\nTeamIdentifier=ABCDE12345"
+        let verification = "/Applications/Example.app: valid on disk"
+        let assessment = "/Applications/Example.app: accepted\nsource=Notarized Developer ID"
+        let details = ApplicationSecurityParser.parse(
+            applicationURL: URL(fileURLWithPath: "/Applications/Example.app"),
+            signingMetadata: CommandResult(
+                output: metadata,
+                success: true,
+                standardOutput: "",
+                standardError: metadata
+            ),
+            signingVerification: CommandResult(
+                output: verification,
+                success: true,
+                standardOutput: "",
+                standardError: verification
+            ),
+            gatekeeperAssessment: CommandResult(
+                output: assessment,
+                success: true,
+                standardOutput: "",
+                standardError: assessment
+            )
+        )
+
+        #expect(details.signingStatus == .valid)
+        #expect(details.signer == "Developer ID Application: Example Corp (ABCDE12345)")
+        #expect(details.gatekeeperStatus == .accepted)
+        #expect(details.notarizationStatus == .acceptedByGatekeeper)
+    }
+
+    @Test("Prefers the bundle verdict over codesign's stdout file list")
+    func splitStreamSigningFailure() {
+        let path = "/Applications/Broken.app"
+        let standardOutput = """
+        file modified: \(path)/Contents/Frameworks/Example.framework/Versions/Current/fileop
+        file modified: \(path)/Contents/Frameworks/Example.framework/Versions/Current/Autoupdate
+        """
+        let standardError = """
+        --prepared:\(path)/Contents/Frameworks/Example.framework
+        --validated:\(path)/Contents/Frameworks/Example.framework
+        \(path): a sealed resource is missing or invalid
+        In subcomponent: \(path)/Contents/Frameworks/Example.framework
+        """
+        let details = ApplicationSecurityParser.parse(
+            applicationURL: URL(fileURLWithPath: path),
+            signingMetadata: CommandResult(output: "", success: false),
+            signingVerification: CommandResult(
+                output: standardOutput + "\n" + standardError,
+                success: false,
+                standardOutput: standardOutput,
+                standardError: standardError,
+                exitCode: 1
+            ),
+            gatekeeperAssessment: CommandResult(
+                output: "\(path): internal error in Code Signing subsystem",
+                success: false,
+                exitCode: 1
+            )
+        )
+
+        #expect(details.signingStatus == .invalid)
+        #expect(details.signingMessage == "A sealed resource is missing or invalid")
+    }
+}
+
+@Suite("Application Security Inspection")
+struct ApplicationSecurityInspectionTests {
+
+    @Test("Runs bounded codesign and Gatekeeper checks with argument arrays")
+    func runsExpectedCommands() async {
+        let mock = MockCommandRunner()
+        let path = "/Applications/Example.app"
+        let metadataArguments = ["--display", "--verbose=4", "--", path]
+        let verificationArguments = ["--verify", "--deep", "--strict", "--verbose=2", "--", path]
+        let gatekeeperArguments = ["--assess", "--type", "execute", "--verbose=4", "--", path]
+        mock.setResult(
+            for: metadataArguments,
+            output: "Authority=Developer ID Application: Example Corp (ABCDE12345)\nTeamIdentifier=ABCDE12345"
+        )
+        mock.setResult(for: verificationArguments, output: "valid on disk")
+        mock.setResult(
+            for: gatekeeperArguments,
+            output: "source=Notarized Developer ID"
+        )
+        let inspector = ApplicationSecurityInspector(commandRunner: mock)
+
+        let details = await inspector.inspect(
+            applicationURL: URL(fileURLWithPath: path)
+        )
+
+        #expect(details.signingStatus == .valid)
+        #expect(mock.executedExecutables.count == 3)
+        #expect(mock.executedExecutables.contains { execution in
+            execution.path == "/usr/bin/codesign" && execution.arguments == metadataArguments
+        })
+        #expect(mock.executedExecutables.contains { execution in
+            execution.path == "/usr/bin/codesign" && execution.arguments == verificationArguments
+        })
+        #expect(mock.executedExecutables.contains { execution in
+            execution.path == "/usr/sbin/spctl" && execution.arguments == gatekeeperArguments
+        })
+        #expect(mock.recordedTimeout(for: metadataArguments) == .seconds(30))
+        #expect(mock.recordedTimeout(for: verificationArguments) == .seconds(30))
+        #expect(mock.recordedTimeout(for: gatekeeperArguments) == .seconds(30))
+    }
+}
+
+@Suite("BrewService Application Security")
+@MainActor
+struct BrewServiceApplicationSecurityTests {
+
+    @Test("Does not run security tools when the application bundle is unknown")
+    func unknownApplicationBundle() async {
+        let mock = MockCommandRunner()
+        let service = BrewService(commandRunner: mock)
+        let package = makePackage(name: "example", source: .cask)
+
+        let details = await service.applicationSecurityDetails(for: package)
+
+        #expect(details == nil)
+        #expect(mock.executedCommands.isEmpty)
+    }
+}

--- a/BrewyUITests/SidebarNavigationUITests.swift
+++ b/BrewyUITests/SidebarNavigationUITests.swift
@@ -155,6 +155,75 @@ final class SidebarNavigationUITests: XCTestCase {
         )
     }
 
+    func testCaskSecurityDetailsRenderFixtureData() throws {
+        let sidebar = app.outlines.firstMatch
+        assertExists(sidebar, timeout: Self.launchTimeout, "Sidebar should exist")
+        sidebar.staticTexts["Casks"].click()
+
+        let package = app.staticTexts["package-row-firefox"]
+        assertExists(package, timeout: Self.elementTimeout, "Fixture cask should appear")
+        package.click()
+
+        let checkSecurity = app.buttons["application-security-check"]
+        assertExists(checkSecurity, timeout: Self.elementTimeout, "Security check should be explicit")
+        let signing = app.descendants(matching: .any)["application-security-signing"].firstMatch
+        XCTAssertFalse(signing.exists, "Opening package details must not run the security check")
+        checkSecurity.click()
+
+        assertExists(signing, timeout: Self.elementTimeout, "Code-signing status should load")
+        XCTAssertEqual(signing.label, "Code Signing: Signature Valid")
+
+        let gatekeeper = app.descendants(matching: .any)["application-security-gatekeeper"].firstMatch
+        assertExists(gatekeeper, timeout: Self.elementTimeout, "Gatekeeper status should load")
+        XCTAssertEqual(gatekeeper.label, "Gatekeeper: Accepted")
+
+        let notarization = app.descendants(matching: .any)["application-security-notarization"].firstMatch
+        assertExists(notarization, timeout: Self.elementTimeout, "Notarization status should load")
+        XCTAssertEqual(notarization.label, "Notarization: Stapled Ticket")
+
+        let signer = app.descendants(matching: .any)["application-security-signer"].firstMatch
+        assertExists(signer, timeout: Self.elementTimeout, "Signing identity should load")
+        XCTAssertEqual(
+            signer.label,
+            "Signed By: Developer ID Application: Mozilla Corporation (43AQ936H96)"
+        )
+        assertExists(
+            app.buttons["application-security-retry"],
+            timeout: Self.elementTimeout,
+            "Loaded security details should be refreshable"
+        )
+    }
+
+    func testCaskSecurityDetailsKeepGatekeeperErrorsUnavailable() throws {
+        app.terminate()
+        app.launchEnvironment["BREWY_UI_GATEKEEPER_FAILURE"] = "1"
+        app.launch()
+        app.activate()
+
+        let sidebar = app.outlines.firstMatch
+        assertExists(sidebar, timeout: Self.launchTimeout, "Sidebar should exist")
+        sidebar.staticTexts["Casks"].click()
+
+        let package = app.staticTexts["package-row-firefox"]
+        assertExists(package, timeout: Self.elementTimeout, "Fixture cask should appear")
+        package.click()
+
+        let checkSecurity = app.buttons["application-security-check"]
+        assertExists(checkSecurity, timeout: Self.elementTimeout, "Security check should be explicit")
+        checkSecurity.click()
+
+        let gatekeeper = app.descendants(matching: .any)["application-security-gatekeeper"].firstMatch
+        assertExists(gatekeeper, timeout: Self.elementTimeout, "Gatekeeper status should load")
+        XCTAssertEqual(
+            gatekeeper.label,
+            "Gatekeeper: Unavailable. Internal error in Code Signing subsystem"
+        )
+        XCTAssertFalse(
+            gatekeeper.label.contains("Rejected"),
+            "A subsystem failure must not be presented as a security rejection"
+        )
+    }
+
     func testManagementViewsRenderFixtureDetails() throws {
         let sidebar = app.outlines.firstMatch
         assertExists(sidebar, timeout: Self.launchTimeout, "Sidebar should exist")


### PR DESCRIPTION
Installed casks and Mac App Store apps with a known bundle path gain a Security Details section reporting code signing, Gatekeeper, and notarization as three independent states rather than one verdict, since they fail independently. Signer and Team ID come from `codesign` output and are shown only when verification succeeds.

Nothing runs until Check Security is clicked, and the section resets to idle when the package, version, or bundle path changes. The three assessments go through the shared command runner with argument arrays, and navigating away cancels them. A timeout, cancellation, or launch failure reports Unavailable rather than a security verdict, and Gatekeeper separates policy denial (`spctl` exit 3) from operation failure (exit 1).

Part of #307.

AI disclosure: Claude Opus 5 with manual testing and review.