### PR TITLE
fix(ci): restore and guard the brew JSON probe build

### DIFF
--- a/.github/workflows/brew-json-probe.yml
+++ b/.github/workflows/brew-json-probe.yml
@@ -44,12 +44,7 @@ jobs:
           brew install --cask font-fira-code
 
       - name: Build probe
-        run: |
-          xcrun swiftc -o /tmp/brew-json-probe \
-            Brewy/Models/BrewJSONTypes.swift \
-            Brewy/Models/PackageModel.swift \
-            Brewy/Models/ExternalURLPolicy.swift \
-            scripts/brew-json-probe/main.swift
+        run: bash scripts/brew-json-probe/build.sh /tmp/brew-json-probe
 
       - name: Run probe against real brew
         run: /tmp/brew-json-probe

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -58,6 +58,7 @@ jobs:
           if [[ "${EVENT_NAME}" == "push" ]]; then
             add_check '{"name":"Lint","check":"lint","runner":"macos-26"}'
             add_check '{"name":"Periphery","check":"periphery","runner":"macos-26"}'
+            add_check '{"name":"Build Brew JSON Probe","check":"probe-build","runner":"macos-26"}'
             add_check '{"name":"Test (Thread Sanitizer)","check":"test-tsan","runner":"macos-26","xcodebuild_flags":"-enableCodeCoverage YES -enableThreadSanitizer YES","result_bundle":"TestResults-TSAN","environment":"codecov"}'
             {
               echo "matrix=${MATRIX}"
@@ -101,6 +102,10 @@ jobs:
             # first place Release-only breakage (optimization warnings, stray references
             # to DEBUG-gated test fixtures) can surface.
             add_check '{"name":"Build (Release)","check":"build-release","runner":"macos-26"}'
+          fi
+
+          if grep -qE '^Brewy/Models/|^scripts/brew-json-probe/|^\.github/workflows/(brew-json-probe|ci)\.yml$' <<< "${CHANGED}"; then
+            add_check '{"name":"Build Brew JSON Probe","check":"probe-build","runner":"macos-26"}'
           fi
 
           # Source or periphery-config changes: dead-code scan
@@ -156,6 +161,9 @@ jobs:
           fetch-depth: ${{ matrix.fetch_depth || 1 }}
           persist-credentials: false
 
+      - name: Build Brew JSON probe
+        if: matrix.check == 'probe-build'
+        run: bash scripts/brew-json-probe/build.sh /tmp/brew-json-probe
 
       - name: Restore Homebrew downloads
         id: homebrew-cache

--- a/justfile
+++ b/justfile
@@ -37,6 +37,10 @@ install-hooks:
 
 # Test
 
+# Compile the standalone live Homebrew JSON decoder
+brew-json-probe-build:
+    bash scripts/brew-json-probe/build.sh /private/tmp/brewy-brew-json-probe
+
 # Run unit tests (skips UI tests that require code signing locally)
 test:
     xcodebuild test \
@@ -120,6 +124,7 @@ check:
     else
         skip lychee lychee lychee
     fi
+    run bash scripts/brew-json-probe/build.sh /private/tmp/brewy-brew-json-probe
     run xcodebuild test \
         -project Brewy.xcodeproj \
         -scheme Brewy \

--- a/scripts/brew-json-probe/build.sh
+++ b/scripts/brew-json-probe/build.sh
@@ -1,0 +1,14 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+# Keep CI's probe-build path filter in sync with inputs outside Brewy/Models or this directory.
+cd "$(dirname "${BASH_SOURCE[0]}")/../.."
+
+output_path="${1:?usage: build.sh OUTPUT_PATH}"
+
+xcrun swiftc -o "${output_path}" \
+  Brewy/Models/BrewJSONTypes.swift \
+  Brewy/Models/PackageModel.swift \
+  Brewy/Models/ExternalURLPolicy.swift \
+  Brewy/Models/GitHubRepositoryURL.swift \
+  scripts/brew-json-probe/main.swift

--- a/scripts/brew-json-probe/main.swift
+++ b/scripts/brew-json-probe/main.swift
@@ -1,6 +1,6 @@
-// Compiled standalone in CI (with BrewJSONTypes.swift, PackageModel.swift, and
-// ExternalURLPolicy.swift) and run against the runner's real Homebrew to catch
-// upstream JSON schema drift before users hit it. See .github/workflows/brew-json-probe.yml.
+// Compiled standalone in CI with its supporting model and URL policy sources,
+// then run against the runner's real Homebrew to catch upstream JSON schema drift
+// before users hit it. See .github/workflows/brew-json-probe.yml.
 import Foundation
 
 struct ProbeFailure: Error, CustomStringConvertible {
@@ -42,12 +42,18 @@ func probe() throws {
     }
 
     // Decode additional live cask metadata without installing large applications.
-    let caskData = try runBrew(["info", "--json=v2", "--cask", "--", "firefox", "iterm2"])
+    let caskData = try runBrew(["info", "--json=v2", "--cask", "--", "firefox", "iterm2", "rectangle"])
     let caskInfo = try JSONDecoder().decode(BrewInfoResponse.self, from: caskData)
     let probedCasks = (caskInfo.casks ?? []).map { $0.toPackage() }
     print("cask metadata: \(probedCasks.count) casks decoded")
-    guard probedCasks.count == 2 else {
-        throw ProbeFailure(description: "expected 2 casks decoded, got \(probedCasks.count)")
+    guard probedCasks.count == 3 else {
+        throw ProbeFailure(description: "expected 3 casks decoded, got \(probedCasks.count)")
+    }
+    guard probedCasks.first(where: { $0.name == "rectangle" })?.repositoryURL != nil else {
+        throw ProbeFailure(description: "rectangle GitHub repository URL was not decoded")
+    }
+    guard caskInfo.casks?.first(where: { $0.token == "firefox" })?.applicationBundleURLs.isEmpty == false else {
+        throw ProbeFailure(description: "firefox application artifact was not decoded")
     }
 
     let outdatedData = try runBrew(["outdated", "--json=v2"])


### PR DESCRIPTION
Brewy's weekly Homebrew JSON drift probe stopped compiling: its standalone `swiftc` invocation never gained `GitHubRepositoryURL.swift` after `BrewJSONTypes` started resolving cask repository URLs. The input list now lives in `scripts/brew-json-probe/build.sh`, which the scheduled workflow, a focused PR CI leg, and `just check` all call, so a missing input fails on the pull request that introduces it rather than on the next Tuesday.

The probe also asserted only that decoding did not throw. Cask `url` and `artifacts` are decoded with `try?`, so an upstream reshape of either would leave both silently empty and still pass. Rectangle, whose homepage is not GitHub, now has to resolve a repository URL from `url`, and Firefox has to yield an application artifact.

AI disclosure: Claude Opus 5 with manual testing and review.
