### PR TITLE
feat(packages): link casks to their GitHub repository

### DIFF
--- a/Brewy/Models/BrewJSONTypes.swift
+++ b/Brewy/Models/BrewJSONTypes.swift
@@ -58,11 +58,12 @@ struct CaskJSON: Decodable {
     let installed: String?
     let desc: String?
     let homepage: String?
+    let url: String?
     let dependencies: [String]
     let artifacts: [CaskArtifactJSON]
 
     enum CodingKeys: String, CodingKey {
-        case token, version, installed, desc, homepage, artifacts
+        case token, version, installed, desc, homepage, url, artifacts
         case dependsOn = "depends_on"
     }
 
@@ -78,6 +79,7 @@ struct CaskJSON: Decodable {
         installed = try container.decodeIfPresent(String.self, forKey: .installed)
         desc = try container.decodeIfPresent(String.self, forKey: .desc)
         homepage = try container.decodeIfPresent(String.self, forKey: .homepage)
+        url = try? container.decodeIfPresent(String.self, forKey: .url)
         artifacts = (try? container.decodeIfPresent([CaskArtifactJSON].self, forKey: .artifacts)) ?? []
         // `depends_on` is usually an object but brew sometimes emits an empty array; tolerate
         // either shape so a cask never fails to decode over its dependency field.
@@ -87,6 +89,10 @@ struct CaskJSON: Decodable {
 
     var applicationBundleURLs: [URL] {
         artifacts.compactMap(\.applicationBundleURL)
+    }
+
+    var repositoryURL: String? {
+        GitHubRepositoryURL.resolve(from: homepage, url)
     }
 
     func toPackage() -> BrewPackage {
@@ -105,7 +111,8 @@ struct CaskJSON: Decodable {
             source: .cask,
             pinned: false,
             installedOnRequest: true,
-            dependencies: dependencies
+            dependencies: dependencies,
+            repositoryURL: repositoryURL
         )
     }
 }

--- a/Brewy/Models/BrewService+History.swift
+++ b/Brewy/Models/BrewService+History.swift
@@ -122,7 +122,8 @@ extension BrewService {
             source: pkg.source,
             pinned: pkg.pinned || outdatedPkg.pinned,
             installedOnRequest: pkg.installedOnRequest,
-            dependencies: pkg.dependencies
+            dependencies: pkg.dependencies,
+            repositoryURL: pkg.repositoryURL
         )
     }
 }

--- a/Brewy/Models/BrewService+PackageDetail.swift
+++ b/Brewy/Models/BrewService+PackageDetail.swift
@@ -31,7 +31,8 @@ extension BrewService {
                         source: package.source,
                         pinned: package.pinned,
                         installedOnRequest: package.installedOnRequest,
-                        dependencies: package.dependencies
+                        dependencies: package.dependencies,
+                        repositoryURL: cask.repositoryURL ?? (cask.url == nil ? package.repositoryURL : nil)
                     )
                 }
                 if let formula = response.formulae?.first {
@@ -48,7 +49,8 @@ extension BrewService {
                         source: package.source,
                         pinned: package.pinned,
                         installedOnRequest: package.installedOnRequest,
-                        dependencies: formula.dependencies ?? package.dependencies
+                        dependencies: formula.dependencies ?? package.dependencies,
+                        repositoryURL: package.repositoryURL
                     )
                 }
                 return nil

--- a/Brewy/Models/GitHubRepositoryURL.swift
+++ b/Brewy/Models/GitHubRepositoryURL.swift
@@ -1,0 +1,44 @@
+import Foundation
+
+enum GitHubRepositoryURL {
+    private static let hosts: Set<String> = ["github.com", "www.github.com"]
+    private static let reservedOwners: Set<String> = [
+        "about", "apps", "collections", "enterprise", "events", "explore", "features",
+        "login", "marketplace", "new", "notifications", "organizations", "orgs", "pricing",
+        "pulls", "search", "security", "settings", "signup", "sponsors", "topics", "trending", "users"
+    ]
+
+    static func resolve(from candidates: String?...) -> String? {
+        for candidate in candidates {
+            guard let candidate,
+                  let url = ExternalURLPolicy.url(from: candidate),
+                  let host = url.host?.lowercased(),
+                  hosts.contains(host) else {
+                continue
+            }
+
+            let pathComponents = url.pathComponents.filter { $0 != "/" }
+            guard pathComponents.count >= 2 else { continue }
+
+            let owner = pathComponents[0]
+            let rawRepository = pathComponents[1]
+            let repository = rawRepository.lowercased().hasSuffix(".git")
+                ? String(rawRepository.dropLast(4))
+                : rawRepository
+            guard !owner.isEmpty,
+                  !repository.isEmpty,
+                  !reservedOwners.contains(owner.lowercased()) else {
+                continue
+            }
+
+            var components = URLComponents()
+            components.scheme = "https"
+            components.host = "github.com"
+            components.path = "/\(owner)/\(repository)"
+            if let resolved = components.url?.absoluteString {
+                return resolved
+            }
+        }
+        return nil
+    }
+}

--- a/Brewy/Models/PackageModel.swift
+++ b/Brewy/Models/PackageModel.swift
@@ -14,6 +14,7 @@ struct BrewPackage: Identifiable, Hashable, Codable {
     let version: String
     let description: String
     let homepage: String
+    let repositoryURL: String?
     let isInstalled: Bool
     let isOutdated: Bool
     let installedVersion: String?
@@ -32,6 +33,38 @@ struct BrewPackage: Identifiable, Hashable, Codable {
             return "\(version) → \(latest)"
         }
         return version
+    }
+
+    init(
+        id: String,
+        name: String,
+        version: String,
+        description: String,
+        homepage: String,
+        isInstalled: Bool,
+        isOutdated: Bool,
+        installedVersion: String?,
+        latestVersion: String?,
+        source: PackageSource,
+        pinned: Bool,
+        installedOnRequest: Bool,
+        dependencies: [String],
+        repositoryURL: String? = nil
+    ) {
+        self.id = id
+        self.name = name
+        self.version = version
+        self.description = description
+        self.homepage = homepage
+        self.repositoryURL = repositoryURL
+        self.isInstalled = isInstalled
+        self.isOutdated = isOutdated
+        self.installedVersion = installedVersion
+        self.latestVersion = latestVersion
+        self.source = source
+        self.pinned = pinned
+        self.installedOnRequest = installedOnRequest
+        self.dependencies = dependencies
     }
 
     static func == (lhs: Self, rhs: Self) -> Bool {

--- a/Brewy/Models/UITestFixtures.swift
+++ b/Brewy/Models/UITestFixtures.swift
@@ -344,7 +344,8 @@ extension BrewService {
             source: .cask,
             pinned: false,
             installedOnRequest: true,
-            dependencies: []
+            dependencies: [],
+            repositoryURL: "https://github.com/mozilla/gecko-dev"
         )
     }
 

--- a/Brewy/Views/PackageDetailView.swift
+++ b/Brewy/Views/PackageDetailView.swift
@@ -164,11 +164,23 @@ private struct ActionBar: View {
                 notInstalledActionsMenu
             }
 
-            if let url = ExternalURLPolicy.url(from: package.homepage) {
+            if let url = ExternalURLPolicy.url(from: package.homepage),
+               package.repositoryURL == nil ||
+               GitHubRepositoryURL.resolve(from: package.homepage) != package.repositoryURL {
                 Link(destination: url) {
                     Label(package.isMas ? "App Store" : "Homepage", systemImage: package.isMas ? "app.badge.fill" : "globe")
                 }
                 .buttonStyle(.bordered)
+                .accessibilityIdentifier("package-homepage")
+            }
+
+            if let repositoryURL = package.repositoryURL,
+               let url = ExternalURLPolicy.url(from: repositoryURL) {
+                Link(destination: url) {
+                    Label("GitHub", systemImage: "chevron.left.forwardslash.chevron.right")
+                }
+                .buttonStyle(.bordered)
+                .accessibilityIdentifier("package-upstream-repository")
             }
 
             Spacer()

--- a/BrewyTests/BrewServiceDetailTests.swift
+++ b/BrewyTests/BrewServiceDetailTests.swift
@@ -216,6 +216,7 @@ struct PackageDetailTests {
 
         #expect(enriched?.description == "Fast web browser")
         #expect(enriched?.homepage == "https://www.mozilla.org/firefox/")
+        #expect(enriched?.repositoryURL == "https://github.com/mozilla/gecko-dev")
     }
 
     @Test("fetchPackageDetail returns nil on failure")

--- a/BrewyTests/BrewServiceTests.swift
+++ b/BrewyTests/BrewServiceTests.swift
@@ -229,22 +229,31 @@ struct MergeOutdatedStatusTests {
 
     @Test("Marks package as outdated when match found")
     func mergesOutdatedMatch() {
-        let pkg = makePackage(name: "node", installedVersion: "20.10.0")
+        let pkg = BrewPackage(
+            id: "cask-example-app", name: "example-app", version: "1.0",
+            description: "", homepage: "https://example.com",
+            isInstalled: true, isOutdated: false,
+            installedVersion: "1.0", latestVersion: "1.0",
+            source: .cask, pinned: false, installedOnRequest: true,
+            dependencies: [],
+            repositoryURL: "https://github.com/example/example-app"
+        )
         let outdated = BrewPackage(
-            id: "formula-node", name: "node", version: "20.10.0",
+            id: "cask-example-app", name: "example-app", version: "1.0",
             description: "", homepage: "",
             isInstalled: true, isOutdated: true,
-            installedVersion: "20.10.0", latestVersion: "21.5.0",
-            source: .formula, pinned: false, installedOnRequest: true,
+            installedVersion: "1.0", latestVersion: "2.0",
+            source: .cask, pinned: false, installedOnRequest: true,
             dependencies: []
         )
         let outdatedByID = [outdated.id: outdated]
 
         let merged = BrewService.mergeOutdatedStatus(pkg, outdatedByID: outdatedByID)
         #expect(merged.isOutdated == true)
-        #expect(merged.latestVersion == "21.5.0")
-        #expect(merged.name == "node")
-        #expect(merged.installedVersion == "20.10.0")
+        #expect(merged.latestVersion == "2.0")
+        #expect(merged.name == "example-app")
+        #expect(merged.installedVersion == "1.0")
+        #expect(merged.repositoryURL == "https://github.com/example/example-app")
     }
 
     @Test("Returns original package when no outdated match")

--- a/BrewyTests/GitHubRepositoryURLTests.swift
+++ b/BrewyTests/GitHubRepositoryURLTests.swift
@@ -1,0 +1,124 @@
+@testable import Brewy
+import Foundation
+import Testing
+
+@Suite("GitHub repository URL parsing")
+struct GitHubRepositoryURLTests {
+    @Test("CaskJSON derives a canonical GitHub repository from its homepage")
+    func caskRepositoryFromHomepage() throws {
+        let package = try decodeCaskPackage(
+            homepage: "https://www.github.com/example/example-app.git",
+            url: "https://example.com/example.zip"
+        )
+
+        #expect(package.repositoryURL == "https://github.com/example/example-app")
+    }
+
+    @Test("CaskJSON derives a canonical GitHub repository from its download URL")
+    func caskRepositoryFromDownloadURL() throws {
+        let package = try decodeCaskPackage(
+            homepage: "https://example.com",
+            url: "https://github.com/example/example-app/releases/download/v1.0/example.zip"
+        )
+
+        #expect(package.repositoryURL == "https://github.com/example/example-app")
+    }
+
+    @Test("CaskJSON does not infer a repository from a lookalike GitHub host")
+    func caskRepositoryRejectsLookalikeHost() throws {
+        let package = try decodeCaskPackage(
+            homepage: "https://github.com.example.invalid/example/example-app",
+            url: "https://example.com/example.zip"
+        )
+
+        #expect(package.repositoryURL == nil)
+    }
+
+    @Test("CaskJSON ignores GitHub site routes and falls back to the download repository")
+    func caskRepositoryRejectsGitHubSiteRoute() throws {
+        let package = try decodeCaskPackage(
+            homepage: "https://github.com/settings/profile",
+            url: "https://github.com/example/example-app/releases/download/v1.0/example.zip"
+        )
+
+        #expect(package.repositoryURL == "https://github.com/example/example-app")
+    }
+
+    @Test("CaskJSON tolerates a non-string download URL")
+    func caskRepositoryToleratesInvalidDownloadURLType() throws {
+        let json = """
+        {
+            "formulae": [],
+            "casks": [{"token": "example-app", "version": "1.0", "url": {"unexpected": true}}]
+        }
+        """
+        let data = try #require(json.data(using: .utf8))
+        let response = try JSONDecoder().decode(BrewInfoResponse.self, from: data)
+        let cask = try #require(response.casks?.first)
+
+        #expect(cask.toPackage().repositoryURL == nil)
+    }
+
+    private func decodeCaskPackage(homepage: String, url: String) throws -> BrewPackage {
+        let json = """
+        {
+            "formulae": [],
+            "casks": [
+                {
+                    "token": "example-app",
+                    "version": "1.0",
+                    "homepage": "\(homepage)",
+                    "url": "\(url)"
+                }
+            ]
+        }
+        """
+        let data = try #require(json.data(using: .utf8))
+        let response = try JSONDecoder().decode(BrewInfoResponse.self, from: data)
+        return try #require(response.casks?.first).toPackage()
+    }
+}
+
+@Suite("GitHub repository package detail")
+@MainActor
+struct GitHubRepositoryPackageDetailTests {
+    @Test("fetchPackageDetail preserves a repository when JSON omits it")
+    func fetchDetailPreservesRepository() async {
+        let mock = MockCommandRunner()
+        let (service, _) = makeService(mock: mock)
+        let package = makePackage(
+            name: "firefox",
+            source: .cask,
+            repositoryURL: "https://github.com/mozilla/gecko-dev"
+        )
+        let detail = """
+        {"formulae":[],"casks":[{"token":"firefox","version":"123.0",\
+        "desc":"Fast web browser","homepage":"https://www.mozilla.org/firefox/"}]}
+        """
+        mock.setResult(for: ["info", "--cask", "--json=v2", "--", "firefox"], output: detail)
+
+        let enriched = await service.fetchPackageDetail(for: package)
+
+        #expect(enriched?.repositoryURL == "https://github.com/mozilla/gecko-dev")
+    }
+
+    @Test("fetchPackageDetail clears a repository when the download URL changes hosts")
+    func fetchDetailClearsStaleRepository() async {
+        let mock = MockCommandRunner()
+        let (service, _) = makeService(mock: mock)
+        let package = makePackage(
+            name: "firefox",
+            source: .cask,
+            repositoryURL: "https://github.com/mozilla/gecko-dev"
+        )
+        let detail = """
+        {"formulae":[],"casks":[{"token":"firefox","version":"123.0",\
+        "homepage":"https://www.mozilla.org/firefox/","url":"https://download.mozilla.org/firefox.dmg"}]}
+        """
+        mock.setResult(for: ["info", "--cask", "--json=v2", "--", "firefox"], output: detail)
+
+        let enriched = await service.fetchPackageDetail(for: package)
+
+        #expect(enriched?.repositoryURL == nil)
+    }
+}

--- a/BrewyTests/PackageCacheTests.swift
+++ b/BrewyTests/PackageCacheTests.swift
@@ -11,7 +11,11 @@ struct PackageCacheTests {
         defer { fixture.remove() }
 
         let formula = makePackage(name: "wget", pinned: true, dependencies: ["openssl@3"])
-        let cask = makePackage(name: "firefox", source: .cask)
+        let cask = makePackage(
+            name: "firefox",
+            source: .cask,
+            repositoryURL: "https://github.com/mozilla/gecko-dev"
+        )
         let mas = makePackage(name: "Xcode", source: .mas)
         let outdated = makePackage(
             name: "wget",
@@ -47,6 +51,7 @@ struct PackageCacheTests {
 
         #expect(reader.installedFormulae == [formula])
         #expect(reader.installedCasks == [cask])
+        #expect(reader.installedCasks.first?.repositoryURL == "https://github.com/mozilla/gecko-dev")
         #expect(reader.installedMasApps == [mas])
         #expect(reader.outdatedPackages == [outdated])
         #expect(reader.installedTaps == [tap])
@@ -77,6 +82,31 @@ struct PackageCacheTests {
 
         #expect(reader.installedFormulae.map(\.name) == ["wget"])
         #expect(reader.installedMasApps.isEmpty)
+    }
+
+    @Test("Package cache tolerates snapshots written before repository URLs were stored")
+    func loadsLegacySnapshotWithoutRepositoryURL() async throws {
+        let fixture = try CacheFixture()
+        defer { fixture.remove() }
+
+        let writer = BrewService(
+            commandRunner: MockCommandRunner(),
+            packageCacheURL: fixture.url,
+            packageCacheWritesEnabled: true
+        )
+        writer.installedCasks = [makePackage(name: "firefox", source: .cask)]
+        await writer.saveToCache()
+        try fixture.mutateJSON { object in
+            guard var casks = object["casks"] as? [[String: Any]], !casks.isEmpty else { return }
+            casks[0].removeValue(forKey: "repositoryURL")
+            object["casks"] = casks
+        }
+
+        let reader = BrewService(commandRunner: MockCommandRunner(), packageCacheURL: fixture.url)
+        reader.loadFromCache()
+
+        #expect(reader.installedCasks.map(\.name) == ["firefox"])
+        #expect(reader.installedCasks.first?.repositoryURL == nil)
     }
 
     @Test("Package cache rejects and deletes an incompatible schema")

--- a/BrewyTests/TestHelpers.swift
+++ b/BrewyTests/TestHelpers.swift
@@ -117,7 +117,8 @@ enum TestJSON {
 
     static let caskDetail = """
     {"formulae":[],"casks":[{"token":"firefox","version":"123.0",\
-    "desc":"Fast web browser","homepage":"https://www.mozilla.org/firefox/"}]}
+    "desc":"Fast web browser","homepage":"https://www.mozilla.org/firefox/",\
+    "url":"https://github.com/mozilla/gecko-dev/releases/download/v123.0/firefox.dmg"}]}
     """
 }
 
@@ -142,6 +143,7 @@ func makePackage(
     isOutdated: Bool = false,
     installedVersion: String? = nil,
     latestVersion: String? = nil,
+    repositoryURL: String? = nil,
     dependencies: [String] = []
 ) -> BrewPackage {
     let prefix: String
@@ -163,7 +165,8 @@ func makePackage(
         source: source,
         pinned: pinned,
         installedOnRequest: true,
-        dependencies: dependencies
+        dependencies: dependencies,
+        repositoryURL: repositoryURL
     )
 }
 

--- a/BrewyUITests/SidebarNavigationUITests.swift
+++ b/BrewyUITests/SidebarNavigationUITests.swift
@@ -8,8 +8,7 @@ final class SidebarNavigationUITests: XCTestCase {
     // sidebar can take much longer than the unscaled timeouts to render, which
     // flaked these waits in CI's TSan job. Scale every timeout and settle delay
     // up when the sanitizer runtime is loaded: the UI-test bundle is built with
-    // the same scheme setting as the app, so its presence in this process is a
-    // reliable proxy for "the app under test is instrumented too".
+    // the same scheme setting as the app, so its presence reliably means the app under test is instrumented.
     private static let timeoutScale: TimeInterval = isThreadSanitizerActive ? 4 : 1
     static let launchTimeout: TimeInterval = 30 * timeoutScale
     static let elementTimeout: TimeInterval = 10 * timeoutScale
@@ -155,6 +154,14 @@ final class SidebarNavigationUITests: XCTestCase {
         )
     }
 
+    func testPackageDetailKeepsHomepageWithoutRepository() throws {
+        let package = app.staticTexts["package-row-pcre2"]
+        assertExists(package, timeout: Self.launchTimeout, "Fixture package should appear")
+        package.click()
+        let homepage = app.descendants(matching: .any)["package-homepage"].firstMatch
+        assertExists(homepage, timeout: Self.elementTimeout, "A package without a repository should keep its Homepage link")
+    }
+
     func testCaskSecurityDetailsRenderFixtureData() throws {
         let sidebar = app.outlines.firstMatch
         assertExists(sidebar, timeout: Self.launchTimeout, "Sidebar should exist")
@@ -163,6 +170,12 @@ final class SidebarNavigationUITests: XCTestCase {
         let package = app.staticTexts["package-row-firefox"]
         assertExists(package, timeout: Self.elementTimeout, "Fixture cask should appear")
         package.click()
+
+        let github = app.descendants(matching: .any)["package-upstream-repository"].firstMatch
+        assertExists(github, timeout: Self.elementTimeout, "Cask details should expose its GitHub link")
+        XCTAssertEqual(github.label, "GitHub")
+        let homepage = app.descendants(matching: .any)["package-homepage"].firstMatch
+        assertExists(homepage, timeout: Self.elementTimeout, "A distinct cask homepage should remain available")
 
         let checkSecurity = app.buttons["application-security-check"]
         assertExists(checkSecurity, timeout: Self.elementTimeout, "Security check should be explicit")


### PR DESCRIPTION
Casks whose homepage or download URL points at GitHub now show a GitHub link in package details. The repository is derived from the `url` and `homepage` fields already in `brew info --json=v2`, so no extra requests are made; lookalike hosts and GitHub site routes are rejected, and the Homepage link is hidden only when it resolves to the same repository.

It is labelled GitHub rather than Repository because some casks ship from release-only repositories holding no source. `repositoryURL` is optional and carried through outdated merging, detail enrichment, and the cache, which stays at schema version 1.

Part of #307.

AI disclosure: Claude Opus 5 with manual testing and review.